### PR TITLE
feat(docs): integrate with Storybook stories

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,9 +1,24 @@
 // @ts-check
 import { defineConfig } from 'astro/config';
+import react from '@astrojs/react';
+import tailwindcss from '@tailwindcss/vite';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // https://astro.build/config
 export default defineConfig({
   site: 'https://beaket.github.io',
   base: '/ui',
   output: 'static',
+  integrations: [react()],
+  vite: {
+    plugins: [tailwindcss()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, '../src'),
+      },
+    },
+  },
 });

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,6 +9,15 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^5.16.6"
+    "@astrojs/react": "^4.4.2",
+    "@radix-ui/react-slot": "^1.2.4",
+    "@tailwindcss/vite": "4.1.18",
+    "astro": "^5.16.6",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "2.1.1",
+    "react": "19.2.3",
+    "react-dom": "19.2.3",
+    "tailwind-merge": "3.4.0",
+    "tailwindcss": "4.1.18"
   }
 }

--- a/docs/src/components/button-page.tsx
+++ b/docs/src/components/button-page.tsx
@@ -1,0 +1,31 @@
+import { AllVariants, AllSizes, AllStates } from "@/components/button/button.stories";
+
+function Preview({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center justify-center p-6 border border-[var(--chrome)] bg-white my-4">
+      {children}
+    </div>
+  );
+}
+
+export function ButtonPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-semibold mb-4">Button</h1>
+      <p className="text-[var(--steel)] mb-6">Clickable button with multiple variants and sizes.</p>
+
+      <pre className="bg-[var(--frost)] border border-[var(--chrome)] p-3 text-sm font-mono mb-8">
+        npx @beaket/ui add button
+      </pre>
+
+      <h2 className="text-base font-medium border-b border-[var(--chrome)] pb-1 mb-2">Variants</h2>
+      <Preview><AllVariants /></Preview>
+
+      <h2 className="text-base font-medium border-b border-[var(--chrome)] pb-1 mb-2 mt-8">Sizes</h2>
+      <Preview><AllSizes /></Preview>
+
+      <h2 className="text-base font-medium border-b border-[var(--chrome)] pb-1 mb-2 mt-8">States</h2>
+      <Preview><AllStates /></Preview>
+    </div>
+  );
+}

--- a/docs/src/components/component-card.tsx
+++ b/docs/src/components/component-card.tsx
@@ -1,0 +1,15 @@
+import { Button } from "@/components/button";
+
+export function ComponentCard() {
+  return (
+    <a href="/ui/components/button" className="block border border-[var(--chrome)] hover:border-[var(--steel)] transition-colors no-underline">
+      <div className="p-6 flex items-center justify-center bg-white">
+        <Button>Button</Button>
+      </div>
+      <div className="px-4 py-3 border-t border-[var(--chrome)] bg-[var(--frost)]">
+        <div className="font-medium text-[var(--ink)]">Button</div>
+        <div className="text-sm text-[var(--steel)]">Multiple variants and sizes</div>
+      </div>
+    </a>
+  );
+}

--- a/docs/src/layouts/doc.astro
+++ b/docs/src/layouts/doc.astro
@@ -1,0 +1,47 @@
+---
+import '../styles/global.css';
+
+interface Props {
+  title?: string;
+}
+const { title = 'Beaket UI' } = Astro.props;
+const currentPath = Astro.url.pathname;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <link rel="icon" type="image/svg+xml" href="/ui/favicon.svg" />
+    <title>{title} - Beaket UI</title>
+  </head>
+  <body>
+    <div class="layout">
+      <nav class="sidebar">
+        <a href="/ui/" class="sidebar-title">Beaket UI</a>
+
+        <div class="sidebar-section">
+          <div class="sidebar-section-title">Getting Started</div>
+          <a href="/ui/" class:list={["sidebar-link", { active: currentPath === '/ui/' }]}>Introduction</a>
+          <a href="/ui/installation" class:list={["sidebar-link", { active: currentPath.includes('/installation') }]}>Installation</a>
+        </div>
+
+        <div class="sidebar-section">
+          <div class="sidebar-section-title">Components</div>
+          <a href="/ui/components/button" class:list={["sidebar-link", { active: currentPath.includes('/button') }]}>Button</a>
+        </div>
+
+        <div class="sidebar-section">
+          <div class="sidebar-section-title">Links</div>
+          <a href="https://github.com/beaket/ui" class="sidebar-link">GitHub</a>
+          <a href="https://www.npmjs.com/package/@beaket/ui" class="sidebar-link">npm</a>
+        </div>
+      </nav>
+
+      <main class="main">
+        <slot />
+      </main>
+    </div>
+  </body>
+</html>

--- a/docs/src/pages/components/button.astro
+++ b/docs/src/pages/components/button.astro
@@ -1,0 +1,8 @@
+---
+import Layout from '../../layouts/doc.astro';
+import { ButtonPage } from '../../components/button-page';
+---
+
+<Layout title="Button">
+  <ButtonPage client:load />
+</Layout>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -1,134 +1,27 @@
 ---
-const title = "Beaket UI";
-const description = "CLI for adding brutalist React components to your project";
+import Layout from '../layouts/doc.astro';
+import { ComponentCard } from '../components/component-card';
 ---
 
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/ui/favicon.svg" />
-    <title>{title}</title>
-    <meta name="description" content={description} />
-    <style>
-      :root {
-        --branch: #1C1F24;
-        --ink: #0D0D0D;
-        --paper: #F8F8F8;
-        --steel: #6B6B6B;
-        --chrome: #C8C8C8;
-        --frost: #F5F5F5;
-        --signal-blue: #2B6CB0;
-      }
-      * {
-        margin: 0;
-        padding: 0;
-        box-sizing: border-box;
-      }
-      body {
-        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-        background: var(--paper);
-        color: var(--ink);
-        line-height: 1.5;
-        font-size: 14px;
-      }
-      .container {
-        max-width: 720px;
-        margin: 0 auto;
-        padding: 2rem 1rem;
-      }
-      h1 {
-        font-size: 2rem;
-        margin-bottom: 0.5rem;
-      }
-      .tagline {
-        color: var(--steel);
-        margin-bottom: 2rem;
-      }
-      h2 {
-        font-size: 1rem;
-        margin: 2rem 0 0.5rem;
-        padding-bottom: 0.25rem;
-        border-bottom: 1px solid var(--chrome);
-      }
-      pre {
-        background: var(--frost);
-        border: 1px solid var(--chrome);
-        padding: 0.75rem 1rem;
-        overflow-x: auto;
-        font-size: 13px;
-        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-      }
-      code {
-        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-        font-size: 13px;
-      }
-      p {
-        margin: 0.5rem 0;
-      }
-      ul {
-        margin: 0.5rem 0;
-        padding-left: 1.5rem;
-      }
-      li {
-        margin: 0.25rem 0;
-      }
-      a {
-        color: var(--signal-blue);
-      }
-      .components {
-        margin-top: 0.5rem;
-      }
-      .component {
-        display: flex;
-        justify-content: space-between;
-        padding: 0.5rem 0;
-        border-bottom: 1px dashed var(--chrome);
-      }
-      .component:last-child {
-        border-bottom: none;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="container">
-      <h1>Beaket UI</h1>
-      <p class="tagline">Brutalist React components. Copy to your project.</p>
+<Layout title="Introduction">
+  <h1>Beaket UI</h1>
+  <p class="tagline">Brutalist React components. Copy to your project.</p>
 
-      <h2>Quick Start</h2>
-      <pre><code>npx @beaket/ui init</code></pre>
+  <h2>Quick Start</h2>
+  <pre><code>npx @beaket/ui init
+npx @beaket/ui add button</code></pre>
 
-      <h2>Add Components</h2>
-      <pre><code>npx @beaket/ui add button</code></pre>
+  <h2>Components</h2>
+  <div class="grid">
+    <ComponentCard client:load />
+  </div>
+</Layout>
 
-      <h2>Available Components</h2>
-      <div class="components">
-        <div class="component">
-          <span>button</span>
-          <span style="color: var(--steel)">Primary, destructive, outline, secondary, ghost, link, success, stark</span>
-        </div>
-      </div>
-
-      <h2>What init does</h2>
-      <ul>
-        <li>Creates <code>beaket.json</code> configuration</li>
-        <li>Adds CSS variables to your stylesheet</li>
-        <li>Creates <code>cn()</code> utility function</li>
-        <li>Installs <code>clsx</code> and <code>tailwind-merge</code></li>
-      </ul>
-
-      <h2>Requirements</h2>
-      <ul>
-        <li>React 18+</li>
-        <li>Tailwind CSS 4+</li>
-      </ul>
-
-      <h2>Links</h2>
-      <ul>
-        <li><a href="https://github.com/beaket/ui">GitHub</a></li>
-        <li><a href="https://www.npmjs.com/package/@beaket/ui">npm</a></li>
-      </ul>
-    </div>
-  </body>
-</html>
+<style>
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 1rem;
+    margin-top: 1rem;
+  }
+</style>

--- a/docs/src/pages/installation.md
+++ b/docs/src/pages/installation.md
@@ -1,0 +1,101 @@
+---
+layout: ../layouts/doc.astro
+title: Installation
+---
+
+# Installation
+
+## Quick Start
+
+```bash
+npx @beaket/ui init
+npx @beaket/ui add button
+```
+
+## Requirements
+
+- React 18+
+- Tailwind CSS 4+
+- Path alias `@/` configured
+
+## Tailwind CSS 4 Setup
+
+### Vite / React Router v7
+
+```bash
+pnpm add -D tailwindcss @tailwindcss/vite
+```
+
+```ts
+// vite.config.ts
+import tailwindcss from '@tailwindcss/vite'
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+})
+```
+
+### Next.js
+
+```bash
+pnpm add -D tailwindcss @tailwindcss/postcss postcss
+```
+
+```js
+// postcss.config.mjs
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {}
+  }
+}
+```
+
+### CSS
+
+Add to your main CSS file:
+
+```css
+@import "tailwindcss";
+```
+
+## Path Alias Setup
+
+Components use `@/` imports.
+
+### Vite
+
+```ts
+// vite.config.ts
+import path from 'path'
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  }
+})
+```
+
+```json
+// tsconfig.json or tsconfig.app.json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
+```
+
+### Next.js
+
+Already configured by default.
+
+## What init does
+
+- Creates `beaket.json` configuration
+- Adds CSS variables to your stylesheet
+- Creates `cn()` utility function
+- Installs `clsx` and `tailwind-merge`

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -1,0 +1,100 @@
+@import "@/styles.css";
+@source "../../../src";
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--paper);
+  color: var(--ink);
+  line-height: 1.6;
+  font-size: 14px;
+}
+
+.layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 200px;
+  border-right: 1px solid var(--chrome);
+  padding: 1.5rem 1rem;
+  position: fixed;
+  height: 100vh;
+  overflow-y: auto;
+}
+
+.sidebar-title {
+  font-weight: 600;
+  margin-bottom: 1.5rem;
+  color: var(--ink);
+  text-decoration: none;
+  display: block;
+}
+
+.sidebar-section {
+  margin-bottom: 1rem;
+}
+
+.sidebar-section-title {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  color: var(--steel);
+  margin-bottom: 0.5rem;
+}
+
+.sidebar-link {
+  display: block;
+  padding: 0.25rem 0;
+  color: var(--ink);
+  text-decoration: none;
+}
+.sidebar-link:hover { color: var(--signal-blue); }
+.sidebar-link.active { color: var(--signal-blue); font-weight: 500; }
+
+.main {
+  flex: 1;
+  margin-left: 200px;
+  padding: 2rem;
+  max-width: 720px;
+}
+
+h1 { font-size: 1.5rem; margin-bottom: 1.5rem; }
+h2 { font-size: 1rem; margin: 2rem 0 0.5rem; border-bottom: 1px solid var(--chrome); padding-bottom: 0.25rem; }
+h3 { font-size: 0.875rem; margin: 1.5rem 0 0.5rem; color: var(--steel); }
+p { margin: 0.5rem 0; }
+ul { margin: 0.5rem 0; padding-left: 1.5rem; }
+li { margin: 0.25rem 0; }
+
+code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+  background: var(--frost);
+  padding: 0.1rem 0.3rem;
+  border-radius: 2px;
+}
+
+pre {
+  background: var(--frost);
+  border: 1px solid var(--chrome);
+  padding: 0.75rem 1rem;
+  overflow-x: auto;
+  font-size: 13px;
+  margin: 0.5rem 0;
+}
+pre code { background: none; padding: 0; }
+
+a { color: var(--signal-blue); }
+
+.tagline {
+  color: var(--steel);
+  margin-bottom: 2rem;
+}
+
+.components { margin-top: 0.5rem; }
+.component {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed var(--chrome);
+}
+.component:last-child { border-bottom: none; }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,9 +93,36 @@ importers:
 
   docs:
     dependencies:
+      '@astrojs/react':
+        specifier: ^4.4.2
+        version: 4.4.2(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@19.2.7)(react@19.2.3)
+      '@tailwindcss/vite':
+        specifier: 4.1.18
+        version: 4.1.18(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2))
       astro:
         specifier: ^5.16.6
         version: 5.16.6(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.54.0)(typescript@5.9.3)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: 2.1.1
+        version: 2.1.1
+      react:
+        specifier: 19.2.3
+        version: 19.2.3
+      react-dom:
+        specifier: 19.2.3
+        version: 19.2.3(react@19.2.3)
+      tailwind-merge:
+        specifier: 3.4.0
+        version: 3.4.0
+      tailwindcss:
+        specifier: 4.1.18
+        version: 4.1.18
 
   packages/cli:
     dependencies:
@@ -129,6 +156,15 @@ packages:
   '@astrojs/prism@3.3.0':
     resolution: {integrity: sha512-q8VwfU/fDZNoDOf+r7jUnMC2//H2l0TuQ6FkGJL8vD8nw/q5KiL3DS1KKBI3QhI9UQhpJ5dc7AtqfbXWuOgLCQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+
+  '@astrojs/react@4.4.2':
+    resolution: {integrity: sha512-1tl95bpGfuaDMDn8O3x/5Dxii1HPvzjvpL2YTuqOOrQehs60I2DKiDgh1jrKc7G8lv+LQT5H15V6QONQ+9waeQ==}
+    engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+    peerDependencies:
+      '@types/react': ^17.0.50 || ^18.0.21 || ^19.0.0
+      '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
+      react: ^17.0.2 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
 
   '@astrojs/telemetry@3.3.0':
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
@@ -757,6 +793,9 @@ packages:
       '@types/react':
         optional: true
 
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
   '@rolldown/pluginutils@1.0.0-beta.53':
     resolution: {integrity: sha512-vENRlFU4YbrwVqNDZ7fLvy+JR1CRkyr01jhSiDpE1u6py3OMzQfztQU2jxykW3ALNxO4kSlqIDeYyD0Y9RcQeQ==}
 
@@ -1169,6 +1208,12 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitejs/plugin-react@5.1.2':
     resolution: {integrity: sha512-EcA07pHJouywpzsoTUqNh5NwGayl2PPVEJKUSinGGSxFGYn+shYbqMGBg6FXDqgXum9Ou/ecb+411ssw8HImJQ==}
@@ -2349,6 +2394,10 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
@@ -3028,6 +3077,29 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
+  '@astrojs/react@4.4.2(@types/node@22.19.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+      '@vitejs/plugin-react': 4.7.0(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2))
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      ultrahtml: 1.6.0
+      vite: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   '@astrojs/telemetry@3.3.0':
     dependencies:
       ci-info: 4.3.1
@@ -3497,6 +3569,8 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
   '@rolldown/pluginutils@1.0.0-beta.53': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.54.0)':
@@ -3891,6 +3965,18 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.0': {}
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2))':
+    dependencies:
+      '@babel/core': 7.28.5
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.5)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.1(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - supports-color
 
   '@vitejs/plugin-react@5.1.2(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2))':
     dependencies:
@@ -5314,6 +5400,8 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@17.0.2: {}
+
+  react-refresh@0.17.0: {}
 
   react-refresh@0.18.0: {}
 

--- a/src/components/button/button.stories.tsx
+++ b/src/components/button/button.stories.tsx
@@ -109,3 +109,33 @@ export const Large: Story = {
     size: "lg",
   },
 };
+
+// Compositions for docs
+export const AllVariants = () => (
+  <div className="flex flex-wrap gap-2">
+    <Button variant="primary">Primary</Button>
+    <Button variant="secondary">Secondary</Button>
+    <Button variant="destructive">Destructive</Button>
+    <Button variant="outline">Outline</Button>
+    <Button variant="ghost">Ghost</Button>
+    <Button variant="link">Link</Button>
+    <Button variant="success">Success</Button>
+    <Button variant="stark">Stark</Button>
+  </div>
+);
+
+export const AllSizes = () => (
+  <div className="flex items-center gap-2">
+    <Button size="sm">Small</Button>
+    <Button size="md">Medium</Button>
+    <Button size="lg">Large</Button>
+    <Button size="icon">→</Button>
+  </div>
+);
+
+export const AllStates = () => (
+  <div className="flex gap-2">
+    <Button disabled>Disabled</Button>
+    <Button loading>Loading</Button>
+  </div>
+);


### PR DESCRIPTION
## Summary
- Add React + Tailwind integration to Astro docs
- Use Storybook stories as source of truth for component demos
- Add sidebar layout with navigation
- Follow kebab-case file naming convention

## Changes
- `docs/astro.config.mjs` - React + Tailwind + path alias
- `docs/src/layouts/doc.astro` - Sidebar layout
- `docs/src/components/button-page.tsx` - Uses stories from `button.stories.tsx`
- `docs/src/components/component-card.tsx` - Component preview card
- `docs/src/pages/installation.md` - Setup guide for Vite/Next.js
- `src/components/button/button.stories.tsx` - Added composition stories

## Test plan
- [ ] `pnpm --filter docs dev` and verify pages render correctly
- [ ] `pnpm storybook` and verify stories work
- [ ] Check component previews match between docs and Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)