### PR TITLE
fix: rename ButtonProps to Props internally

### DIFF
--- a/.changeset/fix-button-props-rename.md
+++ b/.changeset/fix-button-props-rename.md
@@ -2,4 +2,4 @@
 "@beaket/ui": patch
 ---
 
-Merge branch 'main' into fix/button-props-rename
+Rename ButtonProps to Props internally

--- a/.changeset/fix-button-props-rename.md
+++ b/.changeset/fix-button-props-rename.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+Merge branch 'main' into fix/button-props-rename

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -2,7 +2,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?:
     | "primary"
     | "destructive"
@@ -26,7 +26,7 @@ export function Button({
   children,
   asChild = false,
   ...props
-}: ButtonProps) {
+}: Props) {
   const Comp = asChild ? Slot : "button";
 
   return (

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -1,2 +1,2 @@
 export { Button } from "./button";
-export type { ButtonProps } from "./button";
+export type { Props as ButtonProps } from "./button";


### PR DESCRIPTION
## Summary
- Rename internal interface from `ButtonProps` to `Props`
- Re-export as `ButtonProps` for backwards compatibility

## Test plan
- [ ] Verify auto-changeset workflow creates a changeset with `patch` bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)