### PR TITLE
Add paths-ignore to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - '**/*.md'
+      - '**/*.json'
+      - 'docs/**'
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Skip CI runs for markdown files, JSON files, and documentation directory
- Reduces unnecessary CI runs on non-code changes
- Improves CI resource efficiency

## Test plan
- [ ] Verify CI does not run when only `.md` files change
- [ ] Verify CI does not run when only `.json` files change
- [ ] Verify CI still runs when code files change

🤖 Generated with [Claude Code](https://claude.com/claude-code)