### PR TITLE
fix: trigger auto-changeset only on PR open and use PR title

### DIFF
--- a/.changeset/fix-changeset-auto-trigger.md
+++ b/.changeset/fix-changeset-auto-trigger.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+fix: trigger auto-changeset only on PR open and use PR title

--- a/.github/workflows/changeset-auto.yml
+++ b/.github/workflows/changeset-auto.yml
@@ -2,7 +2,7 @@ name: Auto Changeset
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened]
 
 jobs:
   auto-changeset:
@@ -59,6 +59,8 @@ jobs:
 
       - name: Generate changeset
         if: steps.check.outputs.existing == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BUMP="${{ steps.bump.outputs.bump }}"
           BRANCH="${{ github.head_ref }}"
@@ -66,8 +68,8 @@ jobs:
           # Generate a unique filename from branch name
           FILENAME=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9]/-/g' | tr '[:upper:]' '[:lower:]')
 
-          # Get first commit message for summary
-          SUMMARY=$(git log origin/${{ github.base_ref }}..HEAD --pretty=format:"%s" | head -1)
+          # Use PR title as summary
+          SUMMARY=$(gh pr view ${{ github.event.pull_request.number }} --json title -q '.title')
 
           # Create changeset file
           cat > ".changeset/${FILENAME}.md" << EOF


### PR DESCRIPTION
## Summary
- Change trigger from `[opened, synchronize]` to `[opened]` only to prevent multiple runs
- Use PR title instead of first commit message for changeset summary
- Prevents unintended messages from early commits being recorded in changelog

## Test plan
- [ ] Create a new PR and verify auto-changeset runs only once
- [ ] Verify changeset summary matches PR title

🤖 Generated with [Claude Code](https://claude.com/claude-code)