### PR TITLE
chore: add husky pre-commit hook for prettier formatting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g') --write --ignore-unknown

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "typecheck": "tsc --noEmit",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "release": "changeset publish"
+    "release": "changeset publish",
+    "prepare": "husky"
   },
   "keywords": [
     "react",
@@ -33,6 +34,7 @@
     "@vitejs/plugin-react": "5.1.2",
     "@vitest/browser-playwright": "4.0.16",
     "@vitest/coverage-v8": "4.0.16",
+    "husky": "9.1.7",
     "playwright": "1.57.0",
     "prettier": "3.7.4",
     "prettier-plugin-organize-imports": "4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: 4.0.16
         version: 4.0.16(@vitest/browser@4.0.16(vite@7.3.0(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.30.2))(vitest@4.0.16))(vitest@4.0.16)
+      husky:
+        specifier: 9.1.7
+        version: 9.1.7
       playwright:
         specifier: 1.57.0
         version: 1.57.0
@@ -1979,6 +1982,11 @@ packages:
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
+    hasBin: true
+
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
     hasBin: true
 
   iconv-lite@0.7.1:
@@ -5316,6 +5324,8 @@ snapshots:
   http-cache-semantics@4.2.0: {}
 
   human-id@4.1.3: {}
+
+  husky@9.1.7: {}
 
   iconv-lite@0.7.1:
     dependencies:


### PR DESCRIPTION
## Summary
- Add husky as a dev dependency for git hooks management
- Configure a pre-commit hook that runs prettier on staged files
- Ensure consistent code formatting across all contributions automatically

## Test plan
- [ ] Verify `pnpm install` runs husky prepare script
- [ ] Make a code change, stage it, and commit to confirm prettier runs on staged files
- [ ] Confirm formatting is applied correctly before commit completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)