### PR TITLE
ci: add Chromatic visual testing workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,42 @@
+name: Chromatic Tests
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - '.storybook/**'
+  pull_request:
+    paths:
+      - 'src/**'
+      - '.storybook/**'
+
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Required for Chromatic to compare with baseline
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+        timeout-minutes: 2
+
+      - name: Run Chromatic tests
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          buildScriptName: storybook-build
+          onlyChanged: true
+          exitZeroOnChanges: true
+          exitOnceUploaded: true

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
+   "engines": {
+    "node": "24.12.0"
+  },
   "scripts": {
     "dev": "storybook dev -p 6006",
     "build": "storybook build",
     "typecheck": "tsc --noEmit",
-    "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "release": "changeset publish",
     "prepare": "husky"


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for Chromatic visual regression testing
- Configure workflow to run on push to main and PRs affecting `src/` or `.storybook/`
- Add Node.js engine version constraint (24.12.0) to package.json
- Remove duplicate `storybook` script from package.json

## Test plan
- [ ] Verify Chromatic workflow triggers on PRs modifying `src/` or `.storybook/`
- [ ] Ensure `CHROMATIC_PROJECT_TOKEN` secret is configured in repository settings
- [ ] Confirm Node.js version detection works via `node-version-file: 'package.json'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)