### PR TITLE
docs: add JSDoc comment to Button props

### DIFF
--- a/.changeset/add-button-jsdoc.md
+++ b/.changeset/add-button-jsdoc.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+docs: add JSDoc comment to Button props

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -2,6 +2,7 @@ import { cn } from "@/lib/utils";
 import { Slot } from "@radix-ui/react-slot";
 import { cva } from "class-variance-authority";
 
+/** Button component props */
 export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?:
     | "primary"


### PR DESCRIPTION
## Summary
- Add JSDoc comment to Button component Props interface

## Purpose
Test that the release workflow triggers correctly on push to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)