### PR TITLE
fix: remove docs from changeset (ignored package)

### DIFF
--- a/.changeset/sour-panthers-bake.md
+++ b/.changeset/sour-panthers-bake.md
@@ -1,6 +1,5 @@
 ---
 "@beaket/ui": patch
-"docs": patch
 ---
 
 chore: apply code formatting and cleanup


### PR DESCRIPTION
## Summary
- Remove `"docs": patch` from `sour-panthers-bake.md` changeset
- `docs` is listed in `.changeset/config.json` as an ignored package, causing changesets/action to fail

## Root cause
The changeset referenced a package that is configured to be ignored, causing a conflict during release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)