### PR TITLE
fix: add fetch-depth to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
- Add `fetch-depth: 0` to `actions/checkout` in release workflow

## Root cause
changesets/action requires full git history to create branches and push commits for the release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)