### PR TITLE
fix: skip pre-push hook in CI and changeset-release branches

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,5 @@
+# Skip in CI or for changeset-release branches
+[ -n "$CI" ] && exit 0
+[[ "$(git rev-parse --abbrev-ref HEAD)" == changeset-release/* ]] && exit 0
+
 pnpm changeset status --since=main


### PR DESCRIPTION
## Summary
- Skip pre-push hook when `CI` environment variable is set
- Skip pre-push hook for `changeset-release/*` branches

## Root cause
The changesets/action deletes changeset files before pushing to `changeset-release/main`, causing the pre-push hook to fail with "no changesets found".

🤖 Generated with [Claude Code](https://claude.com/claude-code)