### PR TITLE
ci: trigger docs workflow after release succeeds

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,11 @@
-name: Deploy Docs
+name: Docs
 
 on:
-  workflow_dispatch: # Temporarily disabled - manual trigger only
-  # push:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - "docs/**"
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -15,6 +14,7 @@ permissions:
 
 jobs:
   build:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Rename workflow from "Deploy Docs" to "Docs" for consistency with "Release"
- Add `workflow_run` trigger to automatically run after Release workflow completes
- Add condition to only build on manual trigger or release success

## Test plan
- [ ] Verify workflow appears correctly in GitHub Actions tab
- [ ] Test manual trigger via workflow_dispatch works
- [ ] Verify docs deploy after next successful Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)