### PR TITLE
fix(ci): enforce changeset requirement and fix docs trigger

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   check:
+    # Skip for automated branches that don't need changesets
     if: |
       !startsWith(github.head_ref, 'changeset-release/') &&
       !startsWith(github.head_ref, 'renovate/')
@@ -17,4 +18,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - run: npx @changesets/cli status --since=origin/main
+
+      - name: Check for changesets in this PR
+        run: |
+          if ! git diff --name-only origin/main...HEAD -- '.changeset/*.md' | grep -qv README.md; then
+            echo "::error::Missing changeset. Run 'pnpm changeset' to add one."
+            exit 1
+          fi

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,10 +1,7 @@
 name: Docs
 
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types:
-      - completed
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -14,7 +11,6 @@ permissions:
 
 jobs:
   build:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -41,3 +43,12 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  docs:
+    needs: release
+    if: needs.release.outputs.published == 'true'
+    uses: ./.github/workflows/docs.yml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,22 @@
-# Skip in CI or for changeset-release branches
+# Skip in CI or for changeset-release/renovate branches
 [ -n "$CI" ] && exit 0
-[[ "$(git rev-parse --abbrev-ref HEAD)" == changeset-release/* ]] && exit 0
+branch=$(git rev-parse --abbrev-ref HEAD)
+[[ "$branch" == changeset-release/* ]] && exit 0
+[[ "$branch" == renovate/* ]] && exit 0
 
-pnpm changeset status --since=main
+# Check if src/** or packages/** changed
+if git diff --name-only origin/main...HEAD | grep -qE '^(src|packages)/'; then
+  # Check for changeset
+  if ! git diff --name-only origin/main...HEAD -- '.changeset/*.md' | grep -qv README.md; then
+    echo ""
+    echo "⚠️  Missing changeset for source file changes."
+    echo ""
+    echo "To add a changeset:"
+    echo "  pnpm changeset"
+    echo ""
+    echo "If this change should NOT trigger a release:"
+    echo "  pnpm changeset --empty"
+    echo ""
+    exit 1
+  fi
+fi


### PR DESCRIPTION
## Summary

- Changeset Check now uses `git diff` to verify the PR adds a changeset file
- Release workflow triggers docs deployment only when `published == 'true'`
- Docs workflow runs only via `workflow_dispatch` (triggered explicitly by Release)

## Problems Fixed

| Issue | Root Cause | Fix |
|-------|-----------|-----|
| PRs without changesets passed check | `changeset status` doesn't fail on missing changesets | Use `git diff` to check for `.changeset/*.md` files in the PR |
| Docs deployed when no release occurred | `workflow_run` triggered on any Release completion | Only trigger via `gh workflow run` when packages are published |
| No Release PR generated | Above issues allowed merge without changeset | Fixed by enforcing changeset requirement |

## Test Plan

- [ ] Create a PR that modifies `src/**` without a changeset → Changeset Check should **fail**
- [ ] Create a PR that modifies `src/**` with a changeset → Changeset Check should **pass**
- [ ] Merge a PR with changeset → Release workflow creates Release PR
- [ ] Merge Release PR (publish) → Docs workflow is triggered
- [ ] Merge a PR that only modifies `.github/**` → No workflows triggered (paths filter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)