### PR TITLE
docs: add JSDoc comments to Button props

### DIFF
--- a/.changeset/button-jsdoc-comments.md
+++ b/.changeset/button-jsdoc-comments.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+Add JSDoc comments to Button component props

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -3,6 +3,7 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva } from "class-variance-authority";
 
 export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Button style variant */
   variant?:
     | "primary"
     | "destructive"
@@ -12,8 +13,11 @@ export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     | "link"
     | "success"
     | "stark";
+  /** Button size */
   size?: "sm" | "md" | "lg" | "icon";
+  /** Shows a loading spinner and disables the button */
   loading?: boolean;
+  /** Merges props onto the immediate child element instead of rendering a button */
   asChild?: boolean;
 }
 


### PR DESCRIPTION
## Summary

Add JSDoc comments to Button component props for better IDE documentation.

## Test Plan

- [ ] PR merges → Release workflow creates "Changes Included in the Next Release" PR
- [ ] Release PR merges → `@beaket/ui` published to npm
- [ ] Docs workflow triggered after publish