### PR TITLE
fix(ci): report success for automated branches in changeset check

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -9,17 +9,19 @@ on:
 
 jobs:
   check:
-    # Skip for automated branches that don't need changesets
-    if: |
-      !startsWith(github.head_ref, 'changeset-release/') &&
-      !startsWith(github.head_ref, 'renovate/')
     runs-on: ubuntu-latest
     steps:
+      - name: Skip for automated branches
+        if: startsWith(github.head_ref, 'changeset-release/') || startsWith(github.head_ref, 'renovate/')
+        run: echo "Skipping changeset check for automated branch"
+
       - uses: actions/checkout@v6
+        if: ${{ !startsWith(github.head_ref, 'changeset-release/') && !startsWith(github.head_ref, 'renovate/') }}
         with:
           fetch-depth: 0
 
       - name: Check for changesets in this PR
+        if: ${{ !startsWith(github.head_ref, 'changeset-release/') && !startsWith(github.head_ref, 'renovate/') }}
         run: |
           if ! git diff --name-only origin/main...HEAD -- '.changeset/*.md' | grep -qv README.md; then
             echo "::error::Missing changeset. Run 'pnpm changeset' to add one."


### PR DESCRIPTION
## Problem

Release PRs from `changeset-release/*` branches are blocked because:
1. Changeset Check workflow triggers (matches `packages/**` path)
2. Job-level `if` condition skips the job
3. Skipped jobs don't report status
4. Required check "check" never receives a status

## Solution

Move the skip logic from job-level `if` to step-level `if` conditions.
Job always runs and reports success, but actual checks are skipped for automated branches.