### PR TITLE
fix(ci): use PAT for changesets action to trigger workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,9 @@ jobs:
           commit: "chore: version packages"
           publish: pnpm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT to trigger workflows on created PRs
+          # GITHUB_TOKEN doesn't trigger workflows (security restriction)
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   docs:


### PR DESCRIPTION
## Problem

PRs created by `changesets/action` using `GITHUB_TOKEN` don't trigger workflows due to GitHub's security restrictions.

This means required checks never run and the Release PR can't be merged without manual intervention.

## Solution

Use a PAT (`RELEASE_TOKEN`) instead of `GITHUB_TOKEN` for the changesets action.

## Setup Required

1. Create a Fine-grained PAT at GitHub Settings → Developer settings → Personal access tokens
2. Set repository access to `beaket/ui`
3. Grant permissions:
   - **Contents**: Read and write
   - **Pull requests**: Read and write  
   - **Workflows**: Read and write
4. Add as repository secret: Settings → Secrets → `RELEASE_TOKEN`