### PR TITLE
feat(cli): add overwrite prompt for existing files

### DIFF
--- a/.changeset/cli-overwrite-prompt.md
+++ b/.changeset/cli-overwrite-prompt.md
@@ -1,0 +1,10 @@
+---
+"@beaket/ui": minor
+---
+
+Add overwrite prompt for existing files in CLI add command
+
+- Add `--overwrite` (`-o`) flag to force overwrite without prompting
+- Prompt user for confirmation when a file already exists
+- Show skipped files with instructions to use `--overwrite`
+- Improve progress display with checkmarks

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -4,7 +4,11 @@ import { getConfig } from "../utils/config.ts";
 import { installDependencies, writeComponentFiles } from "../utils/files.ts";
 import { fetchComponent, fetchRegistry } from "../utils/registry.ts";
 
-export async function add(componentName: string) {
+interface AddOptions {
+  overwrite?: boolean;
+}
+
+export async function add(componentName: string, options: AddOptions) {
   console.log();
 
   // Read config
@@ -16,9 +20,9 @@ export async function add(componentName: string) {
   }
 
   // Fetch registry
-  console.log(`Adding ${pc.cyan(componentName)}...`);
-
   const registry = await fetchRegistry();
+  console.log(pc.green("✔"), "Checking registry.");
+
   const componentDef = registry.components.find((c) => c.name === componentName);
 
   if (!componentDef) {
@@ -31,22 +35,39 @@ export async function add(componentName: string) {
     process.exit(1);
   }
 
+  // Install dependencies
+  if (componentDef.dependencies.length > 0) {
+    await installDependencies(componentDef.dependencies);
+    console.log(pc.green("✔"), "Installing dependencies.");
+  }
+
   // Fetch component files
   const files = await fetchComponent(componentDef);
 
   // Write files
   const componentsDir = path.join(process.cwd(), config.paths.components);
-  await writeComponentFiles(componentsDir, componentName, files, config);
+  const { written, skipped } = await writeComponentFiles(
+    componentsDir,
+    componentName,
+    files,
+    config,
+    options.overwrite,
+  );
 
-  console.log(pc.green("✓"), `Added ${componentName}`);
-
-  // Install dependencies
-  if (componentDef.dependencies.length > 0) {
-    console.log();
-    console.log("Installing dependencies...");
-    await installDependencies(componentDef.dependencies);
-    console.log(pc.green("✓"), `Installed ${componentDef.dependencies.join(", ")}`);
+  // Show skipped files
+  if (skipped.length > 0) {
+    console.log(
+      pc.yellow("ℹ"),
+      `Skipped ${skipped.length} file(s): (use --overwrite to overwrite)`,
+    );
+    skipped.forEach((f) => console.log(`  - ${f}`));
   }
+
+  if (written.length === 0) {
+    console.log();
+    return;
+  }
+
   console.log();
   console.log("Import it in your code:");
   console.log(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -21,6 +21,7 @@ program
   .command("add")
   .description("Add a component to your project")
   .argument("<component>", "Component name to add")
+  .option("-o, --overwrite", "Overwrite existing files")
   .action(add);
 
 program.parse();

--- a/packages/cli/src/utils/files.ts
+++ b/packages/cli/src/utils/files.ts
@@ -1,19 +1,45 @@
 import { spawn } from "child_process";
 import fs from "fs-extra";
 import path from "path";
+import prompts from "prompts";
 import type { BeaketConfig } from "./config.ts";
 import type { ComponentFile } from "./registry.ts";
+
+export interface WriteResult {
+  written: string[];
+  skipped: string[];
+}
 
 export async function writeComponentFiles(
   baseDir: string,
   componentName: string,
   files: ComponentFile[],
   config: BeaketConfig,
-): Promise<void> {
+  overwrite: boolean = false,
+): Promise<WriteResult> {
+  const written: string[] = [];
+  const skipped: string[] = [];
+
   for (const file of files) {
     // Transform file path: components/button/button.tsx -> button/button.tsx
     const relativePath = file.path.replace(/^components\//, "");
     const targetPath = path.join(baseDir, relativePath);
+
+    // Check if file exists
+    if (await fs.pathExists(targetPath)) {
+      if (!overwrite) {
+        const { confirm } = await prompts({
+          type: "confirm",
+          name: "confirm",
+          message: `${path.basename(targetPath)} already exists. Overwrite?`,
+          initial: false,
+        });
+        if (!confirm) {
+          skipped.push(targetPath);
+          continue;
+        }
+      }
+    }
 
     // Transform imports in content
     let content = file.content;
@@ -26,7 +52,10 @@ export async function writeComponentFiles(
 
     await fs.ensureDir(path.dirname(targetPath));
     await fs.writeFile(targetPath, content);
+    written.push(targetPath);
   }
+
+  return { written, skipped };
 }
 
 export async function installDependencies(deps: string[]): Promise<void> {


### PR DESCRIPTION
## Summary
- Add `--overwrite` (`-o`) flag to force overwrite without prompting
- Prompt user for confirmation when a file already exists
- Show skipped files with instructions to use `--overwrite`
- Improve progress display with checkmarks (✔ Checking registry, etc.)

## Example Output

**New file:**
```
✔ Checking registry.
✔ Installing dependencies.

Import it in your code:
  import { Button } from "@/components/button";
```

**Existing file:**
```
✔ Checking registry.
✔ Installing dependencies.
? button.tsx already exists. Overwrite? › (y/N)
ℹ Skipped 1 file(s): (use --overwrite to overwrite)
  - src/components/button/button.tsx
```

## Test plan
- [ ] Run `npx @beaket/ui add button` on a fresh project
- [ ] Run `npx @beaket/ui add button` again and decline overwrite
- [ ] Run `npx @beaket/ui add button --overwrite` to force overwrite

🤖 Generated with [Claude Code](https://claude.com/claude-code)