### PR TITLE
fix(husky): add formatted files back to staging area

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
-prettier $(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g') --write --ignore-unknown
+# Format staged files and re-add them to include the formatting changes in the commit
+FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
+[ -n "$FILES" ] && prettier $FILES --write --ignore-unknown && git add $FILES


### PR DESCRIPTION
## Problem

The pre-commit hook runs `prettier --write` but doesn't add the modified files back to staging area. This causes unformatted code to be committed.

## Solution

```bash
# Before
prettier ... --write --ignore-unknown

# After
FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
[ -n "$FILES" ] && prettier $FILES --write --ignore-unknown && git add $FILES
```

## Test plan

- [ ] Stage a file with formatting issues
- [ ] Commit and verify the committed file is formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)