### PR TITLE
fix(changeset): use correct package name @beaket/ui

### DIFF
--- a/.changeset/add-checkbox-component.md
+++ b/.changeset/add-checkbox-component.md
@@ -1,5 +1,5 @@
 ---
-"ui": minor
+"@beaket/ui": minor
 ---
 
 Add Checkbox component with Radix UI primitives


### PR DESCRIPTION
## Summary
- Fix changeset package name from `ui` to `@beaket/ui`
- This fixes the Release CI failure

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)