### PR TITLE
fix(docs): add checkbox component to docs page

### DIFF
--- a/docs/src/components/component-page.tsx
+++ b/docs/src/components/component-page.tsx
@@ -1,11 +1,15 @@
-import { AllSizes, AllStates, AllVariants } from "@/components/button.stories";
+import { AllSizes, AllVariants, AllStates as ButtonAllStates } from "@/components/button.stories";
+import { AllStates as CheckboxAllStates } from "@/components/checkbox.stories";
 
 // Map section names to their components
 const sectionComponents: Record<string, Record<string, React.ComponentType>> = {
   button: {
     AllVariants,
     AllSizes,
-    AllStates,
+    AllStates: ButtonAllStates,
+  },
+  checkbox: {
+    AllStates: CheckboxAllStates,
   },
 };
 


### PR DESCRIPTION
## Summary
- Import checkbox stories into the docs component page
- Add checkbox section mapping so the component is visible in documentation

## Test plan
- [ ] Verify checkbox appears at `/ui/components/checkbox` in docs
- [ ] Confirm AllStates section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)