### PR TITLE
feat(docs): auto-generate component pages from Storybook

### DIFF
--- a/.changeset/gentle-foxes-rest.md
+++ b/.changeset/gentle-foxes-rest.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+Add usage field to registry.json for component documentation

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -2,6 +2,8 @@
 dist/
 # generated types
 .astro/
+# generated props data
+src/generated/
 
 # dependencies
 node_modules/

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,8 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
-    "dev": "astro dev",
+    "dev": "tsx scripts/generate-props.ts && astro dev",
+    "prebuild": "tsx scripts/generate-props.ts",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
@@ -18,11 +19,14 @@
     "clsx": "2.1.1",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "shiki": "^3.20.0",
     "tailwind-merge": "3.4.0",
     "tailwindcss": "4.1.18"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.6",
+    "react-docgen-typescript": "^2.4.0",
+    "tsx": "^4.21.0",
     "typescript": "5.9.3"
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "typecheck": "astro check"
+    "typecheck": "tsx scripts/generate-props.ts && astro check"
   },
   "dependencies": {
     "@astrojs/react": "^4.4.2",

--- a/docs/scripts/generate-props.ts
+++ b/docs/scripts/generate-props.ts
@@ -1,0 +1,78 @@
+import * as fs from "fs";
+import * as path from "path";
+import { withCompilerOptions } from "react-docgen-typescript";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+interface PropInfo {
+  name: string;
+  type: string;
+  required: boolean;
+  defaultValue: string | null;
+  description: string;
+}
+
+interface ComponentProps {
+  [componentName: string]: PropInfo[];
+}
+
+// Read registry
+const registryPath = path.resolve(__dirname, "../../registry/registry.json");
+const registry = JSON.parse(fs.readFileSync(registryPath, "utf-8"));
+
+// Parser options
+const parser = withCompilerOptions(
+  { esModuleInterop: true, jsx: 1 }, // 1 = React
+  {
+    savePropValueAsString: true,
+    shouldExtractLiteralValuesFromEnum: true,
+    propFilter: (prop) => {
+      // Only keep props defined in our source files (not from node_modules)
+      if (prop.declarations && prop.declarations.length > 0) {
+        return prop.declarations.some(
+          (d) => !d.fileName.includes("node_modules") && d.fileName.includes("/src/components/"),
+        );
+      }
+      return false;
+    },
+  },
+);
+
+function generateProps() {
+  const result: ComponentProps = {};
+
+  for (const component of registry.components) {
+    const filePath = path.resolve(__dirname, "../../src", component.files[0]);
+
+    if (!fs.existsSync(filePath)) {
+      console.warn(`File not found: ${filePath}`);
+      continue;
+    }
+
+    const docs = parser.parse(filePath);
+
+    if (docs.length > 0) {
+      const componentDoc = docs[0];
+      result[component.name] = Object.entries(componentDoc.props).map(([name, prop]) => ({
+        name,
+        type: prop.type.name,
+        required: prop.required,
+        defaultValue: prop.defaultValue?.value ?? null,
+        description: prop.description,
+      }));
+    }
+  }
+
+  // Output
+  const outputDir = path.resolve(__dirname, "../src/generated");
+  fs.mkdirSync(outputDir, { recursive: true });
+
+  const outputPath = path.join(outputDir, "props.json");
+  fs.writeFileSync(outputPath, JSON.stringify(result, null, 2));
+
+  console.log(`Props generated: ${outputPath}`);
+  console.log(`Components: ${Object.keys(result).join(", ")}`);
+}
+
+generateProps();

--- a/docs/src/components/component-page.tsx
+++ b/docs/src/components/component-page.tsx
@@ -1,13 +1,20 @@
-import { AllSizes, AllStates, AllVariants } from "@/components/button.stories";
+import { useEffect, useMemo, useState } from "react";
+import { createHighlighter, type Highlighter } from "shiki";
+import propsData from "../generated/props.json";
+import { getDefaultStory, getStoriesForComponent, type LoadedStory } from "../utils/story-loader";
+import { generateUsageCode } from "../utils/story-parser";
 
-// Map section names to their components
-const sectionComponents: Record<string, Record<string, React.ComponentType>> = {
-  button: {
-    AllVariants,
-    AllSizes,
-    AllStates,
-  },
-};
+// Lazy-load highlighter
+let highlighterPromise: Promise<Highlighter> | null = null;
+function getHighlighter() {
+  if (!highlighterPromise) {
+    highlighterPromise = createHighlighter({
+      themes: ["gruvbox-dark-soft"],
+      langs: ["tsx", "bash"],
+    });
+  }
+  return highlighterPromise;
+}
 
 interface ComponentData {
   name: string;
@@ -23,41 +30,151 @@ interface ComponentPageProps {
   component: ComponentData;
 }
 
-function formatSectionName(name: string): string {
-  return name.replace(/^All/, "");
-}
-
 export function ComponentPage({ component }: ComponentPageProps) {
   const { name, docs } = component;
   const sections = docs?.sections ?? [];
-  const componentSections = sectionComponents[name] ?? {};
+
+  const stories = useMemo(() => getStoriesForComponent(name), [name]);
+  const defaultStory = useMemo(() => getDefaultStory(name), [name]);
+  const props = propsData[name as keyof typeof propsData] ?? [];
+  const usageCode = useMemo(() => generateUsageCode(name), [name]);
 
   return (
-    <div>
-      <h1 className="mb-4 text-2xl font-semibold">{docs?.title ?? name}</h1>
-      <p className="mb-6 text-[var(--steel)]">{docs?.tagline ?? component.description}</p>
+    <div className="space-y-6">
+      {/* Title + Preview */}
+      <header>
+        <h1 className="font-mono text-xl font-semibold">{docs?.title ?? name}</h1>
+        <p className="text-sm text-[var(--steel)]">{docs?.tagline ?? component.description}</p>
+        {defaultStory && (
+          <Preview>
+            <StoryRenderer story={defaultStory} />
+          </Preview>
+        )}
+      </header>
 
-      <pre className="mb-8 border border-[var(--chrome)] bg-[var(--frost)] p-3 font-mono text-sm">
-        npx @beaket/ui add {name}
-      </pre>
+      {/* Install */}
+      <section>
+        <h2 className="mb-1 font-mono text-xs font-medium text-[var(--steel)] uppercase">
+          Install
+        </h2>
+        <CodeBlock lang="bash">{`npx @beaket/ui add ${name}`}</CodeBlock>
+      </section>
 
-      {sections.map((sectionName) => {
-        const SectionComponent = componentSections[sectionName];
-        return (
-          <div key={sectionName}>
-            <h2 className="mt-8 mb-2 border-b border-[var(--chrome)] pb-1 text-base font-medium">
-              {formatSectionName(sectionName)}
-            </h2>
-            <div className="my-4 flex items-center justify-center border border-[var(--chrome)] bg-white p-6">
-              {SectionComponent ? (
-                <SectionComponent />
-              ) : (
-                <p className="text-[var(--steel)]">Section not found</p>
-              )}
-            </div>
-          </div>
-        );
-      })}
+      {/* Usage */}
+      <section>
+        <h2 className="mb-1 font-mono text-xs font-medium text-[var(--steel)] uppercase">Usage</h2>
+        <CodeBlock>{usageCode}</CodeBlock>
+      </section>
+
+      {/* Examples */}
+      <section>
+        <h2 className="mb-2 font-mono text-xs font-medium text-[var(--steel)] uppercase">
+          Examples
+        </h2>
+        <div className="space-y-4">
+          {sections.map((sectionName) => {
+            const story = stories.get(sectionName);
+            if (!story) return null;
+            return <ExampleSection key={sectionName} story={story} />;
+          })}
+        </div>
+      </section>
+
+      {/* Props */}
+      <section>
+        <h2 className="mb-2 font-mono text-xs font-medium text-[var(--steel)] uppercase">Props</h2>
+        <PropsTable props={props} />
+      </section>
     </div>
+  );
+}
+
+function Preview({ children }: { children: React.ReactNode }) {
+  return <div className="mt-2 border border-[var(--chrome)] bg-white p-4">{children}</div>;
+}
+
+function CodeBlock({ children, lang = "tsx" }: { children: string; lang?: string }) {
+  const [html, setHtml] = useState<string | null>(null);
+
+  useEffect(() => {
+    getHighlighter().then((highlighter) => {
+      setHtml(highlighter.codeToHtml(children, { lang, theme: "gruvbox-dark-soft" }));
+    });
+  }, [children, lang]);
+
+  if (html) {
+    return (
+      <div
+        className="overflow-x-auto font-mono text-sm [&_pre]:p-2"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    );
+  }
+
+  return (
+    <pre className="overflow-x-auto bg-[#32302f] p-2 font-mono text-sm text-[#ebdbb2]">
+      <code>{children}</code>
+    </pre>
+  );
+}
+
+function StoryRenderer({ story }: { story: LoadedStory }) {
+  const { component: Component, args, isComposition } = story;
+  if (!Component) return <span className="text-[var(--steel)]">—</span>;
+  return isComposition ? <Component /> : <Component {...args} />;
+}
+
+function ExampleSection({ story }: { story: LoadedStory }) {
+  return (
+    <div>
+      <h3 className="mb-1 text-sm font-medium">{story.displayName}</h3>
+      <Preview>
+        <StoryRenderer story={story} />
+      </Preview>
+      {story.source && (
+        <details className="mt-1">
+          <summary className="cursor-pointer font-mono text-xs text-[var(--steel)]">code</summary>
+          <CodeBlock>{story.source}</CodeBlock>
+        </details>
+      )}
+    </div>
+  );
+}
+
+interface PropInfo {
+  name: string;
+  type: string;
+  required: boolean;
+  defaultValue: string | null;
+  description: string;
+}
+
+function PropsTable({ props }: { props: PropInfo[] }) {
+  if (!props.length) return <p className="text-sm text-[var(--steel)]">—</p>;
+
+  return (
+    <table className="w-full font-mono text-xs">
+      <thead>
+        <tr className="border-b border-[var(--chrome)] text-left text-[var(--steel)]">
+          <th className="py-1 pr-3">name</th>
+          <th className="py-1 pr-3">type</th>
+          <th className="py-1 pr-3">default</th>
+          <th className="py-1">description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {props.map((p) => (
+          <tr key={p.name} className="border-b border-[var(--chrome)]">
+            <td className="py-1 pr-3">
+              {p.name}
+              {p.required && <span className="text-[var(--signal-red)]">*</span>}
+            </td>
+            <td className="py-1 pr-3 text-[var(--steel)]">{p.type}</td>
+            <td className="py-1 pr-3">{p.defaultValue ?? "—"}</td>
+            <td className="py-1 font-sans text-[var(--steel)]">{p.description}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }

--- a/docs/src/components/component-page.tsx
+++ b/docs/src/components/component-page.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState } from "react";
 import { createHighlighter, type Highlighter } from "shiki";
 import propsData from "../generated/props.json";
 import { getDefaultStory, getStoriesForComponent, type LoadedStory } from "../utils/story-loader";
-import { generateUsageCode } from "../utils/story-parser";
 
 // Lazy-load highlighter
 let highlighterPromise: Promise<Highlighter> | null = null;
@@ -23,6 +22,7 @@ interface ComponentData {
     title?: string;
     tagline?: string;
     sections?: string[];
+    usage?: string;
   };
 }
 
@@ -37,7 +37,11 @@ export function ComponentPage({ component }: ComponentPageProps) {
   const stories = useMemo(() => getStoriesForComponent(name), [name]);
   const defaultStory = useMemo(() => getDefaultStory(name), [name]);
   const props = propsData[name as keyof typeof propsData] ?? [];
-  const usageCode = useMemo(() => generateUsageCode(name), [name]);
+
+  const pascalName = name.charAt(0).toUpperCase() + name.slice(1);
+  const usageCode = `import { ${pascalName} } from "@beaket/ui/${name}"
+
+${docs?.usage ?? `<${pascalName} />`}`;
 
   return (
     <div className="space-y-6">

--- a/docs/src/utils/story-loader.ts
+++ b/docs/src/utils/story-loader.ts
@@ -1,0 +1,118 @@
+import type { ComponentType } from "react";
+import { extractExports, formatExportName } from "./story-parser";
+
+// Import all story modules (for rendering)
+// Path is relative from docs/ since that's where Vite resolves from
+const storyModules = import.meta.glob<Record<string, unknown>>(
+  "../../../src/components/*.stories.tsx",
+  { eager: true },
+);
+
+// Import all story sources (for code display)
+const storySources = import.meta.glob<string>("../../../src/components/*.stories.tsx", {
+  eager: true,
+  query: "?raw",
+  import: "default",
+});
+
+export interface LoadedStory {
+  name: string;
+  displayName: string;
+  component: ComponentType | null;
+  args?: Record<string, unknown>;
+  source: string;
+  isComposition: boolean;
+}
+
+interface StoryMeta {
+  component: ComponentType;
+  title?: string;
+}
+
+interface StoryObj {
+  args?: Record<string, unknown>;
+  play?: unknown;
+}
+
+/**
+ * Get all stories for a component by name.
+ */
+export function getStoriesForComponent(componentName: string): Map<string, LoadedStory> {
+  const storyPath = Object.keys(storyModules).find((path) =>
+    path.includes(`/${componentName}.stories.tsx`),
+  );
+
+  if (!storyPath) return new Map();
+
+  const module = storyModules[storyPath];
+  const source = storySources[storyPath];
+  const parsedSources = extractExports(source);
+  const meta = module.default as StoryMeta | undefined;
+
+  const stories = new Map<string, LoadedStory>();
+
+  for (const [exportName, exportValue] of Object.entries(module)) {
+    if (exportName === "default") continue;
+
+    const storySource = parsedSources.get(exportName) ?? "";
+    const displayName = formatExportName(exportName);
+
+    if (typeof exportValue === "function") {
+      // Composition component (e.g., AllVariants = () => ...)
+      stories.set(exportName, {
+        name: exportName,
+        displayName,
+        component: exportValue as ComponentType,
+        source: storySource,
+        isComposition: true,
+      });
+    } else if (typeof exportValue === "object" && exportValue !== null) {
+      // StoryObj (e.g., Default: Story = { args: {...} })
+      const storyObj = exportValue as StoryObj;
+
+      // Skip interaction test stories (those with play function)
+      if (storyObj.play) continue;
+
+      stories.set(exportName, {
+        name: exportName,
+        displayName,
+        component: meta?.component ?? null,
+        args: storyObj.args,
+        source: storySource,
+        isComposition: false,
+      });
+    }
+  }
+
+  return stories;
+}
+
+/**
+ * Get a specific story by component name and story name.
+ */
+export function getStory(componentName: string, storyName: string): LoadedStory | undefined {
+  const stories = getStoriesForComponent(componentName);
+  return stories.get(storyName);
+}
+
+/**
+ * Get the Default story for preview.
+ * Falls back to first non-composition story if "Default" doesn't exist.
+ */
+export function getDefaultStory(componentName: string): LoadedStory | undefined {
+  const stories = getStoriesForComponent(componentName);
+
+  // Try "Default" first
+  if (stories.has("Default")) {
+    return stories.get("Default");
+  }
+
+  // Fallback to first non-composition story
+  for (const story of stories.values()) {
+    if (!story.isComposition) {
+      return story;
+    }
+  }
+
+  return undefined;
+}

--- a/docs/src/utils/story-parser.ts
+++ b/docs/src/utils/story-parser.ts
@@ -94,21 +94,3 @@ export function formatExportName(name: string): string {
 
   return formatted || name;
 }
-
-/**
- * Generates a basic usage example for a component.
- */
-export function generateUsageCode(componentName: string): string {
-  const pascalName = componentName.charAt(0).toUpperCase() + componentName.slice(1);
-
-  // Different usage patterns for different components
-  if (componentName === "checkbox") {
-    return `import { ${pascalName} } from "@beaket/ui/${componentName}"
-
-<${pascalName} />`;
-  }
-
-  return `import { ${pascalName} } from "@beaket/ui/${componentName}"
-
-<${pascalName}>Click me</${pascalName}>`;
-}

--- a/docs/src/utils/story-parser.ts
+++ b/docs/src/utils/story-parser.ts
@@ -1,0 +1,114 @@
+/**
+ * Extracts named exports from a story file source code.
+ * Returns a Map of export name to source code.
+ */
+export function extractExports(source: string): Map<string, string> {
+  const exports = new Map<string, string>();
+  const lines = source.split("\n");
+
+  let currentExport: { name: string; startLine: number } | null = null;
+  let braceDepth = 0;
+  let parenDepth = 0;
+  let inString: string | null = null;
+  let inTemplateLiteral = false;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    // Check for new export (only at the start of a line, after optional whitespace)
+    if (!currentExport) {
+      const exportMatch = line.match(/^export\s+const\s+(\w+)/);
+      if (exportMatch) {
+        currentExport = { name: exportMatch[1], startLine: i };
+        braceDepth = 0;
+        parenDepth = 0;
+      }
+    }
+
+    if (currentExport) {
+      // Parse the line character by character to track depth
+      for (let j = 0; j < line.length; j++) {
+        const char = line[j];
+        const prevChar = j > 0 ? line[j - 1] : "";
+
+        // Handle string literals
+        if (!inTemplateLiteral && (char === '"' || char === "'") && prevChar !== "\\") {
+          if (inString === char) {
+            inString = null;
+          } else if (!inString) {
+            inString = char;
+          }
+          continue;
+        }
+
+        // Handle template literals
+        if (char === "`" && prevChar !== "\\") {
+          inTemplateLiteral = !inTemplateLiteral;
+          continue;
+        }
+
+        // Skip if inside a string
+        if (inString || inTemplateLiteral) continue;
+
+        // Track braces and parens
+        if (char === "{") braceDepth++;
+        if (char === "}") braceDepth--;
+        if (char === "(") parenDepth++;
+        if (char === ")") parenDepth--;
+      }
+
+      // Export ends when balanced and line ends with ; or )
+      const trimmedLine = line.trimEnd();
+      if (
+        braceDepth === 0 &&
+        parenDepth === 0 &&
+        (trimmedLine.endsWith(";") || trimmedLine.endsWith(")"))
+      ) {
+        const code = lines.slice(currentExport.startLine, i + 1).join("\n");
+        // Skip the default export (meta)
+        if (currentExport.name !== "default") {
+          exports.set(currentExport.name, code);
+        }
+        currentExport = null;
+        inString = null;
+        inTemplateLiteral = false;
+      }
+    }
+  }
+
+  return exports;
+}
+
+/**
+ * Formats an export name into a display title.
+ * AllVariants -> Variants
+ * Default -> Default
+ * ClickTest -> Click Test
+ */
+export function formatExportName(name: string): string {
+  // Remove "All" prefix
+  let formatted = name.replace(/^All/, "");
+
+  // Add spaces before capital letters (camelCase to Title Case)
+  formatted = formatted.replace(/([a-z])([A-Z])/g, "$1 $2");
+
+  return formatted || name;
+}
+
+/**
+ * Generates a basic usage example for a component.
+ */
+export function generateUsageCode(componentName: string): string {
+  const pascalName = componentName.charAt(0).toUpperCase() + componentName.slice(1);
+
+  // Different usage patterns for different components
+  if (componentName === "checkbox") {
+    return `import { ${pascalName} } from "@beaket/ui/${componentName}"
+
+<${pascalName} />`;
+  }
+
+  return `import { ${pascalName} } from "@beaket/ui/${componentName}"
+
+<${pascalName}>Click me</${pascalName}>`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,19 +38,19 @@ importers:
         version: 10.1.10(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@storybook/addon-docs':
         specifier: 10.1.10
-        version: 10.1.10(@types/react@19.2.7)(esbuild@0.27.2)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+        version: 10.1.10(@types/react@19.2.7)(esbuild@0.27.2)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/addon-onboarding':
         specifier: 10.1.10
         version: 10.1.10(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       '@storybook/addon-vitest':
         specifier: 10.1.10
-        version: 10.1.10(@vitest/browser-playwright@4.0.16)(@vitest/browser@4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.16))(@vitest/runner@4.0.16)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.0.16)
+        version: 10.1.10(@vitest/browser-playwright@4.0.16)(@vitest/browser@4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16))(@vitest/runner@4.0.16)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.0.16)
       '@storybook/react-vite':
         specifier: 10.1.10
-        version: 10.1.10(esbuild@0.27.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+        version: 10.1.10(esbuild@0.27.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@tailwindcss/vite':
         specifier: 4.1.18
-        version: 4.1.18(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+        version: 4.1.18(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@types/react':
         specifier: 19.2.7
         version: 19.2.7
@@ -59,13 +59,13 @@ importers:
         version: 19.2.3(@types/react@19.2.7)
       '@vitejs/plugin-react':
         specifier: 5.1.2
-        version: 5.1.2(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+        version: 5.1.2(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/browser-playwright':
         specifier: 4.0.16
-        version: 4.0.16(playwright@1.57.0)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.16)
+        version: 4.0.16(playwright@1.57.0)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)
       '@vitest/coverage-v8':
         specifier: 4.0.16
-        version: 4.0.16(@vitest/browser@4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.16))(vitest@4.0.16)
+        version: 4.0.16(@vitest/browser@4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16))(vitest@4.0.16)
       husky:
         specifier: 9.1.7
         version: 9.1.7
@@ -98,25 +98,25 @@ importers:
         version: 5.9.3
       vite:
         specifier: 7.3.0
-        version: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+        version: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
       vitest:
         specifier: 4.0.16
-        version: 4.0.16(@types/node@25.0.3)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+        version: 4.0.16(@types/node@25.0.3)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   docs:
     dependencies:
       '@astrojs/react':
         specifier: ^4.4.2
-        version: 4.4.2(@types/node@25.0.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(yaml@2.8.2)
+        version: 4.4.2(@types/node@25.0.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(yaml@2.8.2)
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.2.3)
       '@tailwindcss/vite':
         specifier: 4.1.18
-        version: 4.1.18(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+        version: 4.1.18(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       astro:
         specifier: ^5.16.6
-        version: 5.16.6(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.54.0)(typescript@5.9.3)(yaml@2.8.2)
+        version: 5.16.6(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.54.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -129,6 +129,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      shiki:
+        specifier: ^3.20.0
+        version: 3.20.0
       tailwind-merge:
         specifier: 3.4.0
         version: 3.4.0
@@ -139,6 +142,12 @@ importers:
       '@astrojs/check':
         specifier: ^0.9.6
         version: 0.9.6(prettier@3.7.4)(typescript@5.9.3)
+      react-docgen-typescript:
+        specifier: ^2.4.0
+        version: 2.4.0(typescript@5.9.3)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: 5.9.3
         version: 5.9.3
@@ -2138,6 +2147,9 @@ packages:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
 
+  get-tsconfig@4.13.0:
+    resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
+
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
 
@@ -3009,6 +3021,9 @@ packages:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
 
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
@@ -3257,6 +3272,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
@@ -3819,15 +3839,15 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@4.4.2(@types/node@25.0.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(yaml@2.8.2)':
+  '@astrojs/react@4.4.2(@types/node@25.0.3)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.21.0)(yaml@2.8.2)':
     dependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
-      '@vitejs/plugin-react': 4.7.0(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@vitejs/plugin-react': 4.7.0(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
       ultrahtml: 1.6.0
-      vite: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4437,11 +4457,11 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.3(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.3(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       glob: 11.1.0
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -4720,10 +4740,10 @@ snapshots:
       axe-core: 4.11.0
       storybook: 10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  '@storybook/addon-docs@10.1.10(@types/react@19.2.7)(esbuild@0.27.2)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@storybook/addon-docs@10.1.10(@types/react@19.2.7)(esbuild@0.27.2)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.2.7)(react@19.2.3)
-      '@storybook/csf-plugin': 10.1.10(esbuild@0.27.2)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@storybook/csf-plugin': 10.1.10(esbuild@0.27.2)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/icons': 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@storybook/react-dom-shim': 10.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))
       react: 19.2.3
@@ -4741,41 +4761,41 @@ snapshots:
     dependencies:
       storybook: 10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  '@storybook/addon-vitest@10.1.10(@vitest/browser-playwright@4.0.16)(@vitest/browser@4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.16))(@vitest/runner@4.0.16)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.0.16)':
+  '@storybook/addon-vitest@10.1.10(@vitest/browser-playwright@4.0.16)(@vitest/browser@4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16))(@vitest/runner@4.0.16)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vitest@4.0.16)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       storybook: 10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     optionalDependencies:
-      '@vitest/browser': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.16)
-      '@vitest/browser-playwright': 4.0.16(playwright@1.57.0)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.16)
+      '@vitest/browser': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)
+      '@vitest/browser-playwright': 4.0.16(playwright@1.57.0)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)
       '@vitest/runner': 4.0.16
-      vitest: 4.0.16(@types/node@25.0.3)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vitest: 4.0.16(@types/node@25.0.3)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.1.10(esbuild@0.27.2)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@storybook/builder-vite@10.1.10(esbuild@0.27.2)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@storybook/csf-plugin': 10.1.10(esbuild@0.27.2)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
-      '@vitest/mocker': 3.2.4(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@storybook/csf-plugin': 10.1.10(esbuild@0.27.2)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       storybook: 10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       ts-dedent: 2.2.0
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - esbuild
       - msw
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.1.10(esbuild@0.27.2)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@storybook/csf-plugin@10.1.10(esbuild@0.27.2)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       storybook: 10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.27.2
       rollup: 4.54.0
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   '@storybook/global@5.0.0': {}
 
@@ -4790,11 +4810,11 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       storybook: 10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
 
-  '@storybook/react-vite@10.1.10(esbuild@0.27.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@storybook/react-vite@10.1.10(esbuild@0.27.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.3(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.3(typescript@5.9.3)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@rollup/pluginutils': 5.3.0(rollup@4.54.0)
-      '@storybook/builder-vite': 10.1.10(esbuild@0.27.2)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@storybook/builder-vite': 10.1.10(esbuild@0.27.2)(rollup@4.54.0)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/react': 10.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -4804,7 +4824,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.1.10(@testing-library/dom@10.4.1)(prettier@3.7.4)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       tsconfig-paths: 4.2.0
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - esbuild
       - msw
@@ -4891,12 +4911,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.18
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.18
 
-  '@tailwindcss/vite@4.1.18(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.1.18(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -5014,7 +5034,7 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -5022,11 +5042,11 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.1.2(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@vitejs/plugin-react@5.1.2(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -5034,33 +5054,33 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.53
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser-playwright@4.0.16(playwright@1.57.0)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.16)':
+  '@vitest/browser-playwright@4.0.16(playwright@1.57.0)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)':
     dependencies:
-      '@vitest/browser': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.16)
-      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@vitest/browser': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)
+      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       playwright: 1.57.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@types/node@25.0.3)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vitest: 4.0.16(@types/node@25.0.3)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.16)':
+  '@vitest/browser@4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)':
     dependencies:
-      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/utils': 4.0.16
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@types/node@25.0.3)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vitest: 4.0.16(@types/node@25.0.3)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
       ws: 8.18.3
     transitivePeerDependencies:
       - bufferutil
@@ -5068,7 +5088,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.0.16(@vitest/browser@4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.16))(vitest@4.0.16)':
+  '@vitest/coverage-v8@4.0.16(@vitest/browser@4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16))(vitest@4.0.16)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.16
@@ -5081,9 +5101,9 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.16(@types/node@25.0.3)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vitest: 4.0.16(@types/node@25.0.3)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
-      '@vitest/browser': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.16)
+      '@vitest/browser': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)
     transitivePeerDependencies:
       - supports-color
 
@@ -5104,21 +5124,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@3.2.4(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@vitest/mocker@3.2.4(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
-  '@vitest/mocker@4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.16
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5270,7 +5290,7 @@ snapshots:
       estree-walker: 3.0.3
       js-tokens: 9.0.1
 
-  astro@5.16.6(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.54.0)(typescript@5.9.3)(yaml@2.8.2):
+  astro@5.16.6(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.54.0)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
     dependencies:
       '@astrojs/compiler': 2.13.0
       '@astrojs/internal-helpers': 0.7.5
@@ -5327,8 +5347,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.17.3
       vfile: 6.0.3
-      vite: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
-      vitefu: 1.1.1(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      vite: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+      vitefu: 1.1.1(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -5811,6 +5831,10 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.4.0: {}
+
+  get-tsconfig@4.13.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   github-slugger@2.0.0: {}
 
@@ -6818,6 +6842,8 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
+  resolve-pkg-maps@1.0.0: {}
+
   resolve@1.22.11:
     dependencies:
       is-core-module: 2.16.1
@@ -7108,6 +7134,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.2
+      get-tsconfig: 4.13.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-fest@4.41.0: {}
 
   typesafe-path@0.2.2: {}
@@ -7241,7 +7274,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2):
+  vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.3)
@@ -7254,9 +7287,10 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
+      tsx: 4.21.0
       yaml: 2.8.2
 
-  vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2):
+  vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -7269,16 +7303,17 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.30.2
+      tsx: 4.21.0
       yaml: 2.8.2
 
-  vitefu@1.1.1(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)):
+  vitefu@1.1.1(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
 
-  vitest@4.0.16(@types/node@25.0.3)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2):
+  vitest@4.0.16(@types/node@25.0.3)(@vitest/browser-playwright@4.0.16)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.16
-      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.16(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.16
       '@vitest/runner': 4.0.16
       '@vitest/snapshot': 4.0.16
@@ -7295,11 +7330,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+      vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.0.3
-      '@vitest/browser-playwright': 4.0.16(playwright@1.57.0)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2))(vitest@4.0.16)
+      '@vitest/browser-playwright': 4.0.16(playwright@1.57.0)(vite@7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2))(vitest@4.0.16)
     transitivePeerDependencies:
       - jiti
       - less

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -14,7 +14,8 @@
       "docs": {
         "title": "Button",
         "tagline": "Clickable button with multiple variants and sizes.",
-        "sections": ["AllVariants", "AllSizes", "AllStates"]
+        "sections": ["AllVariants", "AllSizes", "AllStates"],
+        "usage": "<Button>Click me</Button>"
       }
     },
     {
@@ -26,7 +27,8 @@
       "docs": {
         "title": "Checkbox",
         "tagline": "A control for boolean input with checked and unchecked states.",
-        "sections": ["AllStates"]
+        "sections": ["AllStates"],
+        "usage": "<Checkbox />"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Auto-generate component documentation pages from Storybook stories
- Extract props from TypeScript using react-docgen-typescript
- Add syntax highlighting with shiki (Gruvbox Dark Soft theme)
- Brutalist design with dense layout and monospace headers

## Changes
- `docs/scripts/generate-props.ts` - Props extraction at build time
- `docs/src/utils/story-loader.ts` - Dynamic story imports via import.meta.glob
- `docs/src/utils/story-parser.ts` - Source code extraction from story files
- `docs/src/components/component-page.tsx` - Refactored with new design

## New component page structure
```
Title
Description
[Preview - immediately visible]

INSTALL
USAGE
EXAMPLES
PROPS
```

## Test plan
- [ ] Run `pnpm run build` in docs folder
- [ ] Verify button and checkbox pages render correctly
- [ ] Check syntax highlighting works on code blocks
- [ ] Verify props table shows correct information

🤖 Generated with [Claude Code](https://claude.com/claude-code)