### PR TITLE
feat(docs): show individual component links in sidebar

### DIFF
--- a/docs/src/layouts/doc.astro
+++ b/docs/src/layouts/doc.astro
@@ -1,12 +1,14 @@
 ---
 import '../styles/global.css';
 import pkg from '../../../packages/cli/package.json';
+import registry from '../../../registry/registry.json';
 
 interface Props {
   title?: string;
 }
 const { title = 'Beaket UI' } = Astro.props;
 const currentPath = Astro.url.pathname;
+const components = registry.components;
 ---
 
 <!doctype html>
@@ -30,8 +32,10 @@ const currentPath = Astro.url.pathname;
         </div>
 
         <div class="sidebar-section">
-          <div class="sidebar-section-title">Docs</div>
-          <a href="/ui/components" class:list={["sidebar-link", { active: currentPath.includes('/components') }]}>Components</a>
+          <div class="sidebar-section-title">Components</div>
+          {components.map((component) => (
+            <a href={`/ui/components/${component.name}`} class:list={["sidebar-link", { active: currentPath.includes(`/components/${component.name}`) }]}>{component.docs.title}</a>
+          ))}
         </div>
 
         <div class="sidebar-section">


### PR DESCRIPTION
## Summary
- Rename sidebar section from "Docs" to "Components"
- Dynamically generate component links from registry.json instead of a single "Components" link
- Each component name (Button, Checkbox, etc.) now appears as a separate navigation item

## Test plan
- [ ] Verify sidebar displays "Components" section title
- [ ] Verify each component from registry.json appears as individual link
- [ ] Verify clicking a component link navigates to correct page
- [ ] Verify active state highlights correctly on component pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)