### PR TITLE
feat(components): add Badge component

### DIFF
--- a/.changeset/add-badge-component.md
+++ b/.changeset/add-badge-component.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": minor
+---
+
+Add Badge component with 6 variants: default, secondary, success, error, info, outline

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -30,6 +30,19 @@
         "sections": ["AllStates"],
         "usage": "<Checkbox />"
       }
+    },
+    {
+      "name": "badge",
+      "description": "Badge component for status indicators and labels",
+      "dependencies": ["class-variance-authority", "clsx", "tailwind-merge"],
+      "registryDependencies": [],
+      "files": ["components/badge.tsx"],
+      "docs": {
+        "title": "Badge",
+        "tagline": "A compact label for status indicators, categories, and counts.",
+        "sections": ["AllVariants"],
+        "usage": "<Badge>Label</Badge>"
+      }
     }
   ]
 }

--- a/src/components/badge.stories.tsx
+++ b/src/components/badge.stories.tsx
@@ -1,0 +1,99 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+import { Badge } from "./badge";
+
+const meta: Meta<typeof Badge> = {
+  title: "Components/Badge",
+  component: Badge,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: {
+      control: "select",
+      options: ["default", "secondary", "success", "error", "info", "outline"],
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Badge>;
+
+export const Default: Story = {
+  args: {
+    children: "Badge",
+    variant: "default",
+  },
+};
+
+export const Secondary: Story = {
+  args: {
+    children: "Secondary",
+    variant: "secondary",
+  },
+};
+
+export const Success: Story = {
+  args: {
+    children: "Success",
+    variant: "success",
+  },
+};
+
+export const Error: Story = {
+  args: {
+    children: "Error",
+    variant: "error",
+  },
+};
+
+export const Info: Story = {
+  args: {
+    children: "Info",
+    variant: "info",
+  },
+};
+
+export const Outline: Story = {
+  args: {
+    children: "Outline",
+    variant: "outline",
+  },
+};
+
+// Compositions for docs
+export const AllVariants = () => (
+  <div className="flex flex-wrap gap-2">
+    <Badge variant="default">Default</Badge>
+    <Badge variant="secondary">Secondary</Badge>
+    <Badge variant="success">Success</Badge>
+    <Badge variant="error">Error</Badge>
+    <Badge variant="info">Info</Badge>
+    <Badge variant="outline">Outline</Badge>
+  </div>
+);
+
+// Interaction Tests
+export const RenderTest: Story = {
+  args: {
+    children: "Test Badge",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const badge = canvas.getByText("Test Badge");
+
+    await expect(badge).toBeInTheDocument();
+  },
+};
+
+export const AccessibilityTest: Story = {
+  args: {
+    children: "Status",
+    role: "status",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const badge = canvas.getByRole("status");
+
+    await expect(badge).toBeInTheDocument();
+    await expect(badge).toHaveTextContent("Status");
+  },
+};

--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -1,0 +1,35 @@
+import { cva } from "class-variance-authority";
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+
+export interface Props extends React.HTMLAttributes<HTMLSpanElement> {
+  /** Badge style variant */
+  variant?: "default" | "secondary" | "success" | "error" | "info" | "outline";
+}
+
+export function Badge({ className, variant, ...props }: Props) {
+  return <span className={cn(badgeVariants({ variant }), className)} {...props} />;
+}
+
+const badgeVariants = cva(
+  ["inline-flex items-center justify-center", "px-2 py-0.5", "text-xs font-medium", "border"].join(
+    " ",
+  ),
+  {
+    variants: {
+      variant: {
+        default: "bg-[var(--ink)] text-white border-[var(--ink)]",
+        secondary: "bg-[var(--frost)] text-[var(--ink)] border-[var(--chrome)]",
+        success: "bg-[var(--signal-green)] text-white border-[var(--signal-green)]",
+        error: "bg-[var(--signal-red)] text-white border-[var(--signal-red)]",
+        info: "bg-[var(--signal-blue)] text-white border-[var(--signal-blue)]",
+        outline: "bg-transparent text-[var(--ink)] border-[var(--chrome)]",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);


### PR DESCRIPTION
## Summary

- Add new Badge component for status indicators and labels
- Support 6 variants: default, secondary, success, error, info, outline
- Include Storybook stories and interaction tests
- Register component in registry.json

## Test plan

- [ ] Run Storybook and verify all badge variants render correctly
- [ ] Run interaction tests via Storybook test runner
- [ ] Verify component builds without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)