### PR TITLE
feat(components): add Input component

### DIFF
--- a/.changeset/add-input-component.md
+++ b/.changeset/add-input-component.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": minor
+---
+
+Add Input component with brutalist design

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -43,6 +43,19 @@
         "sections": ["AllVariants"],
         "usage": "<Badge>Label</Badge>"
       }
+    },
+    {
+      "name": "input",
+      "description": "Text input component for user data entry",
+      "dependencies": ["clsx", "tailwind-merge"],
+      "registryDependencies": [],
+      "files": ["components/input.tsx"],
+      "docs": {
+        "title": "Input",
+        "tagline": "A text input field for capturing user data.",
+        "sections": ["AllStates", "AllTypes"],
+        "usage": "<Input placeholder=\"Email address\" />"
+      }
     }
   ]
 }

--- a/src/components/input.stories.tsx
+++ b/src/components/input.stories.tsx
@@ -1,0 +1,162 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import { Input } from "./input";
+
+const meta: Meta<typeof Input> = {
+  title: "Components/Input",
+  component: Input,
+  tags: ["autodocs"],
+  argTypes: {
+    type: {
+      control: "select",
+      options: ["text", "email", "password", "number", "tel", "url", "search"],
+    },
+    placeholder: {
+      control: "text",
+    },
+    disabled: {
+      control: "boolean",
+    },
+    readOnly: {
+      control: "boolean",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {
+    placeholder: "Email address",
+  },
+};
+
+export const WithValue: Story = {
+  args: {
+    defaultValue: "john@example.com",
+  },
+};
+
+export const Password: Story = {
+  args: {
+    type: "password",
+    placeholder: "Password",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    placeholder: "Disabled input",
+    disabled: true,
+  },
+};
+
+export const DisabledWithValue: Story = {
+  args: {
+    defaultValue: "Cannot edit this",
+    disabled: true,
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    defaultValue: "Read-only value",
+    readOnly: true,
+  },
+};
+
+export const Invalid: Story = {
+  args: {
+    defaultValue: "invalid@",
+    "aria-invalid": true,
+  },
+};
+
+// Compositions for docs
+export const AllStates = () => (
+  <div className="flex w-64 flex-col gap-4">
+    <Input placeholder="Default" />
+    <Input defaultValue="With value" />
+    <Input placeholder="Disabled" disabled />
+    <Input defaultValue="Read-only" readOnly />
+    <Input defaultValue="Invalid" aria-invalid="true" />
+  </div>
+);
+
+export const AllTypes = () => (
+  <div className="flex w-64 flex-col gap-4">
+    <Input type="text" placeholder="Text" />
+    <Input type="email" placeholder="Email" />
+    <Input type="password" placeholder="Password" />
+    <Input type="number" placeholder="Number" />
+    <Input type="tel" placeholder="Telephone" />
+    <Input type="url" placeholder="URL" />
+    <Input type="search" placeholder="Search" />
+  </div>
+);
+
+// Interaction Tests
+export const TypeTest: Story = {
+  args: {
+    placeholder: "Type here",
+    onChange: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("textbox");
+
+    await userEvent.type(input, "Hello");
+    await expect(input).toHaveValue("Hello");
+    await expect(args.onChange).toHaveBeenCalled();
+  },
+};
+
+export const FocusTest: Story = {
+  args: {
+    placeholder: "Focus me",
+    onFocus: fn(),
+    onBlur: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("textbox");
+
+    await userEvent.click(input);
+    await expect(args.onFocus).toHaveBeenCalledTimes(1);
+
+    await userEvent.tab();
+    await expect(args.onBlur).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const DisabledTest: Story = {
+  args: {
+    placeholder: "Disabled",
+    disabled: true,
+    onChange: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("textbox");
+
+    await expect(input).toBeDisabled();
+    await userEvent.type(input, "test");
+    await expect(input).toHaveValue("");
+    await expect(args.onChange).not.toHaveBeenCalled();
+  },
+};
+
+export const ClearTest: Story = {
+  args: {
+    defaultValue: "Clear me",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("textbox");
+
+    await expect(input).toHaveValue("Clear me");
+    await userEvent.clear(input);
+    await expect(input).toHaveValue("");
+  },
+};

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -1,0 +1,31 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+
+export interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
+  /** Additional CSS classes to apply to the input */
+  className?: string;
+}
+
+export function Input({ className, type = "text", ...props }: Props) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-10 w-full px-3 text-sm",
+        "bg-white text-[var(--ink)]",
+        "border border-[var(--graphite)]",
+        "placeholder:text-[var(--steel)]",
+        "hover:border-[var(--ink)]",
+        "focus:ring-2 focus:ring-[var(--signal-blue)] focus:ring-offset-1 focus:outline-none",
+        "disabled:cursor-not-allowed disabled:border-dashed disabled:border-[var(--chrome)] disabled:bg-[var(--frost)] disabled:text-[var(--steel)]",
+        "aria-[invalid=true]:border-[var(--signal-red)] aria-[invalid=true]:focus:ring-[var(--signal-red)]",
+        "read-only:bg-[var(--frost)] read-only:text-[var(--steel)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Add new Input component with brutalist design following the design system
- Supports text, email, password, number, tel, url, and search input types
- Includes disabled, read-only, and invalid states with appropriate styling

## Test plan
- [ ] Run Storybook and verify all Input stories render correctly
- [ ] Verify interaction tests pass (TypeTest, FocusTest, DisabledTest, ClearTest)
- [ ] Check focus ring accessibility
- [ ] Verify disabled and read-only states prevent input

🤖 Generated with [Claude Code](https://claude.com/claude-code)