### PR TITLE
feat(docs): redesign introduction page with component showcase

### DIFF
--- a/docs/src/components/component-showcase.tsx
+++ b/docs/src/components/component-showcase.tsx
@@ -1,0 +1,60 @@
+import { StoryPreview } from "./story-preview";
+
+interface ComponentData {
+  name: string;
+  docs: {
+    title: string;
+    previewStory: string;
+  };
+}
+
+interface ComponentShowcaseProps {
+  components: ComponentData[];
+}
+
+export function ComponentShowcase({ components }: ComponentShowcaseProps) {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+      {/* Branding Card */}
+      <a
+        href="/ui/installation"
+        className="bg-[var(--paper)] p-4 no-underline transition-colors outline-none hover:bg-[#858585]"
+      >
+        <div className="flex flex-col justify-between">
+          <div>
+            <h1 className="m-0 text-sm font-semibold tracking-wide text-[var(--ink)] uppercase">
+              Beaket UI
+            </h1>
+            <p className="m-0 mt-1 text-xs text-[var(--steel)]">
+              Brutalist React components.
+              <br />
+              Copy to your project.
+            </p>
+          </div>
+          <div className="mt-4 text-xs text-[var(--steel)]">→ Get Started</div>
+        </div>
+      </a>
+
+      {/* Component Cards */}
+      {components.map((component) => (
+        <a
+          key={component.name}
+          href={`/ui/components/${component.name}`}
+          className="bg-[var(--paper)] p-4 no-underline transition-colors outline-none hover:bg-[#858585]"
+        >
+          <div>
+            <div className="mb-2 text-xs font-semibold tracking-wide text-[var(--ink)] uppercase">
+              {component.docs.title}
+            </div>
+            <div className="flex min-h-[60px] items-center">
+              <StoryPreview
+                componentName={component.name}
+                storyName={component.docs.previewStory}
+              />
+            </div>
+          </div>
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -1,17 +1,20 @@
 ---
-import { Code } from 'astro:components';
-import Layout from '../layouts/doc.astro';
+import '../styles/global.css';
+import { ComponentShowcase } from '../components/component-showcase';
+import registry from '../../../registry/registry.json';
 ---
 
-<Layout title="Introduction">
-  <h1>Beaket UI</h1>
-  <p class="tagline">Brutalist React components. Copy to your project.</p>
-
-  <h2>Quick Start</h2>
-  <Code code={`npx @beaket/ui init
-npx @beaket/ui add button`} lang="bash" theme="gruvbox-dark-soft" />
-
-  <p>
-    Browse the <a href="/ui/components">components</a> to get started.
-  </p>
-</Layout>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Beaket UI</title>
+    <link rel="icon" type="image/svg+xml" href="/ui/favicon.svg" />
+  </head>
+  <body class="min-h-screen bg-[var(--paper)]">
+    <main class="mx-auto max-w-4xl p-4">
+      <ComponentShowcase client:load components={registry.components} />
+    </main>
+  </body>
+</html>

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -131,12 +131,15 @@ pre code {
 
 a {
   color: var(--ink);
+  text-decoration: none;
+}
+.main a {
   text-decoration: underline;
 }
-a:hover {
+.main a:hover {
   background: var(--frost);
 }
-a:focus {
+.main a:focus {
   outline: 2px solid var(--ink);
   outline-offset: 2px;
 }

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -15,7 +15,8 @@
         "title": "Button",
         "tagline": "Clickable button with multiple variants and sizes.",
         "sections": ["AllVariants", "AllSizes", "AllStates"],
-        "usage": "<Button>Click me</Button>"
+        "usage": "<Button>Click me</Button>",
+        "previewStory": "AllVariants"
       }
     },
     {
@@ -28,7 +29,8 @@
         "title": "Checkbox",
         "tagline": "A control for boolean input with checked and unchecked states.",
         "sections": ["AllStates"],
-        "usage": "<Checkbox />"
+        "usage": "<Checkbox />",
+        "previewStory": "AllStates"
       }
     },
     {
@@ -41,7 +43,8 @@
         "title": "Badge",
         "tagline": "A compact label for status indicators, categories, and counts.",
         "sections": ["AllVariants"],
-        "usage": "<Badge>Label</Badge>"
+        "usage": "<Badge>Label</Badge>",
+        "previewStory": "AllVariants"
       }
     },
     {
@@ -54,7 +57,8 @@
         "title": "Input",
         "tagline": "A text input field for capturing user data.",
         "sections": ["AllStates", "AllTypes"],
-        "usage": "<Input placeholder=\"Email address\" />"
+        "usage": "<Input placeholder=\"Email address\" />",
+        "previewStory": "AllStates"
       }
     },
     {
@@ -67,7 +71,8 @@
         "title": "Radio",
         "tagline": "A control for selecting one option from a set of choices.",
         "sections": ["AllStates"],
-        "usage": "<RadioGroup defaultValue=\"option1\"><RadioItem value=\"option1\" /><RadioItem value=\"option2\" /></RadioGroup>"
+        "usage": "<RadioGroup defaultValue=\"option1\"><RadioItem value=\"option1\" /><RadioItem value=\"option2\" /></RadioGroup>",
+        "previewStory": "AllStates"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Replace text-heavy introduction with visual component grid
- Add ComponentShowcase component displaying all components with live previews
- Remove sidebar for fullscreen layout on introduction page
- Add previewStory field to registry.json for each component
- WCAG 3:1 contrast ratio for hover states

## Design Decisions
- **Flat, not hierarchical**: Branding card is part of the grid, not above it
- **Dense**: No borders between cards, maximizing component visibility
- **Explicit hover state**: #858585 background for clear interaction feedback

## Test plan
- [ ] Visit introduction page and verify all components render
- [ ] Check hover states are clearly visible
- [ ] Verify clicking cards navigates to component detail pages
- [ ] Test responsive layout (1/2/3 columns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)