### PR TITLE
feat(components): add Table and DataTable components

### DIFF
--- a/.changeset/data-table-component.md
+++ b/.changeset/data-table-component.md
@@ -1,0 +1,10 @@
+---
+"@beaket/ui": minor
+---
+
+Add Table and DataTable components
+
+- Table: Semantic HTML table components (TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell, TableCaption)
+- DataTable: TanStack Table-based component with sorting, filtering, pagination, and row selection
+- Update Button to use design tokens
+- Update CLAUDE.md with library architecture and design philosophy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,65 @@
 # CLAUDE.md - AI Component Development Guidelines
 
+## Library Architecture
+
+This is a **copy-paste component library** (like shadcn/ui). Users copy individual component files into their projects.
+
+### Key Principles
+
+1. **Self-contained components** - Each component file must be standalone
+   - Include `cn` utility in every component file
+   - No shared `lib/utils.ts` or similar
+   - Users copy only the files they need
+
+2. **Dependencies in registry** - List npm packages in `registry.json`
+   - `dependencies`: External packages (e.g., `@radix-ui/react-checkbox`)
+   - `registryDependencies`: Other components from this library (e.g., `button`)
+
+## Design Philosophy (Brutalist)
+
+This library follows a **brutalist design system**:
+
+- **No gradients** - Flat colors only
+- **No shadows** - No box-shadow, drop-shadow
+- **No border-radius** - Sharp rectangular corners (except Radio which is circular by nature)
+- **No decorative elements** - No opacity effects for styling
+- **Use design tokens** - Always use CSS variables from `styles.css`
+
+### Design Tokens
+
+```css
+/* Neutral palette */
+--branch, --graphite, --ink, --paper, --steel, --chrome
+--iron, --slate, --zinc, --aluminum, --silver, --platinum, --frost
+
+/* Signal colors */
+--signal-blue, --signal-red, --signal-green, --signal-amber, --signal-purple, --signal-cyan
+```
+
+### Styling Rules
+
+| Do                        | Don't                                     |
+| ------------------------- | ----------------------------------------- |
+| `bg-[var(--paper)]`       | `bg-white` (except where contrast needed) |
+| `text-[var(--steel)]`     | `opacity-50`                              |
+| `border-[var(--chrome)]`  | `rounded-lg`                              |
+| `hover:bg-[var(--frost)]` | `shadow-md`                               |
+
+## Component Template
+
+Every component file must follow this structure:
+
+```tsx
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+
+export function ComponentName({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="component-name" className={cn("base-styles", className)} {...props} />;
+}
+```
+
 ## Required Items When Creating Components
 
 When creating a new component, you **must** create all of the following:

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-slot": "^1.2.4",
+    "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "2.1.1",
     "lucide-react": "^0.562.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.7)(react@19.2.3)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1459,6 +1462,17 @@ packages:
     resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -5049,6 +5063,14 @@ snapshots:
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
       vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2)
+
+  '@tanstack/react-table@8.21.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -1,6 +1,34 @@
 {
   "components": [
     {
+      "name": "table",
+      "description": "Semantic HTML table components with styled header, body, footer, rows, and cells",
+      "dependencies": ["clsx", "tailwind-merge"],
+      "registryDependencies": [],
+      "files": ["components/table.tsx"],
+      "docs": {
+        "title": "Table",
+        "tagline": "A semantic HTML table with styled components.",
+        "sections": ["AllVariants"],
+        "usage": "<Table><TableHeader><TableRow><TableHead>Column</TableHead></TableRow></TableHeader><TableBody><TableRow><TableCell>Data</TableCell></TableRow></TableBody></Table>",
+        "previewStory": "Default"
+      }
+    },
+    {
+      "name": "data-table",
+      "description": "Data table component built on TanStack Table with sorting, filtering, pagination, and row selection",
+      "dependencies": ["@tanstack/react-table", "clsx", "tailwind-merge", "lucide-react"],
+      "registryDependencies": ["table", "button", "input", "checkbox"],
+      "files": ["components/data-table.tsx"],
+      "docs": {
+        "title": "DataTable",
+        "tagline": "A powerful data table with sorting, filtering, pagination, and selection.",
+        "sections": ["AllFeatures"],
+        "usage": "<DataTable columns={columns} data={data} />",
+        "previewStory": "FullFeatured"
+      }
+    },
+    {
       "name": "button",
       "description": "Button component with variants and sizes",
       "dependencies": [

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -67,9 +67,9 @@ const buttonVariants = cva(
     variants: {
       variant: {
         primary:
-          "bg-[var(--branch)] text-white border border-[var(--branch)] hover:bg-[#2A2D33] hover:border-[#2A2D33] active:bg-[var(--ink)] disabled:text-[var(--steel)] no-underline",
+          "bg-[var(--branch)] text-[var(--paper)] border border-[var(--branch)] hover:bg-[var(--iron)] hover:border-[var(--iron)] active:bg-[var(--ink)] disabled:text-[var(--steel)] no-underline",
         destructive:
-          "bg-[var(--signal-red)] text-white border border-[var(--signal-red)] hover:bg-[#b71c1c] hover:border-[#b71c1c] active:bg-[#9a1919] disabled:text-[var(--steel)] no-underline",
+          "bg-[var(--signal-red)] text-[var(--paper)] border border-[var(--signal-red)] hover:bg-[#b71c1c] hover:border-[#b71c1c] active:bg-[#9a1919] disabled:text-[var(--steel)] no-underline",
         outline:
           "border border-[var(--chrome)] bg-transparent text-[var(--ink)] hover:bg-[var(--frost)] active:bg-[var(--platinum)]",
         secondary:
@@ -77,7 +77,7 @@ const buttonVariants = cva(
         ghost: "text-[var(--ink)] hover:bg-[var(--frost)] active:bg-[var(--platinum)]",
         link: "text-[var(--signal-blue)] underline-offset-4 hover:underline",
         success:
-          "bg-[var(--signal-green)] text-white border border-[var(--signal-green)] hover:bg-[#0f5f42] hover:border-[#0f5f42] active:bg-[#0a4a32] disabled:text-[var(--steel)] no-underline",
+          "bg-[var(--signal-green)] text-[var(--paper)] border border-[var(--signal-green)] hover:bg-[#0f5f42] hover:border-[#0f5f42] active:bg-[#0a4a32] disabled:text-[var(--steel)] no-underline",
         stark:
           "border border-[var(--ink)] bg-transparent text-[var(--ink)] hover:bg-[var(--ink)] hover:text-[var(--paper)] active:bg-[var(--graphite)]",
       },

--- a/src/components/data-table.stories.tsx
+++ b/src/components/data-table.stories.tsx
@@ -1,0 +1,381 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import { Badge } from "./badge";
+import { DataTable, type ColumnDef } from "./data-table";
+
+// Sample data type
+interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+  status: "active" | "inactive" | "pending";
+}
+
+// Sample data
+const users: User[] = [
+  { id: "1", name: "Alice Johnson", email: "alice@example.com", role: "Admin", status: "active" },
+  { id: "2", name: "Bob Smith", email: "bob@example.com", role: "Editor", status: "active" },
+  { id: "3", name: "Carol White", email: "carol@example.com", role: "Viewer", status: "inactive" },
+  { id: "4", name: "David Brown", email: "david@example.com", role: "Editor", status: "pending" },
+  { id: "5", name: "Eve Davis", email: "eve@example.com", role: "Admin", status: "active" },
+];
+
+// Column definitions
+const columns: ColumnDef<User>[] = [
+  {
+    accessorKey: "name",
+    header: "Name",
+    size: 180,
+  },
+  {
+    accessorKey: "email",
+    header: "Email",
+    size: 220,
+  },
+  {
+    accessorKey: "role",
+    header: "Role",
+    size: 120,
+  },
+  {
+    accessorKey: "status",
+    header: "Status",
+    size: 120,
+    cell: ({ row }) => {
+      const status = row.getValue("status") as User["status"];
+      const variants = {
+        active: "default",
+        inactive: "secondary",
+        pending: "outline",
+      } as const;
+      return <Badge variant={variants[status]}>{status}</Badge>;
+    },
+  },
+];
+
+const meta: Meta<typeof DataTable<User, unknown>> = {
+  title: "Components/DataTable",
+  component: DataTable<User, unknown>,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A data table component built on TanStack Table. Features sorting, filtering, pagination, and row selection.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    columns,
+    data: users,
+  },
+};
+
+export const WithSearch: Story = {
+  args: {
+    columns,
+    data: users,
+    searchable: true,
+    searchPlaceholder: "Search users...",
+  },
+};
+
+export const WithPagination: Story = {
+  args: {
+    columns,
+    data: [
+      ...users,
+      ...users.map((u, i) => ({
+        ...u,
+        id: `${u.id}-copy-${i}`,
+        email: `${u.name.toLowerCase().replace(" ", ".")}.${i}@example.com`,
+      })),
+    ],
+    paginated: true,
+    pageSize: 3,
+  },
+};
+
+export const WithSelection: Story = {
+  args: {
+    columns,
+    data: users,
+    selectable: true,
+    onSelectionChange: fn(),
+  },
+};
+
+export const WithRowClick: Story = {
+  args: {
+    columns,
+    data: users,
+    onRowClick: fn((row: User) => {
+      console.log("Row clicked:", row);
+    }),
+  },
+};
+
+export const Compact: Story = {
+  args: {
+    columns,
+    data: users,
+    compact: true,
+  },
+};
+
+export const EmptyState: Story = {
+  args: {
+    columns,
+    data: [],
+    emptyMessage: "No users found.",
+  },
+};
+
+export const FullFeatured: Story = {
+  args: {
+    columns,
+    data: [
+      ...users,
+      ...users.map((u, i) => ({
+        ...u,
+        id: `${u.id}-copy-${i}`,
+        email: `${u.name.toLowerCase().replace(" ", ".")}.${i}@example.com`,
+      })),
+    ],
+    searchable: true,
+    searchPlaceholder: "Search users...",
+    paginated: true,
+    pageSize: 5,
+    selectable: true,
+    onRowClick: fn(),
+    onSelectionChange: fn(),
+  },
+};
+
+// Composition for documentation
+export const AllFeatures = () => (
+  <div className="space-y-8">
+    <div>
+      <h3 className="mb-2 text-sm font-medium">Basic Table</h3>
+      <DataTable columns={columns} data={users.slice(0, 3)} />
+    </div>
+    <div>
+      <h3 className="mb-2 text-sm font-medium">With Search</h3>
+      <DataTable
+        columns={columns}
+        data={users.slice(0, 3)}
+        searchable
+        searchPlaceholder="Search..."
+      />
+    </div>
+    <div>
+      <h3 className="mb-2 text-sm font-medium">With Selection</h3>
+      <DataTable columns={columns} data={users.slice(0, 3)} selectable />
+    </div>
+    <div>
+      <h3 className="mb-2 text-sm font-medium">Compact Mode</h3>
+      <DataTable columns={columns} data={users.slice(0, 3)} compact />
+    </div>
+  </div>
+);
+
+// Interaction tests
+export const SearchTest: Story = {
+  args: {
+    columns,
+    data: users,
+    searchable: true,
+    searchPlaceholder: "Search users...",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Verify search input is present
+    const searchInput = canvas.getByPlaceholderText("Search users...");
+    await expect(searchInput).toBeInTheDocument();
+
+    // Type in search input
+    await userEvent.type(searchInput, "Alice");
+
+    // Verify filtered result (only Alice should be visible)
+    const aliceRow = canvas.getByText("Alice Johnson");
+    await expect(aliceRow).toBeInTheDocument();
+
+    // Clear search
+    await userEvent.clear(searchInput);
+  },
+};
+
+export const SortingTest: Story = {
+  args: {
+    columns,
+    data: users,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Find and click the Name header to sort
+    const nameHeader = canvas.getByText("Name");
+    await userEvent.click(nameHeader);
+
+    // Click again for descending sort
+    await userEvent.click(nameHeader);
+
+    // Click again to clear sort
+    await userEvent.click(nameHeader);
+  },
+};
+
+export const SelectionTest: Story = {
+  args: {
+    columns,
+    data: users.slice(0, 3),
+    selectable: true,
+    onSelectionChange: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Get all checkboxes
+    const checkboxes = canvas.getAllByRole("checkbox");
+    await expect(checkboxes.length).toBe(4); // 1 select-all + 3 rows
+
+    // Click first row checkbox (not select-all)
+    await userEvent.click(checkboxes[1]);
+
+    // Verify onSelectionChange was called
+    await expect(args.onSelectionChange).toHaveBeenCalled();
+
+    // Click select-all checkbox
+    await userEvent.click(checkboxes[0]);
+  },
+};
+
+export const PaginationTest: Story = {
+  args: {
+    columns,
+    data: [
+      ...users,
+      ...users.map((u, i) => ({ ...u, id: `${u.id}-copy-${i}`, email: `copy.${i}@example.com` })),
+    ],
+    paginated: true,
+    pageSize: 3,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Verify pagination info is shown
+    const paginationInfo = canvas.getByText(/Showing 1 to 3 of/);
+    await expect(paginationInfo).toBeInTheDocument();
+
+    // Find and click next page button
+    const nextButton = canvas.getByRole("button", { name: "Next page" });
+    await expect(nextButton).toBeEnabled();
+    await userEvent.click(nextButton);
+
+    // Verify we're on page 2
+    const page2Info = canvas.getByText(/Page 2 of/);
+    await expect(page2Info).toBeInTheDocument();
+
+    // Go back to first page
+    const firstPageButton = canvas.getByRole("button", { name: "First page" });
+    await userEvent.click(firstPageButton);
+  },
+};
+
+export const RowClickTest: Story = {
+  args: {
+    columns,
+    data: users.slice(0, 2),
+    onRowClick: fn(),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Find a row and click it
+    const firstRow = canvas.getByText("Alice Johnson").closest("tr");
+    if (firstRow) {
+      await userEvent.click(firstRow);
+      await expect(args.onRowClick).toHaveBeenCalledTimes(1);
+    }
+  },
+};
+
+// Wide content with text wrapping
+interface Article {
+  id: string;
+  title: string;
+  description: string;
+  author: string;
+  date: string;
+}
+
+const articles: Article[] = [
+  {
+    id: "1",
+    title: "Introduction to React Server Components",
+    description:
+      "React Server Components allow you to render components on the server, reducing the amount of JavaScript sent to the client and improving performance for data-heavy applications.",
+    author: "Alice Johnson",
+    date: "2024-01-15",
+  },
+  {
+    id: "2",
+    title: "Building Accessible Web Applications",
+    description:
+      "Accessibility is not just about compliance—it's about creating inclusive experiences. This guide covers ARIA attributes, keyboard navigation, screen reader support, and semantic HTML best practices.",
+    author: "Bob Smith",
+    date: "2024-01-10",
+  },
+  {
+    id: "3",
+    title: "State Management Patterns in Modern React",
+    description:
+      "From useState to Zustand, exploring different approaches to managing application state. We compare Redux, Context API, Jotai, and other solutions for different use cases.",
+    author: "Carol White",
+    date: "2024-01-05",
+  },
+];
+
+const wideColumns: ColumnDef<Article>[] = [
+  {
+    accessorKey: "title",
+    header: "Title",
+    size: 200,
+  },
+  {
+    accessorKey: "description",
+    header: "Description",
+    size: 400,
+    cell: ({ row }) => <div className="whitespace-normal">{row.getValue("description")}</div>,
+  },
+  {
+    accessorKey: "author",
+    header: "Author",
+    size: 120,
+  },
+  {
+    accessorKey: "date",
+    header: "Date",
+    size: 100,
+  },
+];
+
+export const WithWideContent = {
+  render: () => <DataTable columns={wideColumns} data={articles} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Table with wide content that wraps to multiple lines. Use `whitespace-normal` in cell renderer to allow text wrapping.",
+      },
+    },
+  },
+};

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -1,0 +1,330 @@
+import {
+  flexRender,
+  getCoreRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  getSortedRowModel,
+  useReactTable,
+  type ColumnDef,
+  type ColumnFiltersState,
+  type RowSelectionState,
+  type SortingState,
+  type VisibilityState,
+} from "@tanstack/react-table";
+import { clsx, type ClassValue } from "clsx";
+import {
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+  Search,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import { twMerge } from "tailwind-merge";
+import { Button } from "./button";
+import { Checkbox } from "./checkbox";
+import { Input } from "./input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "./table";
+
+const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+
+export interface DataTableProps<TData, TValue> {
+  /** Column definitions using TanStack Table's ColumnDef */
+  columns: ColumnDef<TData, TValue>[];
+  /** Array of data to display */
+  data: TData[];
+  /** Enable global search/filter functionality */
+  searchable?: boolean;
+  /** Search placeholder text */
+  searchPlaceholder?: string;
+  /** Enable pagination */
+  paginated?: boolean;
+  /** Number of rows per page */
+  pageSize?: number;
+  /** Empty state message */
+  emptyMessage?: string;
+  /** Custom empty state component */
+  emptyState?: React.ReactNode;
+  /** Row click handler */
+  onRowClick?: (row: TData) => void;
+  /** Additional CSS class for the table container */
+  className?: string;
+  /** Enable column sorting (default: true) */
+  enableSorting?: boolean;
+  /** Enable column filtering (default: true) */
+  enableFiltering?: boolean;
+  /** Initial column visibility state */
+  initialColumnVisibility?: VisibilityState;
+  /** Show compact table styling */
+  compact?: boolean;
+  /** Enable row selection with checkboxes */
+  selectable?: boolean;
+  /** Callback when row selection changes */
+  onSelectionChange?: (selectedRows: TData[]) => void;
+  /** Initial row selection state */
+  initialRowSelection?: RowSelectionState;
+  /** Function to generate custom class names for each row based on row data */
+  getRowClassName?: (row: TData) => string;
+  /** Callback when mouse enters a row */
+  onRowMouseEnter?: (row: TData) => void;
+  /** Callback when mouse leaves a row */
+  onRowMouseLeave?: (row: TData) => void;
+}
+
+/**
+ * A data table component built on TanStack Table.
+ * Features sorting, filtering, pagination, and row selection.
+ */
+export function DataTable<TData, TValue>({
+  columns,
+  data,
+  searchable = false,
+  searchPlaceholder = "Search...",
+  paginated = false,
+  pageSize = 10,
+  emptyMessage = "No data available",
+  emptyState,
+  onRowClick,
+  className,
+  enableSorting = true,
+  enableFiltering = true,
+  initialColumnVisibility,
+  compact = false,
+  selectable = false,
+  onSelectionChange,
+  initialRowSelection,
+  getRowClassName,
+  onRowMouseEnter,
+  onRowMouseLeave,
+}: DataTableProps<TData, TValue>) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
+  const [columnVisibility, setColumnVisibility] = useState<VisibilityState>(
+    initialColumnVisibility || {},
+  );
+  const [globalFilter, setGlobalFilter] = useState("");
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>(initialRowSelection || {});
+
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: paginated ? getPaginationRowModel() : undefined,
+    getSortedRowModel: enableSorting ? getSortedRowModel() : undefined,
+    getFilteredRowModel: enableFiltering ? getFilteredRowModel() : undefined,
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onColumnVisibilityChange: setColumnVisibility,
+    onGlobalFilterChange: setGlobalFilter,
+    onRowSelectionChange: setRowSelection,
+    enableRowSelection: selectable,
+    state: {
+      sorting,
+      columnFilters,
+      columnVisibility,
+      globalFilter,
+      rowSelection,
+    },
+    initialState: {
+      pagination: {
+        pageSize,
+      },
+    },
+  });
+
+  useEffect(() => {
+    if (selectable && onSelectionChange) {
+      const selectedRows = table.getFilteredSelectedRowModel().rows.map((row) => row.original);
+      onSelectionChange(selectedRows);
+    }
+  }, [rowSelection, selectable, onSelectionChange, table]);
+
+  return (
+    <div className={className}>
+      {searchable && (
+        <div className="mb-4 flex items-center gap-2">
+          <div className="relative max-w-sm flex-1">
+            <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-[var(--steel)]" />
+            <Input
+              type="search"
+              placeholder={searchPlaceholder}
+              value={globalFilter ?? ""}
+              onChange={(e) => setGlobalFilter(e.target.value)}
+              className="pl-9"
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="overflow-x-auto border border-[var(--chrome)] bg-[var(--paper)]">
+        <Table className="min-w-full">
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {selectable && (
+                  <TableHead className="w-12">
+                    <Checkbox
+                      checked={
+                        table.getIsAllPageRowsSelected() ||
+                        (table.getIsSomePageRowsSelected() && "indeterminate")
+                      }
+                      onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
+                      aria-label="Select all"
+                    />
+                  </TableHead>
+                )}
+                {headerGroup.headers.map((header) => {
+                  const canSort = header.column.getCanSort();
+                  const sortDirection = header.column.getIsSorted();
+
+                  return (
+                    <TableHead
+                      key={header.id}
+                      className={canSort ? "cursor-pointer select-none" : ""}
+                      style={{ width: header.getSize() }}
+                      onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
+                    >
+                      {header.isPlaceholder ? null : (
+                        <div className="flex items-center gap-2">
+                          {flexRender(header.column.columnDef.header, header.getContext())}
+                          {canSort && (
+                            <div className="flex h-4 w-4 items-center justify-center">
+                              {sortDirection === "asc" ? (
+                                <ArrowUp className="h-4 w-4" />
+                              ) : sortDirection === "desc" ? (
+                                <ArrowDown className="h-4 w-4" />
+                              ) : (
+                                <ArrowUpDown className="h-4 w-4 text-[var(--steel)]" />
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </TableHead>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableHeader>
+          <TableBody>
+            {table.getRowModel().rows?.length ? (
+              table.getRowModel().rows.map((row) => (
+                <TableRow
+                  key={row.id}
+                  data-state={row.getIsSelected() && "selected"}
+                  onClick={() => onRowClick?.(row.original)}
+                  onMouseEnter={() => onRowMouseEnter?.(row.original)}
+                  onMouseLeave={() => onRowMouseLeave?.(row.original)}
+                  className={cn(
+                    onRowClick && "cursor-pointer",
+                    compact && "h-10",
+                    getRowClassName?.(row.original),
+                  )}
+                >
+                  {selectable && (
+                    <TableCell
+                      onClick={(e) => e.stopPropagation()}
+                      className={compact ? "py-2" : ""}
+                    >
+                      <Checkbox
+                        checked={row.getIsSelected()}
+                        onCheckedChange={(value) => row.toggleSelected(!!value)}
+                        aria-label="Select row"
+                      />
+                    </TableCell>
+                  )}
+                  {row.getVisibleCells().map((cell) => (
+                    <TableCell
+                      key={cell.id}
+                      className={compact ? "py-2" : ""}
+                      style={{ width: cell.column.getSize() }}
+                    >
+                      {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            ) : (
+              <TableRow>
+                <TableCell
+                  colSpan={columns.length + (selectable ? 1 : 0)}
+                  className="h-64 text-center"
+                >
+                  {emptyState || <div className="text-[var(--steel)]">{emptyMessage}</div>}
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      {paginated && (
+        <div className="mt-4 flex flex-wrap items-center justify-between gap-4">
+          <div className="text-sm text-[var(--steel)]">
+            Showing{" "}
+            {table.getFilteredRowModel().rows.length === 0
+              ? 0
+              : table.getState().pagination.pageIndex * table.getState().pagination.pageSize +
+                1}{" "}
+            to{" "}
+            {Math.min(
+              (table.getState().pagination.pageIndex + 1) * table.getState().pagination.pageSize,
+              table.getFilteredRowModel().rows.length,
+            )}{" "}
+            of {table.getFilteredRowModel().rows.length} results
+            {selectable &&
+              table.getFilteredSelectedRowModel().rows.length > 0 &&
+              ` (${table.getFilteredSelectedRowModel().rows.length} selected)`}
+          </div>
+
+          <div className="flex items-center gap-1">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.setPageIndex(0)}
+              disabled={!table.getCanPreviousPage()}
+              aria-label="First page"
+            >
+              <ChevronsLeft className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.previousPage()}
+              disabled={!table.getCanPreviousPage()}
+              aria-label="Previous page"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="px-4 text-sm">
+              Page {table.getState().pagination.pageIndex + 1} of {table.getPageCount() || 1}
+            </span>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.nextPage()}
+              disabled={!table.getCanNextPage()}
+              aria-label="Next page"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+              disabled={!table.getCanNextPage()}
+              aria-label="Last page"
+            >
+              <ChevronsRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export type { Cell, ColumnDef, Row } from "@tanstack/react-table";

--- a/src/components/table.stories.tsx
+++ b/src/components/table.stories.tsx
@@ -1,0 +1,176 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "./table";
+
+const meta: Meta<typeof Table> = {
+  title: "Components/Table",
+  component: Table,
+  tags: ["autodocs"],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "A semantic HTML table with styled components for header, body, footer, rows, and cells.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Sample data
+const invoices = [
+  { id: "INV001", status: "Paid", method: "Credit Card", amount: "$250.00" },
+  { id: "INV002", status: "Pending", method: "PayPal", amount: "$150.00" },
+  { id: "INV003", status: "Unpaid", method: "Bank Transfer", amount: "$350.00" },
+  { id: "INV004", status: "Paid", method: "Credit Card", amount: "$450.00" },
+  { id: "INV005", status: "Paid", method: "PayPal", amount: "$550.00" },
+];
+
+export const Default: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Method</TableHead>
+          <TableHead className="text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.map((invoice) => (
+          <TableRow key={invoice.id}>
+            <TableCell className="font-medium">{invoice.id}</TableCell>
+            <TableCell>{invoice.status}</TableCell>
+            <TableCell>{invoice.method}</TableCell>
+            <TableCell className="text-right">{invoice.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+};
+
+export const WithCaption: Story = {
+  render: () => (
+    <Table>
+      <TableCaption>A list of recent invoices.</TableCaption>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Method</TableHead>
+          <TableHead className="text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.slice(0, 3).map((invoice) => (
+          <TableRow key={invoice.id}>
+            <TableCell className="font-medium">{invoice.id}</TableCell>
+            <TableCell>{invoice.status}</TableCell>
+            <TableCell>{invoice.method}</TableCell>
+            <TableCell className="text-right">{invoice.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+};
+
+export const WithFooter: Story = {
+  render: () => (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Method</TableHead>
+          <TableHead className="text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.map((invoice) => (
+          <TableRow key={invoice.id}>
+            <TableCell className="font-medium">{invoice.id}</TableCell>
+            <TableCell>{invoice.status}</TableCell>
+            <TableCell>{invoice.method}</TableCell>
+            <TableCell className="text-right">{invoice.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+      <TableFooter>
+        <TableRow>
+          <TableCell colSpan={3}>Total</TableCell>
+          <TableCell className="text-right">$1,750.00</TableCell>
+        </TableRow>
+      </TableFooter>
+    </Table>
+  ),
+};
+
+// Composition for documentation
+export const AllVariants = () => (
+  <div className="space-y-8">
+    <div>
+      <h3 className="mb-2 text-sm font-medium">Basic Table</h3>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Name</TableHead>
+            <TableHead>Role</TableHead>
+            <TableHead className="text-right">Salary</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>Alice</TableCell>
+            <TableCell>Developer</TableCell>
+            <TableCell className="text-right">$120,000</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Bob</TableCell>
+            <TableCell>Designer</TableCell>
+            <TableCell className="text-right">$100,000</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+    <div>
+      <h3 className="mb-2 text-sm font-medium">With Footer</h3>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Item</TableHead>
+            <TableHead className="text-right">Price</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell>Product A</TableCell>
+            <TableCell className="text-right">$50.00</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Product B</TableCell>
+            <TableCell className="text-right">$75.00</TableCell>
+          </TableRow>
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell>Total</TableCell>
+            <TableCell className="text-right">$125.00</TableCell>
+          </TableRow>
+        </TableFooter>
+      </Table>
+    </div>
+  </div>
+);

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -1,0 +1,99 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+
+export function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <table
+      data-slot="table"
+      className={cn("w-full caption-bottom text-sm tabular-nums", className)}
+      {...props}
+    />
+  );
+}
+
+export function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn(
+        "[&_tr]:border-b [&_tr]:border-[var(--chrome)] [&_tr]:bg-[var(--frost)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  );
+}
+
+export function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t border-[var(--chrome)] bg-[var(--frost)] font-medium [&>tr]:last:border-b-0",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b border-[var(--chrome)] bg-white hover:bg-[var(--frost)] data-[state=selected]:bg-[var(--platinum)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-9 px-2 py-1.5 text-left align-middle font-semibold whitespace-nowrap text-[var(--ink)] [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "px-2 py-1.5 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function TableCaption({ className, ...props }: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-[var(--steel)]", className)}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- Add **Table** component with semantic HTML table sub-components (TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell, TableCaption)
- Add **DataTable** component built on TanStack Table with sorting, filtering, pagination, row selection, and compact mode
- Update **Button** component to use design tokens (`--iron`, `--paper`) instead of hardcoded colors
- Update **CLAUDE.md** with library architecture (copy-paste, self-contained components) and brutalist design philosophy

## Test plan

- [ ] Run `pnpm storybook` and verify Table stories render correctly
- [ ] Run `pnpm storybook` and verify DataTable stories render correctly
- [ ] Test DataTable sorting by clicking column headers
- [ ] Test DataTable search functionality
- [ ] Test DataTable pagination navigation
- [ ] Test DataTable row selection with checkboxes
- [ ] Run `pnpm tsc --noEmit` to verify no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)