### PR TITLE
feat(components): add Dialog component

### DIFF
--- a/.changeset/dialog-component.md
+++ b/.changeset/dialog-component.md
@@ -1,0 +1,5 @@
+---
+"ui": minor
+---
+
+Add Dialog component with compound pattern, controlled/uncontrolled modes, and Storybook tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,70 @@ export function ComponentName({ className, ...props }: React.ComponentProps<"div
 }
 ```
 
+### Compound Components
+
+For complex components with sub-components, use the **compound pattern**:
+
+```tsx
+// Main component (exported)
+export function Dialog({ children }: Props) {
+  return <DialogPrimitive.Root>{children}</DialogPrimitive.Root>;
+}
+
+// Sub-components (not exported individually)
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return <DialogPrimitive.Title className={cn("...", className)} {...props} />;
+}
+
+function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("...", className)} {...props} />;
+}
+
+// Attach sub-components to main component
+Dialog.Title = DialogTitle;
+Dialog.Footer = DialogFooter;
+```
+
+**Why compound-only (no individual exports)?**
+
+- **Semantic coupling**: `Dialog.Title` only makes sense inside `<Dialog>` - compound pattern signals this relationship
+- **Discoverability**: Type `Dialog.` and autocomplete shows all sub-components
+- **Encapsulation**: Not exporting sub-components signals they shouldn't be used outside their parent
+- **Namespace clarity**: `Dialog.Title` clearly shows hierarchy, avoids collision with other `Title` components
+
+### Controlled/Uncontrolled Pattern
+
+For components supporting both modes:
+
+```tsx
+export function Dialog({ open, onOpenChange, children }: Props) {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const isControlled = open !== undefined;
+
+  // Dev warning for incomplete controlled usage
+  if (process.env.NODE_ENV !== "production") {
+    if (isControlled && !onOpenChange) {
+      console.warn("Dialog: `open` provided without `onOpenChange`.");
+    }
+  }
+
+  const dialogOpen = isControlled ? open : internalOpen;
+  const dialogOnOpenChange = useCallback(
+    (value: boolean) => {
+      onOpenChange?.(value);
+      if (!isControlled) setInternalOpen(value);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  return (
+    <Root open={dialogOpen} onOpenChange={dialogOnOpenChange}>
+      {children}
+    </Root>
+  );
+}
+```
+
 ## Required Items When Creating Components
 
 When creating a new component, you **must** create all of the following:
@@ -114,6 +178,36 @@ export const ClickTest: Story = {
   },
 };
 ```
+
+#### Testing Portal-Based Components
+
+For components using portals (Dialog, Popover, etc.), content renders outside `canvasElement`. Use `screen` instead:
+
+```tsx
+import { expect, screen, userEvent, within } from "storybook/test";
+
+export const DialogTest: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Trigger is in canvas
+    await userEvent.click(canvas.getByRole("button", { name: "Open" }));
+
+    // Dialog content is in portal - use screen
+    const dialog = await screen.findByRole("dialog");
+    await expect(dialog).toBeInTheDocument();
+
+    // Query within the dialog
+    const closeBtn = within(dialog).getByRole("button", { name: "Close" });
+    await userEvent.click(closeBtn);
+
+    // Verify closed
+    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  },
+};
+```
+
+**Important:** Don't use mock `fn()` for `onOpenChange` props - it prevents internal state updates and the component won't actually open/close.
 
 ### 3. Registry Registration
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "echo 'TODO: Add ESLint'",
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit && pnpm -r typecheck",
+    "test": "vitest",
     "build-storybook": "storybook build",
     "release": "changeset publish",
     "prepare": "husky"
@@ -53,6 +54,7 @@
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-table": "^8.21.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-radio-group':
         specifier: ^1.3.8
         version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -987,6 +990,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
@@ -996,6 +1012,41 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
@@ -1003,6 +1054,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-presence@1.1.5':
@@ -1095,6 +1159,15 @@ packages:
 
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1731,6 +1804,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -2004,6 +2081,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   deterministic-object-hash@2.0.2:
     resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
     engines: {node: '>=18'}
@@ -2226,6 +2306,10 @@ packages:
   get-east-asian-width@1.4.0:
     resolution: {integrity: sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q==}
     engines: {node: '>=18'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
@@ -3026,6 +3110,36 @@ packages:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
@@ -3503,6 +3617,26 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
@@ -4646,11 +4780,63 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.3)
+      aria-hidden: 1.2.6
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-direction@1.1.1(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
   '@radix-ui/react-id@1.1.1(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
@@ -4658,6 +4844,16 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
   '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -4744,6 +4940,13 @@ snapshots:
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
@@ -5422,6 +5625,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -5738,6 +5945,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  detect-node-es@1.1.0: {}
+
   deterministic-object-hash@2.0.2:
     dependencies:
       base-64: 1.0.0
@@ -5985,6 +6194,8 @@ snapshots:
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.4.0: {}
+
+  get-nonce@1.0.1: {}
 
   get-tsconfig@4.13.0:
     dependencies:
@@ -6886,6 +7097,33 @@ snapshots:
 
   react-refresh@0.18.0: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.7)(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-style-singleton: 2.2.3(@types/react@19.2.7)(react@19.2.3)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  react-remove-scroll@2.7.2(@types/react@19.2.7)(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.7)(react@19.2.3)
+      react-style-singleton: 2.2.3(@types/react@19.2.7)(react@19.2.3)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.7)(react@19.2.3)
+      use-sidecar: 1.1.3(@types/react@19.2.7)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  react-style-singleton@2.2.3(@types/react@19.2.7)(react@19.2.3):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.3
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   react@19.2.3: {}
 
   read-yaml-file@1.1.0:
@@ -7408,6 +7646,21 @@ snapshots:
       browserslist: 4.28.1
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  use-callback-ref@1.3.3(@types/react@19.2.7)(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  use-sidecar@1.1.3(@types/react@19.2.7)(react@19.2.3):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.3
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.7
 
   use-sync-external-store@1.6.0(react@19.2.3):
     dependencies:

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -1,6 +1,20 @@
 {
   "components": [
     {
+      "name": "dialog",
+      "description": "Modal dialog component for confirmations, forms, and alerts",
+      "dependencies": ["@radix-ui/react-dialog", "clsx", "lucide-react", "tailwind-merge"],
+      "registryDependencies": ["button"],
+      "files": ["components/dialog.tsx"],
+      "docs": {
+        "title": "Dialog",
+        "tagline": "A modal dialog for confirmations, forms, and alerts.",
+        "sections": ["AllStates"],
+        "usage": "<Dialog trigger={<Button>Open</Button>}><Dialog.Header><Dialog.Title>Title</Dialog.Title></Dialog.Header></Dialog>",
+        "previewStory": "Default"
+      }
+    },
+    {
       "name": "table",
       "description": "Semantic HTML table components with styled header, body, footer, rows, and cells",
       "dependencies": ["clsx", "tailwind-merge"],

--- a/src/components/dialog.stories.tsx
+++ b/src/components/dialog.stories.tsx
@@ -1,0 +1,426 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import { expect, screen, userEvent, within } from "storybook/test";
+import { Button } from "./button";
+import { Dialog } from "./dialog";
+
+const meta: Meta<typeof Dialog> = {
+  title: "Components/Dialog",
+  component: Dialog,
+  tags: ["autodocs"],
+  argTypes: {
+    preventClose: {
+      control: "boolean",
+      description: "Prevents closing via ESC or clicking outside",
+    },
+    hideCloseButton: {
+      control: "boolean",
+      description: "Hides the X close button",
+    },
+    open: {
+      control: "boolean",
+      description: "Controlled open state",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Dialog>;
+
+export const Default: Story = {
+  args: {
+    trigger: <Button>Open Dialog</Button>,
+    children: (
+      <>
+        <Dialog.Header>
+          <Dialog.Title>Dialog Title</Dialog.Title>
+          <Dialog.Description>
+            This is a dialog description that provides additional context.
+          </Dialog.Description>
+        </Dialog.Header>
+        <p className="text-sm text-[var(--graphite)]">
+          Dialog content goes here. You can put any content inside.
+        </p>
+        <Dialog.Footer>
+          <Dialog.Close>
+            <Button variant="outline">Cancel</Button>
+          </Dialog.Close>
+          <Button>Confirm</Button>
+        </Dialog.Footer>
+      </>
+    ),
+  },
+};
+
+export const PreventClose: Story = {
+  args: {
+    preventClose: true,
+    trigger: <Button>Open (Cannot dismiss by clicking outside)</Button>,
+    children: (
+      <>
+        <Dialog.Header>
+          <Dialog.Title>Important Action</Dialog.Title>
+          <Dialog.Description>
+            This dialog cannot be dismissed by pressing ESC or clicking outside.
+          </Dialog.Description>
+        </Dialog.Header>
+        <Dialog.Footer>
+          <Dialog.Close>
+            <Button variant="outline">Cancel</Button>
+          </Dialog.Close>
+          <Button variant="destructive">Delete</Button>
+        </Dialog.Footer>
+      </>
+    ),
+  },
+};
+
+export const HideCloseButton: Story = {
+  args: {
+    hideCloseButton: true,
+    preventClose: true,
+    trigger: <Button>Open (No X button)</Button>,
+    children: (
+      <>
+        <Dialog.Header>
+          <Dialog.Title>Action Required</Dialog.Title>
+          <Dialog.Description>
+            This dialog has no X button. You must use the action buttons below.
+          </Dialog.Description>
+        </Dialog.Header>
+        <Dialog.Footer>
+          <Dialog.Close>
+            <Button variant="outline">Cancel</Button>
+          </Dialog.Close>
+          <Dialog.Close>
+            <Button>Confirm</Button>
+          </Dialog.Close>
+        </Dialog.Footer>
+      </>
+    ),
+  },
+};
+
+export const WithForm: Story = {
+  args: {
+    trigger: <Button>Edit Profile</Button>,
+    children: (
+      <>
+        <Dialog.Header>
+          <Dialog.Title>Edit Profile</Dialog.Title>
+          <Dialog.Description>
+            Make changes to your profile here. Click save when you're done.
+          </Dialog.Description>
+        </Dialog.Header>
+        <div className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <label htmlFor="name" className="text-sm font-medium text-[var(--ink)]">
+              Name
+            </label>
+            <input
+              id="name"
+              defaultValue="John Doe"
+              className="h-9 border border-[var(--chrome)] bg-[var(--paper)] px-3 text-sm text-[var(--ink)] placeholder:text-[var(--steel)] focus:ring-2 focus:ring-[var(--signal-blue)] focus:outline-none"
+            />
+          </div>
+          <div className="grid gap-2">
+            <label htmlFor="email" className="text-sm font-medium text-[var(--ink)]">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              defaultValue="john@example.com"
+              className="h-9 border border-[var(--chrome)] bg-[var(--paper)] px-3 text-sm text-[var(--ink)] placeholder:text-[var(--steel)] focus:ring-2 focus:ring-[var(--signal-blue)] focus:outline-none"
+            />
+          </div>
+        </div>
+        <Dialog.Footer>
+          <Dialog.Close>
+            <Button variant="outline">Cancel</Button>
+          </Dialog.Close>
+          <Button>Save changes</Button>
+        </Dialog.Footer>
+      </>
+    ),
+  },
+};
+
+export const Destructive: Story = {
+  args: {
+    trigger: <Button variant="destructive">Delete Account</Button>,
+    children: (
+      <>
+        <Dialog.Header>
+          <Dialog.Title>Are you sure?</Dialog.Title>
+          <Dialog.Description>
+            This action cannot be undone. This will permanently delete your account and remove your
+            data from our servers.
+          </Dialog.Description>
+        </Dialog.Header>
+        <Dialog.Footer>
+          <Dialog.Close>
+            <Button variant="outline">Cancel</Button>
+          </Dialog.Close>
+          <Button variant="destructive">Delete Account</Button>
+        </Dialog.Footer>
+      </>
+    ),
+  },
+};
+
+function ControlledDialogExample() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex gap-2">
+        <Button onClick={() => setOpen(true)}>Open Dialog</Button>
+        <span className="self-center text-sm text-[var(--steel)]">
+          Dialog is {open ? "open" : "closed"}
+        </span>
+      </div>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <Dialog.Header>
+          <Dialog.Title>Controlled Dialog</Dialog.Title>
+          <Dialog.Description>This dialog's state is controlled externally.</Dialog.Description>
+        </Dialog.Header>
+        <Dialog.Footer>
+          <Button variant="outline" onClick={() => setOpen(false)}>
+            Close
+          </Button>
+        </Dialog.Footer>
+      </Dialog>
+    </div>
+  );
+}
+
+export const Controlled: Story = {
+  render: () => <ControlledDialogExample />,
+};
+
+export const AllStates = () => (
+  <div className="flex flex-wrap gap-4">
+    <Dialog trigger={<Button>Default</Button>}>
+      <Dialog.Header>
+        <Dialog.Title>Default Dialog</Dialog.Title>
+        <Dialog.Description>A standard dialog with title and description.</Dialog.Description>
+      </Dialog.Header>
+      <Dialog.Footer>
+        <Dialog.Close>
+          <Button variant="outline">Close</Button>
+        </Dialog.Close>
+      </Dialog.Footer>
+    </Dialog>
+
+    <Dialog trigger={<Button variant="outline">With Form</Button>}>
+      <Dialog.Header>
+        <Dialog.Title>Form Dialog</Dialog.Title>
+        <Dialog.Description>Dialog containing a form.</Dialog.Description>
+      </Dialog.Header>
+      <div className="py-4">
+        <input
+          placeholder="Enter something..."
+          className="h-9 w-full border border-[var(--chrome)] bg-[var(--paper)] px-3 text-sm"
+        />
+      </div>
+      <Dialog.Footer>
+        <Dialog.Close>
+          <Button variant="outline">Cancel</Button>
+        </Dialog.Close>
+        <Button>Submit</Button>
+      </Dialog.Footer>
+    </Dialog>
+
+    <Dialog preventClose trigger={<Button variant="stark">Prevent Close</Button>}>
+      <Dialog.Header>
+        <Dialog.Title>Cannot Dismiss</Dialog.Title>
+        <Dialog.Description>Must use buttons to close.</Dialog.Description>
+      </Dialog.Header>
+      <Dialog.Footer>
+        <Dialog.Close>
+          <Button>Got it</Button>
+        </Dialog.Close>
+      </Dialog.Footer>
+    </Dialog>
+
+    <Dialog trigger={<Button variant="destructive">Destructive</Button>}>
+      <Dialog.Header>
+        <Dialog.Title>Confirm Deletion</Dialog.Title>
+        <Dialog.Description>This action is irreversible.</Dialog.Description>
+      </Dialog.Header>
+      <Dialog.Footer>
+        <Dialog.Close>
+          <Button variant="outline">Cancel</Button>
+        </Dialog.Close>
+        <Dialog.Close>
+          <Button variant="destructive">Delete</Button>
+        </Dialog.Close>
+      </Dialog.Footer>
+    </Dialog>
+
+    <Dialog hideCloseButton preventClose trigger={<Button variant="secondary">No X Button</Button>}>
+      <Dialog.Header>
+        <Dialog.Title>Action Required</Dialog.Title>
+        <Dialog.Description>No X button, must use actions.</Dialog.Description>
+      </Dialog.Header>
+      <Dialog.Footer>
+        <Dialog.Close>
+          <Button>Acknowledge</Button>
+        </Dialog.Close>
+      </Dialog.Footer>
+    </Dialog>
+  </div>
+);
+
+// Interaction Tests
+export const OpenCloseTest: Story = {
+  args: {
+    trigger: <Button>Open Dialog</Button>,
+    children: (
+      <>
+        <Dialog.Header>
+          <Dialog.Title>Test Dialog</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Footer>
+          <Dialog.Close>
+            <Button variant="outline">Close</Button>
+          </Dialog.Close>
+        </Dialog.Footer>
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open dialog
+    const trigger = canvas.getByRole("button", { name: "Open Dialog" });
+    await userEvent.click(trigger);
+
+    // Wait for dialog to be visible
+    const dialogElement = await screen.findByRole("dialog");
+    await expect(dialogElement).toBeInTheDocument();
+
+    // Close dialog via close button
+    const closeButton = within(dialogElement).getByRole("button", { name: "Close" });
+    await userEvent.click(closeButton);
+
+    // Verify dialog is closed
+    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  },
+};
+
+export const CloseViaXButtonTest: Story = {
+  args: {
+    trigger: <Button>Open Dialog</Button>,
+    children: (
+      <>
+        <Dialog.Header>
+          <Dialog.Title>Test Dialog</Dialog.Title>
+        </Dialog.Header>
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open dialog
+    const trigger = canvas.getByRole("button", { name: "Open Dialog" });
+    await userEvent.click(trigger);
+
+    // Wait for dialog to be visible
+    const dialogElement = await screen.findByRole("dialog");
+    await expect(dialogElement).toBeInTheDocument();
+
+    // Close via X button
+    const xButton = within(dialogElement).getByRole("button", { name: "Close dialog" });
+    await userEvent.click(xButton);
+
+    // Verify dialog is closed
+    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  },
+};
+
+export const PreventCloseTest: Story = {
+  args: {
+    preventClose: true,
+    trigger: <Button>Open Dialog</Button>,
+    children: (
+      <>
+        <Dialog.Header>
+          <Dialog.Title>Cannot dismiss by escape</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Footer>
+          <Dialog.Close>
+            <Button>Close via button</Button>
+          </Dialog.Close>
+        </Dialog.Footer>
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open dialog
+    const trigger = canvas.getByRole("button", { name: "Open Dialog" });
+    await userEvent.click(trigger);
+
+    // Wait for dialog to be visible
+    const dialogElement = await screen.findByRole("dialog");
+    await expect(dialogElement).toBeInTheDocument();
+
+    // Try to close with Escape - should not close due to preventClose
+    await userEvent.keyboard("{Escape}");
+
+    // Dialog should still be visible
+    await expect(screen.queryByRole("dialog")).toBeInTheDocument();
+
+    // Close via button - should work
+    const closeButton = within(dialogElement).getByRole("button", { name: "Close via button" });
+    await userEvent.click(closeButton);
+
+    // Verify dialog is closed
+    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  },
+};
+
+export const HideCloseButtonTest: Story = {
+  args: {
+    hideCloseButton: true,
+    trigger: <Button>Open Dialog</Button>,
+    children: (
+      <>
+        <Dialog.Header>
+          <Dialog.Title>No X Button</Dialog.Title>
+        </Dialog.Header>
+        <Dialog.Footer>
+          <Dialog.Close>
+            <Button>Close</Button>
+          </Dialog.Close>
+        </Dialog.Footer>
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open dialog
+    const trigger = canvas.getByRole("button", { name: "Open Dialog" });
+    await userEvent.click(trigger);
+
+    // Wait for dialog to be visible
+    const dialogElement = await screen.findByRole("dialog");
+    await expect(dialogElement).toBeInTheDocument();
+
+    // Verify X button does not exist
+    const xButton = within(dialogElement).queryByRole("button", { name: "Close dialog" });
+    await expect(xButton).not.toBeInTheDocument();
+
+    // Close via action button - should work
+    const closeButton = within(dialogElement).getByRole("button", { name: "Close" });
+    await userEvent.click(closeButton);
+
+    // Verify dialog is closed
+    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  },
+};

--- a/src/components/dialog.tsx
+++ b/src/components/dialog.tsx
@@ -1,0 +1,179 @@
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { type ClassValue, clsx } from "clsx";
+import { X } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { twMerge } from "tailwind-merge";
+
+const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+
+interface Props {
+  /**
+   * When true, prevents closing the dialog via ESC key or clicking outside.
+   * Users must use the close button or action buttons to dismiss the dialog.
+   */
+  preventClose?: boolean;
+
+  /**
+   * When true, hides the X close button in the top-right corner.
+   * Useful with preventClose when you want users to use only action buttons.
+   */
+  hideCloseButton?: boolean;
+
+  /**
+   * Element that opens the dialog when clicked.
+   * Can be any clickable element like Button, link, or custom trigger.
+   * Optional - if not provided, dialog must be controlled via open/onOpenChange props.
+   */
+  trigger?: React.ReactNode;
+
+  /**
+   * Dialog content including Header, Description, Footer, and custom elements
+   */
+  children?: React.ReactNode;
+
+  /**
+   * Controlled open state of the dialog.
+   * When provided, you must also provide onOpenChange to handle state updates.
+   */
+  open?: boolean;
+
+  /**
+   * Callback when the open state changes.
+   * Required when using controlled mode (open prop).
+   */
+  onOpenChange?: (open: boolean) => void;
+
+  /**
+   * When this value becomes truthy, automatically close the dialog.
+   * Useful for closing dialog after successful form submission via React Router action.
+   */
+  closeWhen?: unknown;
+}
+
+export function Dialog({
+  children,
+  trigger,
+  preventClose = false,
+  hideCloseButton = false,
+  open,
+  onOpenChange,
+  closeWhen,
+}: Props) {
+  const [internalOpen, setInternalOpen] = useState(false);
+
+  const isControlled = open !== undefined;
+
+  // Warn in dev mode if controlled without onOpenChange
+  if (process.env.NODE_ENV !== "production") {
+    if (isControlled && !onOpenChange) {
+      console.warn(
+        "Dialog: `open` prop provided without `onOpenChange`. The dialog will be read-only.",
+      );
+    }
+  }
+
+  const dialogOpen = isControlled ? open : internalOpen;
+  const dialogOnOpenChange = useCallback(
+    (value: boolean) => {
+      if (onOpenChange) {
+        onOpenChange(value);
+      }
+      if (!isControlled) {
+        setInternalOpen(value);
+      }
+    },
+    [isControlled, onOpenChange],
+  );
+
+  // Auto-close when closeWhen becomes truthy
+  useEffect(() => {
+    if (closeWhen) {
+      dialogOnOpenChange(false);
+    }
+  }, [closeWhen, dialogOnOpenChange]);
+
+  return (
+    <DialogPrimitive.Root open={dialogOpen} onOpenChange={dialogOnOpenChange}>
+      {trigger && <DialogPrimitive.Trigger asChild>{trigger}</DialogPrimitive.Trigger>}
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          data-slot="dialog-overlay"
+          className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-40 bg-[var(--ink)]/50"
+        />
+        <DialogPrimitive.Content
+          data-slot="dialog-content"
+          className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 border border-[var(--chrome)] bg-[var(--paper)] p-6 sm:max-w-lg"
+          onInteractOutside={preventClose ? (e) => e.preventDefault() : undefined}
+          onEscapeKeyDown={preventClose ? (e) => e.preventDefault() : undefined}
+        >
+          {children}
+          {!hideCloseButton && (
+            <DialogPrimitive.Close
+              data-slot="dialog-close"
+              className="absolute top-4 right-4 text-[var(--steel)] transition-colors hover:text-[var(--ink)] focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--signal-blue)] disabled:pointer-events-none"
+              aria-label="Close dialog"
+            >
+              <X className="size-4" aria-hidden="true" />
+            </DialogPrimitive.Close>
+          )}
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-xl leading-7 font-semibold text-[var(--ink)]", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-sm text-[var(--steel)]", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-left", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn("mt-4 flex items-center justify-end gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+function DialogClose({
+  asChild = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close-action" {...props} asChild={asChild} />;
+}
+
+Dialog.Title = DialogTitle;
+Dialog.Description = DialogDescription;
+Dialog.Header = DialogHeader;
+Dialog.Footer = DialogFooter;
+Dialog.Close = DialogClose;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,30 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { storybookTest } from "@storybook/addon-vitest/vitest-plugin";
+import { playwright } from "@vitest/browser-playwright";
+import { defineConfig } from "vitest/config";
+
+const dirname =
+  typeof __dirname !== "undefined" ? __dirname : path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  test: {
+    projects: [
+      {
+        extends: true,
+        plugins: [storybookTest({ configDir: path.join(dirname, ".storybook") })],
+        test: {
+          name: "storybook",
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright({}),
+            instances: [{ browser: "chromium" }],
+          },
+          setupFiles: [".storybook/vitest.setup.ts"],
+        },
+      },
+    ],
+  },
+});


### PR DESCRIPTION
## Summary

- Add Dialog component built on Radix UI Dialog primitive
- Compound component pattern (`Dialog.Title`, `Dialog.Header`, `Dialog.Footer`, `Dialog.Description`, `Dialog.Close`)
- Support both controlled and uncontrolled modes with dev warnings
- Props: `preventClose`, `hideCloseButton`, `closeWhen` for auto-closing
- Brutalist styling with design tokens
- Add Vitest config for running Storybook interaction tests
- Update CLAUDE.md with compound component and portal testing patterns

## Test plan

- [x] All 86 Storybook interaction tests pass
- [x] Type check passes
- [ ] Visual review in Storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)