### PR TITLE
feat(components): add DropdownMenu component

### DIFF
--- a/.changeset/dropdown-menu-component.md
+++ b/.changeset/dropdown-menu-component.md
@@ -1,0 +1,5 @@
+---
+"ui": minor
+---
+
+Add DropdownMenu component with compound pattern, checkbox/radio items, submenus, and keyboard shortcuts support

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@tanstack/react-table": "^8.21.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-radio-group':
         specifier: ^1.3.8
         version: 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -727,6 +730,21 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@floating-ui/core@1.7.3':
+    resolution: {integrity: sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==}
+
+  '@floating-ui/dom@1.7.4':
+    resolution: {integrity: sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==}
+
+  '@floating-ui/react-dom@2.1.6':
+    resolution: {integrity: sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.10':
+    resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
+
   '@img/colour@1.0.0':
     resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
     engines: {node: '>=18'}
@@ -946,6 +964,19 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-checkbox@1.3.3':
     resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
     peerDependencies:
@@ -1025,6 +1056,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -1054,6 +1098,32 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-portal@1.1.9':
@@ -1193,6 +1263,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-size@1.1.1':
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
     peerDependencies:
@@ -1201,6 +1280,9 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -4552,6 +4634,23 @@ snapshots:
   '@esbuild/win32-x64@0.27.2':
     optional: true
 
+  '@floating-ui/core@1.7.3':
+    dependencies:
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/dom@1.7.4':
+    dependencies:
+      '@floating-ui/core': 1.7.3
+      '@floating-ui/utils': 0.2.10
+
+  '@floating-ui/react-dom@2.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@floating-ui/dom': 1.7.4
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  '@floating-ui/utils@0.2.10': {}
+
   '@img/colour@1.0.0':
     optional: true
 
@@ -4740,6 +4839,15 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -4821,6 +4929,21 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       react: 19.2.3
@@ -4844,6 +4967,50 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      aria-hidden: 1.2.6
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
@@ -4963,12 +5130,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.7
 
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
   '@radix-ui/react-use-size@1.1.1(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
     optionalDependencies:
       '@types/react': 19.2.7
+
+  '@radix-ui/rect@1.1.1': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -1,6 +1,20 @@
 {
   "components": [
     {
+      "name": "dropdown-menu",
+      "description": "Dropdown menu component for actions, navigation, and selection",
+      "dependencies": ["@radix-ui/react-dropdown-menu", "clsx", "lucide-react", "tailwind-merge"],
+      "registryDependencies": [],
+      "files": ["components/dropdown-menu.tsx"],
+      "docs": {
+        "title": "DropdownMenu",
+        "tagline": "A menu of actions or options triggered by a button.",
+        "sections": ["AllStates"],
+        "usage": "<DropdownMenu><DropdownMenu.Trigger asChild><Button>Open</Button></DropdownMenu.Trigger><DropdownMenu.Content><DropdownMenu.Item>Action</DropdownMenu.Item></DropdownMenu.Content></DropdownMenu>",
+        "previewStory": "Default"
+      }
+    },
+    {
       "name": "dialog",
       "description": "Modal dialog component for confirmations, forms, and alerts",
       "dependencies": ["@radix-ui/react-dialog", "clsx", "lucide-react", "tailwind-merge"],

--- a/src/components/dropdown-menu.stories.tsx
+++ b/src/components/dropdown-menu.stories.tsx
@@ -1,0 +1,561 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import {
+  Cloud,
+  CreditCard,
+  Github,
+  Keyboard,
+  LifeBuoy,
+  LogOut,
+  Mail,
+  MessageSquare,
+  Plus,
+  PlusCircle,
+  Settings,
+  User,
+  UserPlus,
+  Users,
+} from "lucide-react";
+import { useState } from "react";
+import { expect, screen, userEvent, within } from "storybook/test";
+import { Button } from "./button";
+import { DropdownMenu } from "./dropdown-menu";
+
+const meta: Meta<typeof DropdownMenu> = {
+  title: "Components/DropdownMenu",
+  component: DropdownMenu,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof DropdownMenu>;
+
+export const Default: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button variant="outline">Open Menu</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Label>My Account</DropdownMenu.Label>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item>
+          <User className="size-4" />
+          Profile
+          <DropdownMenu.Shortcut>⇧⌘P</DropdownMenu.Shortcut>
+        </DropdownMenu.Item>
+        <DropdownMenu.Item>
+          <CreditCard className="size-4" />
+          Billing
+          <DropdownMenu.Shortcut>⌘B</DropdownMenu.Shortcut>
+        </DropdownMenu.Item>
+        <DropdownMenu.Item>
+          <Settings className="size-4" />
+          Settings
+          <DropdownMenu.Shortcut>⌘S</DropdownMenu.Shortcut>
+        </DropdownMenu.Item>
+        <DropdownMenu.Item>
+          <Keyboard className="size-4" />
+          Keyboard shortcuts
+          <DropdownMenu.Shortcut>⌘K</DropdownMenu.Shortcut>
+        </DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item>
+          <LogOut className="size-4" />
+          Log out
+          <DropdownMenu.Shortcut>⇧⌘Q</DropdownMenu.Shortcut>
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  ),
+};
+
+export const WithSubmenus: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button variant="outline">Open Menu</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content className="w-56">
+        <DropdownMenu.Label>My Account</DropdownMenu.Label>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Group>
+          <DropdownMenu.Item>
+            <User className="size-4" />
+            Profile
+          </DropdownMenu.Item>
+          <DropdownMenu.Item>
+            <CreditCard className="size-4" />
+            Billing
+          </DropdownMenu.Item>
+          <DropdownMenu.Item>
+            <Settings className="size-4" />
+            Settings
+          </DropdownMenu.Item>
+        </DropdownMenu.Group>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Group>
+          <DropdownMenu.Item>
+            <Users className="size-4" />
+            Team
+          </DropdownMenu.Item>
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger>
+              <UserPlus className="size-4" />
+              Invite users
+            </DropdownMenu.SubTrigger>
+            <DropdownMenu.SubContent>
+              <DropdownMenu.Item>
+                <Mail className="size-4" />
+                Email
+              </DropdownMenu.Item>
+              <DropdownMenu.Item>
+                <MessageSquare className="size-4" />
+                Message
+              </DropdownMenu.Item>
+              <DropdownMenu.Separator />
+              <DropdownMenu.Item>
+                <PlusCircle className="size-4" />
+                More...
+              </DropdownMenu.Item>
+            </DropdownMenu.SubContent>
+          </DropdownMenu.Sub>
+          <DropdownMenu.Item>
+            <Plus className="size-4" />
+            New Team
+          </DropdownMenu.Item>
+        </DropdownMenu.Group>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item>
+          <Github className="size-4" />
+          GitHub
+        </DropdownMenu.Item>
+        <DropdownMenu.Item>
+          <LifeBuoy className="size-4" />
+          Support
+        </DropdownMenu.Item>
+        <DropdownMenu.Item disabled>
+          <Cloud className="size-4" />
+          API
+        </DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item>
+          <LogOut className="size-4" />
+          Log out
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  ),
+};
+
+function CheckboxItemsExample() {
+  const [showStatusBar, setShowStatusBar] = useState(true);
+  const [showActivityBar, setShowActivityBar] = useState(false);
+  const [showPanel, setShowPanel] = useState(false);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button variant="outline">View Options</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content className="w-56">
+        <DropdownMenu.Label>Appearance</DropdownMenu.Label>
+        <DropdownMenu.Separator />
+        <DropdownMenu.CheckboxItem checked={showStatusBar} onCheckedChange={setShowStatusBar}>
+          Status Bar
+        </DropdownMenu.CheckboxItem>
+        <DropdownMenu.CheckboxItem checked={showActivityBar} onCheckedChange={setShowActivityBar}>
+          Activity Bar
+        </DropdownMenu.CheckboxItem>
+        <DropdownMenu.CheckboxItem checked={showPanel} onCheckedChange={setShowPanel}>
+          Panel
+        </DropdownMenu.CheckboxItem>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  );
+}
+
+export const WithCheckboxItems: Story = {
+  render: () => <CheckboxItemsExample />,
+};
+
+function RadioItemsExample() {
+  const [position, setPosition] = useState("bottom");
+
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button variant="outline">Panel Position</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content className="w-56">
+        <DropdownMenu.Label>Panel Position</DropdownMenu.Label>
+        <DropdownMenu.Separator />
+        <DropdownMenu.RadioGroup value={position} onValueChange={setPosition}>
+          <DropdownMenu.RadioItem value="top">Top</DropdownMenu.RadioItem>
+          <DropdownMenu.RadioItem value="bottom">Bottom</DropdownMenu.RadioItem>
+          <DropdownMenu.RadioItem value="right">Right</DropdownMenu.RadioItem>
+        </DropdownMenu.RadioGroup>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  );
+}
+
+export const WithRadioItems: Story = {
+  render: () => <RadioItemsExample />,
+};
+
+export const DestructiveItem: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button variant="outline">Actions</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item>Edit</DropdownMenu.Item>
+        <DropdownMenu.Item>Duplicate</DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item variant="destructive">Delete</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  ),
+};
+
+export const WithDisabledItems: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button variant="outline">Open Menu</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item>Edit</DropdownMenu.Item>
+        <DropdownMenu.Item disabled>Copy (Disabled)</DropdownMenu.Item>
+        <DropdownMenu.Item>Paste</DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item disabled>Delete (Disabled)</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  ),
+};
+
+export const InsetItems: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button variant="outline">Open Menu</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content className="w-56">
+        <DropdownMenu.Item>
+          <User className="size-4" />
+          Profile
+        </DropdownMenu.Item>
+        <DropdownMenu.Item inset>Inset Item (no icon)</DropdownMenu.Item>
+        <DropdownMenu.Item>
+          <Settings className="size-4" />
+          Settings
+        </DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Label inset>Inset Label</DropdownMenu.Label>
+        <DropdownMenu.Item inset>Another Inset Item</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  ),
+};
+
+export const AllStates = () => (
+  <div className="flex flex-wrap gap-4">
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button>Default</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Label>Actions</DropdownMenu.Label>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item>View</DropdownMenu.Item>
+        <DropdownMenu.Item>Edit</DropdownMenu.Item>
+        <DropdownMenu.Item>Delete</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button variant="outline">With Icons</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item>
+          <User className="size-4" />
+          Profile
+        </DropdownMenu.Item>
+        <DropdownMenu.Item>
+          <Settings className="size-4" />
+          Settings
+        </DropdownMenu.Item>
+        <DropdownMenu.Separator />
+        <DropdownMenu.Item variant="destructive">
+          <LogOut className="size-4" />
+          Log out
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button variant="stark">With Shortcuts</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item>
+          Copy
+          <DropdownMenu.Shortcut>⌘C</DropdownMenu.Shortcut>
+        </DropdownMenu.Item>
+        <DropdownMenu.Item>
+          Paste
+          <DropdownMenu.Shortcut>⌘V</DropdownMenu.Shortcut>
+        </DropdownMenu.Item>
+        <DropdownMenu.Item>
+          Cut
+          <DropdownMenu.Shortcut>⌘X</DropdownMenu.Shortcut>
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button variant="secondary">Disabled Items</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item>Enabled</DropdownMenu.Item>
+        <DropdownMenu.Item disabled>Disabled</DropdownMenu.Item>
+        <DropdownMenu.Item>Enabled</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  </div>
+);
+
+// Interaction Tests
+export const OpenCloseTest: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button>Open Menu</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item>Profile</DropdownMenu.Item>
+        <DropdownMenu.Item>Settings</DropdownMenu.Item>
+        <DropdownMenu.Item>Log out</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open dropdown
+    const trigger = canvas.getByRole("button", { name: "Open Menu" });
+    await userEvent.click(trigger);
+
+    // Wait for menu to be visible
+    const menu = await screen.findByRole("menu");
+    await expect(menu).toBeInTheDocument();
+
+    // Verify menu items are present
+    await expect(within(menu).getByRole("menuitem", { name: "Profile" })).toBeInTheDocument();
+    await expect(within(menu).getByRole("menuitem", { name: "Settings" })).toBeInTheDocument();
+
+    // Close with Escape key
+    await userEvent.keyboard("{Escape}");
+
+    // Verify menu is closed
+    await expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  },
+};
+
+export const ItemSelectionTest: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button>Open Menu</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item>Profile</DropdownMenu.Item>
+        <DropdownMenu.Item>Settings</DropdownMenu.Item>
+        <DropdownMenu.Item>Log out</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open dropdown
+    const trigger = canvas.getByRole("button", { name: "Open Menu" });
+    await userEvent.click(trigger);
+
+    // Wait for menu to be visible
+    const menu = await screen.findByRole("menu");
+    await expect(menu).toBeInTheDocument();
+
+    // Click on an item
+    const profileItem = within(menu).getByRole("menuitem", { name: "Profile" });
+    await userEvent.click(profileItem);
+
+    // Menu should close after selection
+    await expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  },
+};
+
+export const KeyboardNavigationTest: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button>Open Menu</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item>First</DropdownMenu.Item>
+        <DropdownMenu.Item>Second</DropdownMenu.Item>
+        <DropdownMenu.Item>Third</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Focus trigger and open with Enter
+    const trigger = canvas.getByRole("button", { name: "Open Menu" });
+    trigger.focus();
+    await userEvent.keyboard("{Enter}");
+
+    // Wait for menu to be visible
+    const menu = await screen.findByRole("menu");
+    await expect(menu).toBeInTheDocument();
+
+    // Navigate with arrow keys
+    await userEvent.keyboard("{ArrowDown}");
+    await userEvent.keyboard("{ArrowDown}");
+
+    // Close with Escape
+    await userEvent.keyboard("{Escape}");
+
+    // Verify menu is closed
+    await expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  },
+};
+
+export const DisabledItemTest: Story = {
+  render: () => (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button>Open Menu</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.Item>Enabled</DropdownMenu.Item>
+        <DropdownMenu.Item disabled>Disabled</DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open dropdown
+    const trigger = canvas.getByRole("button", { name: "Open Menu" });
+    await userEvent.click(trigger);
+
+    // Wait for menu to be visible
+    const menu = await screen.findByRole("menu");
+    await expect(menu).toBeInTheDocument();
+
+    // Verify disabled item has correct attribute
+    const disabledItem = within(menu).getByRole("menuitem", { name: "Disabled" });
+    await expect(disabledItem).toHaveAttribute("data-disabled");
+  },
+};
+
+function CheckboxTestExample() {
+  const [checked, setChecked] = useState(false);
+
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button>Open Menu</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.CheckboxItem checked={checked} onCheckedChange={setChecked}>
+          Toggle Option
+        </DropdownMenu.CheckboxItem>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  );
+}
+
+export const CheckboxItemTest: Story = {
+  render: () => <CheckboxTestExample />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open dropdown
+    const trigger = canvas.getByRole("button", { name: "Open Menu" });
+    await userEvent.click(trigger);
+
+    // Wait for menu to be visible
+    const menu = await screen.findByRole("menu");
+    await expect(menu).toBeInTheDocument();
+
+    // Find and click checkbox item
+    const checkboxItem = within(menu).getByRole("menuitemcheckbox", { name: "Toggle Option" });
+    await expect(checkboxItem).toHaveAttribute("aria-checked", "false");
+    await userEvent.click(checkboxItem);
+
+    // Re-open menu to verify state
+    await userEvent.click(trigger);
+    const menuAfter = await screen.findByRole("menu");
+    const checkboxItemAfter = within(menuAfter).getByRole("menuitemcheckbox", {
+      name: "Toggle Option",
+    });
+    await expect(checkboxItemAfter).toHaveAttribute("aria-checked", "true");
+  },
+};
+
+function RadioTestExample() {
+  const [value, setValue] = useState("one");
+
+  return (
+    <DropdownMenu>
+      <DropdownMenu.Trigger asChild>
+        <Button>Open Menu</Button>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content>
+        <DropdownMenu.RadioGroup value={value} onValueChange={setValue}>
+          <DropdownMenu.RadioItem value="one">Option One</DropdownMenu.RadioItem>
+          <DropdownMenu.RadioItem value="two">Option Two</DropdownMenu.RadioItem>
+        </DropdownMenu.RadioGroup>
+      </DropdownMenu.Content>
+    </DropdownMenu>
+  );
+}
+
+export const RadioItemTest: Story = {
+  render: () => <RadioTestExample />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Open dropdown
+    const trigger = canvas.getByRole("button", { name: "Open Menu" });
+    await userEvent.click(trigger);
+
+    // Wait for menu to be visible
+    const menu = await screen.findByRole("menu");
+    await expect(menu).toBeInTheDocument();
+
+    // Verify initial selection
+    const optionOne = within(menu).getByRole("menuitemradio", { name: "Option One" });
+    const optionTwo = within(menu).getByRole("menuitemradio", { name: "Option Two" });
+    await expect(optionOne).toHaveAttribute("aria-checked", "true");
+    await expect(optionTwo).toHaveAttribute("aria-checked", "false");
+
+    // Select option two
+    await userEvent.click(optionTwo);
+
+    // Re-open menu to verify state
+    await userEvent.click(trigger);
+    const menuAfter = await screen.findByRole("menu");
+    const optionOneAfter = within(menuAfter).getByRole("menuitemradio", { name: "Option One" });
+    const optionTwoAfter = within(menuAfter).getByRole("menuitemradio", { name: "Option Two" });
+    await expect(optionOneAfter).toHaveAttribute("aria-checked", "false");
+    await expect(optionTwoAfter).toHaveAttribute("aria-checked", "true");
+  },
+};

--- a/src/components/dropdown-menu.tsx
+++ b/src/components/dropdown-menu.tsx
@@ -1,0 +1,258 @@
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { type ClassValue, clsx } from "clsx";
+import { Check, ChevronRight, Circle } from "lucide-react";
+import { twMerge } from "tailwind-merge";
+
+const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+
+export function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuTrigger({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      className={cn("outline-none", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] origin-[var(--radix-dropdown-menu-content-transform-origin)] overflow-x-hidden overflow-y-auto border border-[var(--ink)] bg-[var(--paper)] p-1 text-[var(--ink)]",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuGroup({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />;
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+  /**
+   * Adds left padding to align with items that have icons
+   */
+  inset?: boolean;
+  /**
+   * Visual style variant of the menu item
+   */
+  variant?: "default" | "destructive";
+}) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "relative flex cursor-default items-center gap-2 px-2 py-1.5 text-sm outline-none select-none",
+        "focus:bg-[var(--ink)] focus:text-[var(--paper)]",
+        "data-[disabled]:pointer-events-none data-[disabled]:text-[var(--steel)]",
+        "data-[inset]:pl-8",
+        "data-[variant=destructive]:text-[var(--signal-red)] data-[variant=destructive]:focus:bg-[var(--signal-red)] data-[variant=destructive]:focus:text-[var(--paper)]",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 py-1.5 pr-2 pl-8 text-sm outline-none select-none",
+        "focus:bg-[var(--ink)] focus:text-[var(--paper)]",
+        "data-[disabled]:pointer-events-none data-[disabled]:text-[var(--steel)]",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Check className="size-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return <DropdownMenuPrimitive.RadioGroup data-slot="dropdown-menu-radio-group" {...props} />;
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "relative flex cursor-default items-center gap-2 py-1.5 pr-2 pl-8 text-sm outline-none select-none",
+        "focus:bg-[var(--ink)] focus:text-[var(--paper)]",
+        "data-[disabled]:pointer-events-none data-[disabled]:text-[var(--steel)]",
+        "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className,
+      )}
+      {...props}
+    >
+      <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Circle className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label> & {
+  /**
+   * Adds left padding to align with items that have icons
+   */
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.Label
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-2 py-1.5 text-sm font-medium text-[var(--ink)] data-[inset]:pl-8",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-[var(--chrome)]", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn("ml-auto text-xs tracking-widest text-[var(--steel)]", className)}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuSub({ ...props }: React.ComponentProps<typeof DropdownMenuPrimitive.Sub>) {
+  return <DropdownMenuPrimitive.Sub data-slot="dropdown-menu-sub" {...props} />;
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubTrigger> & {
+  /**
+   * Adds left padding to align with items that have icons
+   */
+  inset?: boolean;
+}) {
+  return (
+    <DropdownMenuPrimitive.SubTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center px-2 py-1.5 text-sm outline-none select-none",
+        "focus:bg-[var(--ink)] focus:text-[var(--paper)]",
+        "data-[state=open]:bg-[var(--ink)] data-[state=open]:text-[var(--paper)]",
+        "data-[inset]:pl-8",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRight className="ml-auto size-4" />
+    </DropdownMenuPrimitive.SubTrigger>
+  );
+}
+
+function DropdownMenuSubContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
+  return (
+    <DropdownMenuPrimitive.SubContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn(
+        "z-50 min-w-[8rem] origin-[var(--radix-dropdown-menu-content-transform-origin)] overflow-hidden border border-[var(--ink)] bg-[var(--paper)] p-1 text-[var(--ink)]",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+// Attach sub-components to main component
+DropdownMenu.Trigger = DropdownMenuTrigger;
+DropdownMenu.Content = DropdownMenuContent;
+DropdownMenu.Group = DropdownMenuGroup;
+DropdownMenu.Item = DropdownMenuItem;
+DropdownMenu.CheckboxItem = DropdownMenuCheckboxItem;
+DropdownMenu.RadioGroup = DropdownMenuRadioGroup;
+DropdownMenu.RadioItem = DropdownMenuRadioItem;
+DropdownMenu.Label = DropdownMenuLabel;
+DropdownMenu.Separator = DropdownMenuSeparator;
+DropdownMenu.Shortcut = DropdownMenuShortcut;
+DropdownMenu.Sub = DropdownMenuSub;
+DropdownMenu.SubTrigger = DropdownMenuSubTrigger;
+DropdownMenu.SubContent = DropdownMenuSubContent;


### PR DESCRIPTION
## Summary
- Add DropdownMenu component built on Radix UI with compound pattern
- Includes sub-components: Trigger, Content, Item, Label, Separator, CheckboxItem, RadioGroup, RadioItem, Sub, SubTrigger, SubContent, Shortcut
- Supports inset and destructive variants
- Full Storybook documentation with 14 stories and interaction tests

## Test plan
- [x] TypeScript compilation passes
- [x] All 14 interaction tests pass
- [x] Storybook stories render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)