### PR TITLE
fix: correct package name in changesets

### DIFF
--- a/.changeset/dialog-component.md
+++ b/.changeset/dialog-component.md
@@ -1,5 +1,5 @@
 ---
-"ui": minor
+"@beaket/ui": minor
 ---
 
 Add Dialog component with compound pattern, controlled/uncontrolled modes, and Storybook tests

--- a/.changeset/dropdown-menu-component.md
+++ b/.changeset/dropdown-menu-component.md
@@ -1,5 +1,5 @@
 ---
-"ui": minor
+"@beaket/ui": minor
 ---
 
 Add DropdownMenu component with compound pattern, checkbox/radio items, submenus, and keyboard shortcuts support

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,29 @@ Register the component in `registry/registry.json`.
 }
 ```
 
+### 4. Changeset
+
+Create a changeset for version tracking using `pnpm changeset` or manually create a file in `.changeset/`.
+
+**Important:** The package name must be `@beaket/ui` (not `ui`).
+
+```md
+---
+"@beaket/ui": minor
+---
+
+Add ComponentName component with feature X, Y, and Z
+```
+
+**Version bump guidelines:**
+
+| Change Type                       | Bump    | Example                      |
+| --------------------------------- | ------- | ---------------------------- |
+| New component                     | `minor` | Adding Dialog component      |
+| New feature to existing component | `minor` | Adding new variant to Button |
+| Bug fix                           | `patch` | Fixing focus state issue     |
+| Breaking change                   | `major` | Changing component API       |
+
 ## File Structure
 
 ```
@@ -237,6 +260,9 @@ src/components/
 
 registry/
 └── registry.json        # Component registration
+
+.changeset/
+└── [description].md     # Changeset for versioning
 ```
 
 ## Checklist
@@ -247,3 +273,4 @@ Verify when creating a component:
 - [ ] `src/components/[name].stories.tsx` - Storybook created
 - [ ] Interaction tests implemented (play function)
 - [ ] Registered in `registry/registry.json`
+- [ ] Changeset created with `@beaket/ui` package name


### PR DESCRIPTION
## Summary
- Fix incorrect package name in `dialog-component.md` and `dropdown-menu-component.md` changesets
- Change `"ui"` to `"@beaket/ui"` to match the actual workspace package name
- Resolves release workflow failure: https://github.com/beaket/ui/actions/runs/20773713497

## Test plan
- [ ] CI passes
- [ ] Release workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)