### PR TITLE
feat(components): add Avatar component

### DIFF
--- a/.changeset/add-avatar-component.md
+++ b/.changeset/add-avatar-component.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": minor
+---
+
+Add Avatar component for displaying user profile images with fallback support

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -19,6 +19,7 @@ const preview: Preview = {
 
     options: {
       storySort: {
+        method: "alphabetical",
         order: ["Introduction", "Token", ["Colors", "Typography"], "UI"],
       },
     },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "vitest": "4.0.16"
   },
   "dependencies": {
+    "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-avatar':
+        specifier: ^1.1.11
+        version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -977,6 +980,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-avatar@1.1.11':
+    resolution: {integrity: sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-checkbox@1.3.3':
     resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
     peerDependencies:
@@ -1014,6 +1030,15 @@ packages:
 
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.3':
+    resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -1165,6 +1190,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-primitive@2.1.4':
+    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-radio-group@1.3.8':
     resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
     peerDependencies:
@@ -1238,6 +1276,15 @@ packages:
 
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -4848,6 +4895,19 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-avatar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.3(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.7)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -4883,6 +4943,12 @@ snapshots:
       '@types/react': 19.2.7
 
   '@radix-ui/react-context@1.1.2(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-context@1.1.3(@types/react@19.2.7)(react@19.2.3)':
     dependencies:
       react: 19.2.3
     optionalDependencies:
@@ -5041,6 +5107,15 @@ snapshots:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
 
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.7)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.7
+      '@types/react-dom': 19.2.3(@types/react@19.2.7)
+
   '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -5115,6 +5190,13 @@ snapshots:
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.3)
       react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.7)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
     optionalDependencies:
       '@types/react': 19.2.7
 

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -1,6 +1,20 @@
 {
   "components": [
     {
+      "name": "avatar",
+      "description": "Avatar component for displaying user profile images with fallback support",
+      "dependencies": ["@radix-ui/react-avatar", "clsx", "tailwind-merge"],
+      "registryDependencies": [],
+      "files": ["components/avatar.tsx"],
+      "docs": {
+        "title": "Avatar",
+        "tagline": "A visual representation of a user with image and fallback support.",
+        "sections": ["AllStates", "CustomSizes", "AvatarGroup"],
+        "usage": "<Avatar><Avatar.Image src=\"/user.png\" alt=\"User\" /><Avatar.Fallback>JD</Avatar.Fallback></Avatar>",
+        "previewStory": "Default"
+      }
+    },
+    {
       "name": "dropdown-menu",
       "description": "Dropdown menu component for actions, navigation, and selection",
       "dependencies": ["@radix-ui/react-dropdown-menu", "clsx", "lucide-react", "tailwind-merge"],

--- a/src/components/avatar.stories.tsx
+++ b/src/components/avatar.stories.tsx
@@ -1,0 +1,162 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+import { Avatar } from "./avatar";
+
+const meta: Meta<typeof Avatar> = {
+  title: "UI/Avatar",
+  component: Avatar,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Avatar>;
+
+export const Default: Story = {
+  render: () => (
+    <Avatar>
+      <Avatar.Image src="https://github.com/beaket.png" alt="@beaket" />
+      <Avatar.Fallback>BK</Avatar.Fallback>
+    </Avatar>
+  ),
+};
+
+export const WithFallback: Story = {
+  render: () => (
+    <Avatar>
+      <Avatar.Image src="/broken-image.jpg" alt="User" />
+      <Avatar.Fallback>JD</Avatar.Fallback>
+    </Avatar>
+  ),
+};
+
+export const FallbackOnly: Story = {
+  render: () => (
+    <Avatar>
+      <Avatar.Fallback>AB</Avatar.Fallback>
+    </Avatar>
+  ),
+};
+
+// Compositions for docs
+export const AllStates = () => (
+  <div className="flex items-center gap-4">
+    <div className="flex flex-col items-center gap-2">
+      <Avatar>
+        <Avatar.Image src="https://github.com/beaket.png" alt="@beaket" />
+        <Avatar.Fallback>BK</Avatar.Fallback>
+      </Avatar>
+      <span className="text-xs text-[var(--steel)]">With Image</span>
+    </div>
+    <div className="flex flex-col items-center gap-2">
+      <Avatar>
+        <Avatar.Fallback>JD</Avatar.Fallback>
+      </Avatar>
+      <span className="text-xs text-[var(--steel)]">Fallback</span>
+    </div>
+    <div className="flex flex-col items-center gap-2">
+      <Avatar>
+        <Avatar.Fallback>A</Avatar.Fallback>
+      </Avatar>
+      <span className="text-xs text-[var(--steel)]">Single Letter</span>
+    </div>
+  </div>
+);
+
+export const CustomSizes = () => (
+  <div className="flex items-end gap-4">
+    <div className="flex flex-col items-center gap-2">
+      <Avatar className="size-6">
+        <Avatar.Fallback className="text-xs">XS</Avatar.Fallback>
+      </Avatar>
+      <span className="text-xs text-[var(--steel)]">24px</span>
+    </div>
+    <div className="flex flex-col items-center gap-2">
+      <Avatar className="size-8">
+        <Avatar.Fallback className="text-sm">SM</Avatar.Fallback>
+      </Avatar>
+      <span className="text-xs text-[var(--steel)]">32px</span>
+    </div>
+    <div className="flex flex-col items-center gap-2">
+      <Avatar>
+        <Avatar.Fallback>MD</Avatar.Fallback>
+      </Avatar>
+      <span className="text-xs text-[var(--steel)]">40px (default)</span>
+    </div>
+    <div className="flex flex-col items-center gap-2">
+      <Avatar className="size-12">
+        <Avatar.Fallback className="text-lg">LG</Avatar.Fallback>
+      </Avatar>
+      <span className="text-xs text-[var(--steel)]">48px</span>
+    </div>
+    <div className="flex flex-col items-center gap-2">
+      <Avatar className="size-16">
+        <Avatar.Fallback className="text-xl">XL</Avatar.Fallback>
+      </Avatar>
+      <span className="text-xs text-[var(--steel)]">64px</span>
+    </div>
+  </div>
+);
+
+export const AvatarGroup = () => (
+  <div className="flex -space-x-2">
+    <Avatar className="border-2 border-[var(--paper)]">
+      <Avatar.Image src="https://github.com/beaket.png" alt="@beaket" />
+      <Avatar.Fallback>BK</Avatar.Fallback>
+    </Avatar>
+    <Avatar className="border-2 border-[var(--paper)]">
+      <Avatar.Fallback>JD</Avatar.Fallback>
+    </Avatar>
+    <Avatar className="border-2 border-[var(--paper)]">
+      <Avatar.Fallback>AB</Avatar.Fallback>
+    </Avatar>
+    <Avatar className="border-2 border-[var(--paper)]">
+      <Avatar.Fallback>+3</Avatar.Fallback>
+    </Avatar>
+  </div>
+);
+
+// Interaction Tests
+export const RenderTest: Story = {
+  render: () => (
+    <Avatar>
+      <Avatar.Fallback>TT</Avatar.Fallback>
+    </Avatar>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const fallback = canvas.getByText("TT");
+
+    await expect(fallback).toBeInTheDocument();
+  },
+};
+
+export const FallbackTest: Story = {
+  render: () => (
+    <Avatar>
+      <Avatar.Image src="/broken-image.jpg" alt="User" />
+      <Avatar.Fallback>FB</Avatar.Fallback>
+    </Avatar>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // When image fails to load, fallback should be visible
+    const fallback = canvas.getByText("FB");
+
+    await expect(fallback).toBeInTheDocument();
+  },
+};
+
+export const DataSlotTest: Story = {
+  render: () => (
+    <Avatar>
+      <Avatar.Fallback>DS</Avatar.Fallback>
+    </Avatar>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const avatar = canvas.getByText("DS").closest("[data-slot='avatar']");
+
+    await expect(avatar).toBeInTheDocument();
+    await expect(avatar).toHaveAttribute("data-slot", "avatar");
+  },
+};

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -1,0 +1,54 @@
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+
+interface Props extends React.ComponentProps<typeof AvatarPrimitive.Root> {
+  /**
+   * Additional CSS classes to apply to the avatar container
+   */
+  className?: string;
+}
+
+export function Avatar({ className, ...props }: Props) {
+  return (
+    <AvatarPrimitive.Root
+      data-slot="avatar"
+      className={cn(
+        "relative flex size-10 shrink-0 overflow-hidden border border-[var(--chrome)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function AvatarImage({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  return (
+    <AvatarPrimitive.Image
+      data-slot="avatar-image"
+      className={cn("aspect-square size-full", className)}
+      {...props}
+    />
+  );
+}
+
+function AvatarFallback({
+  className,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Fallback>) {
+  return (
+    <AvatarPrimitive.Fallback
+      data-slot="avatar-fallback"
+      className={cn(
+        "flex size-full items-center justify-center bg-[var(--frost)] text-[var(--ink)]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+Avatar.Image = AvatarImage;
+Avatar.Fallback = AvatarFallback;


### PR DESCRIPTION
## Summary
- Add Avatar component with `Avatar.Image` and `Avatar.Fallback` sub-components
- Built on `@radix-ui/react-avatar` with brutalist design (no rounded corners)
- Include Storybook stories with AllStates, CustomSizes, and AvatarGroup compositions
- Add alphabetical sorting to Storybook sidebar for UI category

## Test plan
- [x] TypeScript compiles without errors
- [x] All 117 tests pass (including 9 new Avatar tests)
- [ ] Verify Avatar renders correctly in Storybook
- [ ] Verify fallback displays when image fails to load

🤖 Generated with [Claude Code](https://claude.com/claude-code)