### PR TITLE
feat(components): add Phase 3 components (Pagination, BlankSlate)

### DIFF
--- a/.changeset/phase3-pagination-blank-slate.md
+++ b/.changeset/phase3-pagination-blank-slate.md
@@ -1,0 +1,8 @@
+---
+"@beaket/ui": minor
+---
+
+Add Pagination and BlankSlate components (Phase 3 migration)
+
+- Pagination: Server-side pagination with ellipsis support for SSR-friendly navigation
+- BlankSlate: Empty state component with preset icons and custom icon support

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -289,6 +289,34 @@
         "usage": "<Alert variant=\"warning\">Important message here.</Alert>",
         "previewStory": "Default"
       }
+    },
+    {
+      "name": "pagination",
+      "description": "Server-side pagination component using links for SSR-friendly navigation",
+      "dependencies": ["clsx", "lucide-react", "tailwind-merge"],
+      "registryDependencies": [],
+      "files": ["components/pagination.tsx"],
+      "docs": {
+        "title": "Pagination",
+        "tagline": "A navigation component for paginated content with ellipsis support.",
+        "sections": ["AllStates"],
+        "usage": "<Pagination page={1} totalPages={10} buildPageUrl={(p) => `?page=${p}`} />",
+        "previewStory": "Default"
+      }
+    },
+    {
+      "name": "blank-slate",
+      "description": "Empty state component for displaying placeholder content",
+      "dependencies": ["clsx", "lucide-react", "tailwind-merge"],
+      "registryDependencies": [],
+      "files": ["components/blank-slate.tsx"],
+      "docs": {
+        "title": "BlankSlate",
+        "tagline": "An empty state component for when there is no data to display.",
+        "sections": ["AllStates"],
+        "usage": "<BlankSlate icon=\"inbox\" title=\"No messages\" description=\"Your inbox is empty.\" />",
+        "previewStory": "Default"
+      }
     }
   ]
 }

--- a/src/components/blank-slate.stories.tsx
+++ b/src/components/blank-slate.stories.tsx
@@ -1,0 +1,210 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Package } from "lucide-react";
+import { expect, within } from "storybook/test";
+import { BlankSlate } from "./blank-slate";
+import { Button } from "./button";
+
+const meta: Meta<typeof BlankSlate> = {
+  title: "UI/BlankSlate",
+  component: BlankSlate,
+  tags: ["autodocs"],
+  argTypes: {
+    icon: {
+      control: "select",
+      options: [
+        undefined,
+        "inbox",
+        "alert-circle",
+        "search",
+        "file-question",
+        "folder-open",
+        "users",
+      ],
+      description: "Icon to display above the title",
+    },
+    title: {
+      control: "text",
+      description: "Main heading text",
+    },
+    description: {
+      control: "text",
+      description: "Supporting description text",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "An empty state component for displaying placeholder content when there is no data to show.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BlankSlate>;
+
+export const Default: Story = {
+  args: {
+    icon: "inbox",
+    title: "No messages",
+    description: "You don't have any messages yet. Start a conversation!",
+  },
+};
+
+export const WithAction: Story = {
+  args: {
+    icon: "inbox",
+    title: "No messages",
+    description: "You don't have any messages yet.",
+  },
+  render: (args) => (
+    <BlankSlate {...args}>
+      <Button>Create New</Button>
+    </BlankSlate>
+  ),
+};
+
+export const WithMultipleActions: Story = {
+  args: {
+    icon: "file-question",
+    title: "No documents found",
+    description: "There are no documents matching your search criteria.",
+  },
+  render: (args) => (
+    <BlankSlate {...args}>
+      <Button variant="outline">Clear Filters</Button>
+      <Button>Upload Document</Button>
+    </BlankSlate>
+  ),
+};
+
+export const SearchEmpty: Story = {
+  args: {
+    icon: "search",
+    title: "No results found",
+    description: "Try adjusting your search terms or filters.",
+  },
+};
+
+export const FolderEmpty: Story = {
+  args: {
+    icon: "folder-open",
+    title: "This folder is empty",
+    description: "Upload files or create new documents to get started.",
+  },
+};
+
+export const UsersEmpty: Story = {
+  args: {
+    icon: "users",
+    title: "No team members",
+    description: "Invite people to collaborate on this project.",
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    icon: "alert-circle",
+    title: "Something went wrong",
+    description: "We couldn't load your data. Please try again later.",
+  },
+  render: (args) => (
+    <BlankSlate {...args}>
+      <Button variant="outline">Retry</Button>
+    </BlankSlate>
+  ),
+};
+
+export const WithoutIcon: Story = {
+  args: {
+    title: "Getting started",
+    description: "Complete the steps below to set up your workspace.",
+  },
+};
+
+export const CustomIcon: Story = {
+  args: {
+    icon: Package,
+    title: "No packages",
+    description: "You haven't added any packages to your project yet.",
+  },
+};
+
+export const AllStates = () => (
+  <div className="space-y-12">
+    <div>
+      <h3 className="mb-4 text-sm font-medium">With Icon Presets</h3>
+      <div className="grid gap-8 md:grid-cols-2">
+        <BlankSlate icon="inbox" title="No messages" description="Your inbox is empty." />
+        <BlankSlate icon="search" title="No results" description="Try different search terms." />
+        <BlankSlate
+          icon="folder-open"
+          title="Empty folder"
+          description="No files in this folder."
+        />
+        <BlankSlate icon="users" title="No members" description="Invite people to join." />
+      </div>
+    </div>
+
+    <div>
+      <h3 className="mb-4 text-sm font-medium">With Actions</h3>
+      <BlankSlate
+        icon="file-question"
+        title="No documents"
+        description="Create your first document to get started."
+      >
+        <Button>Create Document</Button>
+      </BlankSlate>
+    </div>
+
+    <div>
+      <h3 className="mb-4 text-sm font-medium">Error State</h3>
+      <BlankSlate
+        icon="alert-circle"
+        title="Failed to load"
+        description="There was an error loading the content."
+      >
+        <Button variant="outline">Retry</Button>
+      </BlankSlate>
+    </div>
+
+    <div>
+      <h3 className="mb-4 text-sm font-medium">Without Icon</h3>
+      <BlankSlate title="Welcome" description="Get started by exploring the features below." />
+    </div>
+
+    <div>
+      <h3 className="mb-4 text-sm font-medium">Custom Icon</h3>
+      <BlankSlate icon={Package} title="No packages" description="Add packages to your project." />
+    </div>
+  </div>
+);
+
+export const InteractionTest: Story = {
+  args: {
+    icon: "inbox",
+    title: "Test Title",
+    description: "Test description text",
+  },
+  render: (args) => (
+    <BlankSlate data-testid="blank-slate" {...args}>
+      <Button data-testid="action-button">Action</Button>
+    </BlankSlate>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Check title is rendered
+    const title = canvas.getByRole("heading", { name: "Test Title" });
+    await expect(title).toBeInTheDocument();
+
+    // Check description is rendered
+    const description = canvas.getByText("Test description text");
+    await expect(description).toBeInTheDocument();
+
+    // Check action button is rendered
+    const button = canvas.getByTestId("action-button");
+    await expect(button).toBeInTheDocument();
+  },
+};

--- a/src/components/blank-slate.tsx
+++ b/src/components/blank-slate.tsx
@@ -1,0 +1,84 @@
+import { type ClassValue, clsx } from "clsx";
+import {
+  AlertCircle,
+  FileQuestion,
+  FolderOpen,
+  Inbox,
+  type LucideIcon,
+  Search,
+  Users,
+} from "lucide-react";
+import { twMerge } from "tailwind-merge";
+
+const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+
+const iconMap = {
+  inbox: Inbox,
+  "alert-circle": AlertCircle,
+  search: Search,
+  "file-question": FileQuestion,
+  "folder-open": FolderOpen,
+  users: Users,
+} as const;
+
+type IconName = keyof typeof iconMap;
+
+export interface BlankSlateProps {
+  /**
+   * Icon to display above the title. Can be a preset name or a custom LucideIcon component.
+   */
+  icon?: IconName | LucideIcon;
+
+  /**
+   * Main heading text
+   */
+  title: string;
+
+  /**
+   * Supporting description text
+   */
+  description: string;
+
+  /**
+   * Optional action buttons or links
+   */
+  children?: React.ReactNode;
+
+  /**
+   * Additional CSS class for the container
+   */
+  className?: string;
+}
+
+export function BlankSlate({ icon, title, description, children, className }: BlankSlateProps) {
+  let IconComponent: LucideIcon | null = null;
+
+  if (icon) {
+    if (typeof icon === "string") {
+      IconComponent = iconMap[icon];
+    } else {
+      IconComponent = icon;
+    }
+  }
+
+  return (
+    <div data-slot="blank-slate" className={cn("py-12 text-center", className)}>
+      {IconComponent && (
+        <div data-slot="blank-slate-icon" className="mb-4 flex justify-center text-[var(--steel)]">
+          <IconComponent size={48} />
+        </div>
+      )}
+      <h1 data-slot="blank-slate-title" className="mb-2 text-2xl font-bold text-[var(--ink)]">
+        {title}
+      </h1>
+      <p data-slot="blank-slate-description" className="mb-4 text-[var(--steel)]">
+        {description}
+      </p>
+      {children && (
+        <div data-slot="blank-slate-actions" className="flex justify-center gap-2">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/pagination.stories.tsx
+++ b/src/components/pagination.stories.tsx
@@ -1,0 +1,192 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, within } from "storybook/test";
+import { Pagination } from "./pagination";
+
+const meta: Meta<typeof Pagination> = {
+  title: "UI/Pagination",
+  component: Pagination,
+  tags: ["autodocs"],
+  argTypes: {
+    page: {
+      control: { type: "number", min: 1 },
+      description: "Current page number (1-indexed)",
+    },
+    totalPages: {
+      control: { type: "number", min: 1 },
+      description: "Total number of pages",
+    },
+    maxPageButtons: {
+      control: { type: "number", min: 3 },
+      description: "Maximum number of page buttons to show",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "Server-side pagination component using links. Works with React Router's Link component for SSR-friendly navigation.",
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Pagination>;
+
+const buildPageUrl = (page: number) => `?page=${page}`;
+
+export const Default: Story = {
+  args: {
+    page: 1,
+    totalPages: 10,
+    buildPageUrl,
+  },
+};
+
+export const MiddlePage: Story = {
+  args: {
+    page: 5,
+    totalPages: 10,
+    buildPageUrl,
+  },
+};
+
+export const LastPage: Story = {
+  args: {
+    page: 10,
+    totalPages: 10,
+    buildPageUrl,
+  },
+};
+
+export const FewPages: Story = {
+  args: {
+    page: 2,
+    totalPages: 3,
+    buildPageUrl,
+  },
+};
+
+export const ManyPages: Story = {
+  args: {
+    page: 15,
+    totalPages: 100,
+    buildPageUrl,
+  },
+};
+
+export const SinglePage: Story = {
+  args: {
+    page: 1,
+    totalPages: 1,
+    buildPageUrl,
+  },
+};
+
+export const AllStates = () => (
+  <div className="space-y-8">
+    <div>
+      <h3 className="mb-4 text-sm font-medium">First Page</h3>
+      <Pagination page={1} totalPages={10} buildPageUrl={buildPageUrl} />
+    </div>
+
+    <div>
+      <h3 className="mb-4 text-sm font-medium">Middle Page</h3>
+      <Pagination page={5} totalPages={10} buildPageUrl={buildPageUrl} />
+    </div>
+
+    <div>
+      <h3 className="mb-4 text-sm font-medium">Last Page</h3>
+      <Pagination page={10} totalPages={10} buildPageUrl={buildPageUrl} />
+    </div>
+
+    <div>
+      <h3 className="mb-4 text-sm font-medium">Few Pages (3)</h3>
+      <Pagination page={2} totalPages={3} buildPageUrl={buildPageUrl} />
+    </div>
+
+    <div>
+      <h3 className="mb-4 text-sm font-medium">Many Pages with Ellipsis</h3>
+      <Pagination page={50} totalPages={100} buildPageUrl={buildPageUrl} />
+    </div>
+
+    <div>
+      <h3 className="mb-4 text-sm font-medium">Single Page (Hidden)</h3>
+      <p className="text-sm text-[var(--steel)]">Pagination is hidden when totalPages = 1</p>
+      <Pagination page={1} totalPages={1} buildPageUrl={buildPageUrl} />
+    </div>
+  </div>
+);
+
+export const InteractionTest: Story = {
+  args: {
+    page: 5,
+    totalPages: 10,
+    buildPageUrl,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Check navigation exists
+    const nav = canvas.getByRole("navigation", { name: "Pagination" });
+    await expect(nav).toBeInTheDocument();
+
+    // Check current page is marked
+    const currentPage = canvas.getByRole("link", { name: "5" });
+    await expect(currentPage).toHaveAttribute("aria-current", "page");
+
+    // Check prev/next links exist and have correct hrefs
+    const prevLink = canvas.getByRole("link", { name: "Previous page" });
+    await expect(prevLink).toHaveAttribute("href", "?page=4");
+
+    const nextLink = canvas.getByRole("link", { name: "Next page" });
+    await expect(nextLink).toHaveAttribute("href", "?page=6");
+
+    // Check page links
+    const page1 = canvas.getByRole("link", { name: "1" });
+    await expect(page1).toHaveAttribute("href", "?page=1");
+
+    const page10 = canvas.getByRole("link", { name: "10" });
+    await expect(page10).toHaveAttribute("href", "?page=10");
+  },
+};
+
+export const FirstPageTest: Story = {
+  args: {
+    page: 1,
+    totalPages: 10,
+    buildPageUrl,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Previous button should be disabled (span, not link)
+    const prevSpan = canvas.getByLabelText("Previous page");
+    await expect(prevSpan.tagName).toBe("SPAN");
+    await expect(prevSpan).toHaveAttribute("aria-disabled", "true");
+
+    // Next link should be active
+    const nextLink = canvas.getByRole("link", { name: "Next page" });
+    await expect(nextLink).toHaveAttribute("href", "?page=2");
+  },
+};
+
+export const LastPageTest: Story = {
+  args: {
+    page: 10,
+    totalPages: 10,
+    buildPageUrl,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Next button should be disabled (span, not link)
+    const nextSpan = canvas.getByLabelText("Next page");
+    await expect(nextSpan.tagName).toBe("SPAN");
+    await expect(nextSpan).toHaveAttribute("aria-disabled", "true");
+
+    // Previous link should be active
+    const prevLink = canvas.getByRole("link", { name: "Previous page" });
+    await expect(prevLink).toHaveAttribute("href", "?page=9");
+  },
+};

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -1,0 +1,175 @@
+import { type ClassValue, clsx } from "clsx";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { twMerge } from "tailwind-merge";
+
+const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+
+export interface PaginationProps {
+  /**
+   * Current page number (1-indexed)
+   */
+  page: number;
+
+  /**
+   * Total number of pages
+   */
+  totalPages: number;
+
+  /**
+   * Function to build URL for a given page number
+   */
+  buildPageUrl: (page: number) => string;
+
+  /**
+   * Additional CSS class for the container
+   */
+  className?: string;
+
+  /**
+   * Maximum number of page buttons to show (default: 5)
+   * When there are more pages, ellipsis will be shown
+   */
+  maxPageButtons?: number;
+}
+
+/**
+ * Server-side pagination component using links.
+ * Works with React Router's Link component for SSR-friendly navigation.
+ */
+export function Pagination({
+  page,
+  totalPages,
+  buildPageUrl,
+  className,
+  maxPageButtons = 5,
+}: PaginationProps) {
+  if (totalPages <= 1) return null;
+
+  // Calculate which page numbers to show
+  const getPageNumbers = (): (number | "ellipsis-start" | "ellipsis-end")[] => {
+    if (totalPages <= maxPageButtons) {
+      return Array.from({ length: totalPages }, (_, i) => i + 1);
+    }
+
+    const pages: (number | "ellipsis-start" | "ellipsis-end")[] = [];
+    const halfRange = Math.floor((maxPageButtons - 3) / 2);
+
+    // Always show first page
+    pages.push(1);
+
+    let start = Math.max(2, page - halfRange);
+    let end = Math.min(totalPages - 1, page + halfRange);
+
+    // Adjust range if at the edges
+    if (page <= halfRange + 2) {
+      end = maxPageButtons - 2;
+    } else if (page >= totalPages - halfRange - 1) {
+      start = totalPages - maxPageButtons + 3;
+    }
+
+    // Add ellipsis before middle numbers if needed
+    if (start > 2) {
+      pages.push("ellipsis-start");
+    }
+
+    // Add middle pages
+    for (let i = start; i <= end; i++) {
+      pages.push(i);
+    }
+
+    // Add ellipsis after middle numbers if needed
+    if (end < totalPages - 1) {
+      pages.push("ellipsis-end");
+    }
+
+    // Always show last page
+    pages.push(totalPages);
+
+    return pages;
+  };
+
+  const pageNumbers = getPageNumbers();
+  const buttonBaseClass = "px-3 py-1 border text-sm transition-colors";
+  const buttonActiveClass = "bg-[var(--ink)] text-[var(--paper)] border-[var(--ink)]";
+  const buttonInactiveClass = "border-[var(--chrome)] hover:bg-[var(--frost)]";
+  const buttonDisabledClass = "border-[var(--chrome)] text-[var(--steel)] cursor-not-allowed";
+
+  return (
+    <nav
+      data-slot="pagination"
+      className={cn("flex items-center justify-center gap-1", className)}
+      aria-label="Pagination"
+    >
+      {/* Previous button */}
+      {page > 1 ? (
+        <a
+          data-slot="pagination-prev"
+          href={buildPageUrl(page - 1)}
+          className={cn(buttonBaseClass, buttonInactiveClass)}
+          aria-label="Previous page"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </a>
+      ) : (
+        <span
+          data-slot="pagination-prev"
+          className={cn(buttonBaseClass, buttonDisabledClass)}
+          aria-disabled="true"
+          aria-label="Previous page"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </span>
+      )}
+
+      {/* Page numbers */}
+      {pageNumbers.map((pageNum) => {
+        if (pageNum === "ellipsis-start" || pageNum === "ellipsis-end") {
+          return (
+            <span
+              key={pageNum}
+              data-slot="pagination-ellipsis"
+              className="px-2 py-1 text-[var(--steel)]"
+              aria-hidden="true"
+            >
+              ...
+            </span>
+          );
+        }
+
+        const isCurrentPage = pageNum === page;
+        return (
+          <a
+            key={pageNum}
+            data-slot="pagination-page"
+            href={buildPageUrl(pageNum)}
+            className={cn(buttonBaseClass, isCurrentPage ? buttonActiveClass : buttonInactiveClass)}
+            aria-current={isCurrentPage ? "page" : undefined}
+          >
+            {pageNum}
+          </a>
+        );
+      })}
+
+      {/* Next button */}
+      {page < totalPages ? (
+        <a
+          data-slot="pagination-next"
+          href={buildPageUrl(page + 1)}
+          className={cn(buttonBaseClass, buttonInactiveClass)}
+          aria-label="Next page"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </a>
+      ) : (
+        <span
+          data-slot="pagination-next"
+          className={cn(buttonBaseClass, buttonDisabledClass)}
+          aria-disabled="true"
+          aria-label="Next page"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </span>
+      )}
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary

- Add **Pagination** component: Server-side pagination with ellipsis support for SSR-friendly navigation
- Add **BlankSlate** component: Empty state component with preset icons and custom LucideIcon support

## Changes

### Pagination
- Accessible navigation with proper ARIA labels
- Automatic ellipsis for large page counts
- Disabled state for first/last page boundaries
- Brutalist design with design tokens

### BlankSlate
- Preset icon options: inbox, alert-circle, search, file-question, folder-open, users
- Custom LucideIcon support via `icon` prop
- Optional action slot for buttons/links
- Brutalist design with design tokens

## Test plan

- [x] TypeScript type checking passes
- [x] All 198 Storybook interaction tests pass
- [x] Pagination tests cover: first page, middle page, last page, ellipsis states
- [x] BlankSlate tests verify title, description, and action rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)