### PR TITLE
fix(ci): add push trigger for changeset-release/main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - changeset-release/main
 
 jobs:
   check:


### PR DESCRIPTION
## Summary
- Adds push trigger for `changeset-release/main` branch to CI workflow
- Fixes #77 being blocked because CI never ran on release PR updates

## Problem
The release PR (changeset-release/main) was blocked by branch protection requiring "check" status. However, CI only triggered on `pull_request` events. Since Changesets uses `GITHUB_TOKEN` to push commits, those pushes don't trigger pull_request workflows (GitHub security design).

## Solution
Add a `push` trigger specifically for the `changeset-release/main` branch so CI runs when Changesets updates the release PR.

## Test plan
- [ ] Merge this PR
- [ ] Push to main to trigger release workflow
- [ ] Verify CI runs on changeset-release/main branch
- [ ] Verify PR #77 can be merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)