### PR TITLE
feat(components): add offset shadow system and new variants

### DIFF
--- a/.changeset/component-shadow-updates.md
+++ b/.changeset/component-shadow-updates.md
@@ -1,0 +1,11 @@
+---
+"@beaket/ui": minor
+---
+
+Add offset shadow system and new component variants
+
+- Button: Add offset shadow states, warning variant, mono prop
+- Badge: Add warning and code variants
+- Table: Add shadow prop, TableSectionHeader component
+- Card, Tabs: Add optional shadow prop
+- Dialog, Sheet, Dropdown, Tooltip: Add offset shadows

--- a/src/components/badge.stories.tsx
+++ b/src/components/badge.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof Badge> = {
   argTypes: {
     variant: {
       control: "select",
-      options: ["default", "secondary", "success", "error", "info", "outline"],
+      options: ["default", "secondary", "success", "error", "info", "outline", "warning", "code"],
     },
   },
 };
@@ -59,6 +59,20 @@ export const Outline: Story = {
   },
 };
 
+export const Warning: Story = {
+  args: {
+    children: "Warning",
+    variant: "warning",
+  },
+};
+
+export const Code: Story = {
+  args: {
+    children: "SPEC-001",
+    variant: "code",
+  },
+};
+
 // Compositions for docs
 export const AllVariants = () => (
   <div className="flex flex-wrap gap-2">
@@ -68,6 +82,8 @@ export const AllVariants = () => (
     <Badge variant="error">Error</Badge>
     <Badge variant="info">Info</Badge>
     <Badge variant="outline">Outline</Badge>
+    <Badge variant="warning">Warning</Badge>
+    <Badge variant="code">SPEC-001</Badge>
   </div>
 );
 

--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -6,7 +6,7 @@ const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
 export interface Props extends React.HTMLAttributes<HTMLSpanElement> {
   /** Badge style variant */
-  variant?: "default" | "secondary" | "success" | "error" | "info" | "outline";
+  variant?: "default" | "secondary" | "success" | "error" | "info" | "outline" | "warning" | "code";
 }
 
 export function Badge({ className, variant, ...props }: Props) {
@@ -26,6 +26,8 @@ const badgeVariants = cva(
         error: "bg-[var(--signal-red)] text-white border-[var(--signal-red)]",
         info: "bg-[var(--signal-blue)] text-white border-[var(--signal-blue)]",
         outline: "bg-transparent text-[var(--ink)] border-[var(--chrome)]",
+        warning: "bg-[var(--signal-amber)] text-[var(--graphite)] border-[var(--signal-amber)]",
+        code: "font-mono bg-[var(--frost)] text-[var(--ink)] border-[var(--chrome)]",
       },
     },
     defaultVariants: {

--- a/src/components/button.stories.tsx
+++ b/src/components/button.stories.tsx
@@ -18,6 +18,7 @@ const meta: Meta<typeof Button> = {
         "link",
         "success",
         "stark",
+        "warning",
       ],
     },
     size: {
@@ -28,6 +29,9 @@ const meta: Meta<typeof Button> = {
       control: "boolean",
     },
     disabled: {
+      control: "boolean",
+    },
+    mono: {
       control: "boolean",
     },
   },
@@ -92,6 +96,21 @@ export const Stark: Story = {
   },
 };
 
+export const Warning: Story = {
+  args: {
+    children: "Warning",
+    variant: "warning",
+  },
+};
+
+export const Mono: Story = {
+  args: {
+    children: "SUBMIT",
+    variant: "success",
+    mono: true,
+  },
+};
+
 export const Loading: Story = {
   args: {
     children: "Loading",
@@ -131,6 +150,24 @@ export const AllVariants = () => (
     <Button variant="link">Link</Button>
     <Button variant="success">Success</Button>
     <Button variant="stark">Stark</Button>
+    <Button variant="warning">Warning</Button>
+  </div>
+);
+
+export const MonoVariants = () => (
+  <div className="flex flex-wrap gap-2">
+    <Button variant="primary" mono>
+      SIGN IN
+    </Button>
+    <Button variant="success" mono>
+      SUBMIT
+    </Button>
+    <Button variant="destructive" mono>
+      DELETE
+    </Button>
+    <Button variant="warning" mono>
+      CONFIRM
+    </Button>
   </div>
 );
 
@@ -139,7 +176,7 @@ export const AllSizes = () => (
     <Button size="sm">Small</Button>
     <Button size="md">Medium</Button>
     <Button size="lg">Large</Button>
-    <Button size="icon">→</Button>
+    <Button size="icon">+</Button>
   </div>
 );
 

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -15,11 +15,14 @@ export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     | "ghost"
     | "link"
     | "success"
-    | "stark";
+    | "stark"
+    | "warning";
   /** Button size */
   size?: "sm" | "md" | "lg" | "icon";
   /** Shows a loading spinner and disables the button */
   loading?: boolean;
+  /** Use monospace font for CTA-style text */
+  mono?: boolean;
   /** Merges props onto the immediate child element instead of rendering a button */
   asChild?: boolean;
 }
@@ -31,6 +34,7 @@ export function Button({
   loading,
   disabled,
   children,
+  mono = false,
   asChild = false,
   ...props
 }: Props) {
@@ -38,7 +42,7 @@ export function Button({
 
   return (
     <Comp
-      className={cn(buttonVariants({ variant, size }), className)}
+      className={cn(buttonVariants({ variant, size, mono }), className)}
       disabled={!asChild ? disabled || loading : undefined}
       {...props}
     >
@@ -59,9 +63,13 @@ const buttonVariants = cva(
     "inline-flex items-center justify-center gap-2",
     "font-medium",
     "cursor-pointer",
-    "disabled:cursor-not-allowed disabled:border-dashed disabled:border-[var(--chrome)] disabled:bg-[var(--frost)] disabled:text-[var(--steel)]",
+    "shadow-offset",
+    "hover:shadow-offset-hover",
+    "active:shadow-offset-active",
+    "disabled:shadow-none disabled:cursor-not-allowed disabled:border-dashed disabled:border-[var(--chrome)] disabled:bg-[var(--frost)] disabled:text-[var(--steel)]",
     "focus-visible:outline-2 focus-visible:outline-[var(--signal-blue)] focus-visible:outline-offset-2",
     "[&_svg]:size-4",
+    "transition-shadow duration-100",
   ].join(" "),
   {
     variants: {
@@ -74,12 +82,15 @@ const buttonVariants = cva(
           "border border-[var(--chrome)] bg-transparent text-[var(--ink)] hover:bg-[var(--frost)] active:bg-[var(--platinum)]",
         secondary:
           "bg-[var(--frost)] text-[var(--ink)] border border-[var(--chrome)] hover:bg-[var(--platinum)] active:bg-[var(--silver)]",
-        ghost: "text-[var(--ink)] hover:bg-[var(--frost)] active:bg-[var(--platinum)]",
-        link: "text-[var(--signal-blue)] underline-offset-4 hover:underline",
+        ghost:
+          "text-[var(--ink)] hover:bg-[var(--frost)] active:bg-[var(--platinum)] shadow-none hover:shadow-none active:shadow-none",
+        link: "text-[var(--signal-blue)] underline-offset-4 hover:underline shadow-none hover:shadow-none active:shadow-none",
         success:
           "bg-[var(--signal-green)] text-[var(--paper)] border border-[var(--signal-green)] hover:bg-[#0f5f42] hover:border-[#0f5f42] active:bg-[#0a4a32] disabled:text-[var(--steel)] no-underline",
         stark:
           "border border-[var(--ink)] bg-transparent text-[var(--ink)] hover:bg-[var(--ink)] hover:text-[var(--paper)] active:bg-[var(--graphite)]",
+        warning:
+          "bg-[var(--signal-amber)] text-[var(--graphite)] border border-[var(--signal-amber)] hover:bg-[#9a7209] hover:border-[#9a7209] active:bg-[#7a5a07] disabled:text-[var(--steel)] no-underline",
       },
       size: {
         sm: "h-8 px-3 text-xs",
@@ -87,10 +98,15 @@ const buttonVariants = cva(
         lg: "h-10 px-6 text-sm",
         icon: "size-9 p-0",
       },
+      mono: {
+        true: "font-mono tracking-wide",
+        false: "",
+      },
     },
     defaultVariants: {
       variant: "primary",
       size: "md",
+      mono: false,
     },
   },
 );

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -3,12 +3,18 @@ import { twMerge } from "tailwind-merge";
 
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
-function CardRoot({ className, ...props }: React.ComponentProps<"div">) {
+interface CardRootProps extends React.ComponentProps<"div"> {
+  /** Add offset shadow to the card */
+  shadow?: boolean;
+}
+
+function CardRoot({ className, shadow, ...props }: CardRootProps) {
   return (
     <div
       data-slot="card"
       className={cn(
         "flex flex-col gap-0 border border-[var(--chrome)] bg-[var(--paper)] text-[var(--ink)]",
+        shadow && "shadow-offset",
         className,
       )}
       {...props}

--- a/src/components/dialog.tsx
+++ b/src/components/dialog.tsx
@@ -102,7 +102,7 @@ export function Dialog({
         />
         <DialogPrimitive.Content
           data-slot="dialog-content"
-          className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 border border-[var(--chrome)] bg-[var(--paper)] p-6 sm:max-w-lg"
+          className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 shadow-offset-dark fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 border border-[var(--chrome)] bg-[var(--paper)] p-6 sm:max-w-lg"
           onInteractOutside={preventClose ? (e) => e.preventDefault() : undefined}
           onEscapeKeyDown={preventClose ? (e) => e.preventDefault() : undefined}
         >

--- a/src/components/dropdown-menu.tsx
+++ b/src/components/dropdown-menu.tsx
@@ -35,7 +35,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] origin-[var(--radix-dropdown-menu-content-transform-origin)] overflow-x-hidden overflow-y-auto border border-[var(--ink)] bg-[var(--paper)] p-1 text-[var(--ink)]",
+          "shadow-offset z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] origin-[var(--radix-dropdown-menu-content-transform-origin)] overflow-x-hidden overflow-y-auto border border-[var(--ink)] bg-[var(--paper)] p-1 text-[var(--ink)]",
           "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
@@ -233,7 +233,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "z-50 min-w-[8rem] origin-[var(--radix-dropdown-menu-content-transform-origin)] overflow-hidden border border-[var(--ink)] bg-[var(--paper)] p-1 text-[var(--ink)]",
+        "shadow-offset z-50 min-w-[8rem] origin-[var(--radix-dropdown-menu-content-transform-origin)] overflow-hidden border border-[var(--ink)] bg-[var(--paper)] p-1 text-[var(--ink)]",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -14,7 +14,7 @@ export function Input({ className, type = "text", ...props }: Props) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-10 w-full px-3 text-sm",
+        "h-9 w-full px-3 text-sm",
         "bg-white text-[var(--ink)]",
         "border border-[var(--graphite)]",
         "placeholder:text-[var(--steel)]",

--- a/src/components/sheet.tsx
+++ b/src/components/sheet.tsx
@@ -111,7 +111,7 @@ export function Sheet({
         <DialogPrimitive.Content
           data-slot="sheet-content"
           className={cn(
-            "fixed z-50 gap-4 border border-[var(--chrome)] bg-[var(--paper)] p-4",
+            "shadow-offset-dark fixed z-50 gap-4 border border-[var(--chrome)] bg-[var(--paper)] p-4",
             sidePositions[side],
             sideAnimations[side],
           )}

--- a/src/components/table.stories.tsx
+++ b/src/components/table.stories.tsx
@@ -8,6 +8,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
+  TableSectionHeader,
 } from "./table";
 
 const meta: Meta<typeof Table> = {
@@ -29,11 +30,11 @@ type Story = StoryObj<typeof meta>;
 
 // Sample data
 const invoices = [
-  { id: "INV001", status: "Paid", method: "Credit Card", amount: "$250.00" },
-  { id: "INV002", status: "Pending", method: "PayPal", amount: "$150.00" },
-  { id: "INV003", status: "Unpaid", method: "Bank Transfer", amount: "$350.00" },
-  { id: "INV004", status: "Paid", method: "Credit Card", amount: "$450.00" },
-  { id: "INV005", status: "Paid", method: "PayPal", amount: "$550.00" },
+  { id: "INV001", status: "Paid", method: "Credit Card", amount: "¥25,000" },
+  { id: "INV002", status: "Pending", method: "PayPal", amount: "¥15,000" },
+  { id: "INV003", status: "Unpaid", method: "Bank Transfer", amount: "¥35,000" },
+  { id: "INV004", status: "Paid", method: "Credit Card", amount: "¥45,000" },
+  { id: "INV005", status: "Paid", method: "PayPal", amount: "¥55,000" },
 ];
 
 export const Default: Story = {
@@ -111,9 +112,72 @@ export const WithFooter: Story = {
       <TableFooter>
         <TableRow>
           <TableCell colSpan={3}>Total</TableCell>
-          <TableCell className="text-right">$1,750.00</TableCell>
+          <TableCell className="text-right">¥175,000</TableCell>
         </TableRow>
       </TableFooter>
+    </Table>
+  ),
+};
+
+export const WithShadow: Story = {
+  render: () => (
+    <Table shadow>
+      <TableHeader>
+        <TableRow>
+          <TableHead>Invoice</TableHead>
+          <TableHead>Status</TableHead>
+          <TableHead>Method</TableHead>
+          <TableHead className="text-right">Amount</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {invoices.slice(0, 3).map((invoice) => (
+          <TableRow key={invoice.id}>
+            <TableCell className="font-medium">{invoice.id}</TableCell>
+            <TableCell>{invoice.status}</TableCell>
+            <TableCell>{invoice.method}</TableCell>
+            <TableCell className="text-right">{invoice.amount}</TableCell>
+          </TableRow>
+        ))}
+      </TableBody>
+    </Table>
+  ),
+};
+
+export const WithSectionHeader: Story = {
+  render: () => (
+    <Table shadow>
+      <TableHeader>
+        <TableRow>
+          <TableHead>SKU</TableHead>
+          <TableHead>Product</TableHead>
+          <TableHead>Category</TableHead>
+          <TableHead className="text-right">Price</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell className="font-mono text-xs">SPEC-001</TableCell>
+          <TableCell>Widget Pro</TableCell>
+          <TableCell>Hardware</TableCell>
+          <TableCell className="text-right font-mono">¥7,500</TableCell>
+        </TableRow>
+        <TableSectionHeader>
+          <th colSpan={4}>Accessories</th>
+        </TableSectionHeader>
+        <TableRow>
+          <TableCell className="font-mono text-xs">SPEC-002</TableCell>
+          <TableCell>USB Cable</TableCell>
+          <TableCell>Accessory</TableCell>
+          <TableCell className="text-right font-mono">Incl.</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell className="font-mono text-xs">SPEC-003</TableCell>
+          <TableCell>Power Adapter</TableCell>
+          <TableCell>Accessory</TableCell>
+          <TableCell className="text-right font-mono">¥1,500</TableCell>
+        </TableRow>
+      </TableBody>
     </Table>
   ),
 };
@@ -135,12 +199,12 @@ export const AllVariants = () => (
           <TableRow>
             <TableCell>Alice</TableCell>
             <TableCell>Developer</TableCell>
-            <TableCell className="text-right">$120,000</TableCell>
+            <TableCell className="text-right">¥12,000,000</TableCell>
           </TableRow>
           <TableRow>
             <TableCell>Bob</TableCell>
             <TableCell>Designer</TableCell>
-            <TableCell className="text-right">$100,000</TableCell>
+            <TableCell className="text-right">¥10,000,000</TableCell>
           </TableRow>
         </TableBody>
       </Table>
@@ -157,17 +221,17 @@ export const AllVariants = () => (
         <TableBody>
           <TableRow>
             <TableCell>Product A</TableCell>
-            <TableCell className="text-right">$50.00</TableCell>
+            <TableCell className="text-right">¥5,000</TableCell>
           </TableRow>
           <TableRow>
             <TableCell>Product B</TableCell>
-            <TableCell className="text-right">$75.00</TableCell>
+            <TableCell className="text-right">¥7,500</TableCell>
           </TableRow>
         </TableBody>
         <TableFooter>
           <TableRow>
             <TableCell>Total</TableCell>
-            <TableCell className="text-right">$125.00</TableCell>
+            <TableCell className="text-right">¥12,500</TableCell>
           </TableRow>
         </TableFooter>
       </Table>

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -3,11 +3,20 @@ import { twMerge } from "tailwind-merge";
 
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
-export function Table({ className, ...props }: React.ComponentProps<"table">) {
+export interface TableProps extends React.ComponentProps<"table"> {
+  /** Add offset shadow to the table */
+  shadow?: boolean;
+}
+
+export function Table({ className, shadow, ...props }: TableProps) {
   return (
     <table
       data-slot="table"
-      className={cn("w-full caption-bottom text-sm tabular-nums", className)}
+      className={cn(
+        "w-full caption-bottom text-sm tabular-nums",
+        shadow && "shadow-offset",
+        className,
+      )}
       {...props}
     />
   );
@@ -18,7 +27,7 @@ export function TableHeader({ className, ...props }: React.ComponentProps<"thead
     <thead
       data-slot="table-header"
       className={cn(
-        "[&_tr]:border-b [&_tr]:border-[var(--chrome)] [&_tr]:bg-[var(--frost)]",
+        "[&_tr]:border-b [&_tr]:border-[var(--graphite)] [&_tr]:bg-[var(--frost)]",
         className,
       )}
       {...props}
@@ -67,7 +76,7 @@ export function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-9 px-2 py-1.5 text-left align-middle font-semibold whitespace-nowrap text-[var(--ink)] [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "h-9 px-1.5 py-1 text-left align-middle font-semibold whitespace-nowrap text-[var(--ink)] [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}
@@ -80,7 +89,20 @@ export function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "px-2 py-1.5 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "px-1.5 py-1 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function TableSectionHeader({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-section-header"
+      className={cn(
+        "bg-[var(--platinum)] [&>th]:border-y [&>th]:border-[var(--chrome)] [&>th]:px-1.5 [&>th]:py-1 [&>th]:font-semibold",
         className,
       )}
       {...props}

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -14,12 +14,18 @@ function TabsRoot({ className, ...props }: React.ComponentProps<typeof TabsPrimi
   );
 }
 
-function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) {
+interface TabsListProps extends React.ComponentProps<typeof TabsPrimitive.List> {
+  /** Add offset shadow to the tabs list */
+  shadow?: boolean;
+}
+
+function TabsList({ className, shadow, ...props }: TabsListProps) {
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
         "inline-flex h-9 w-fit items-center justify-center border border-[var(--chrome)] bg-[var(--frost)] p-[3px] text-[var(--ink)]",
+        shadow && "shadow-offset",
         className,
       )}
       {...props}

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -49,7 +49,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "z-50 overflow-hidden border border-[var(--ink)] bg-[var(--ink)] px-3 py-1.5 text-xs text-[var(--paper)]",
+          "shadow-offset z-50 overflow-hidden border border-[var(--ink)] bg-[var(--ink)] px-3 py-1.5 text-xs text-[var(--paper)]",
           "animate-in fade-in-0 zoom-in-95",
           "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
           "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",


### PR DESCRIPTION
## Summary
- Add offset shadow system to interactive components
- Add new Button variants (warning, mono)
- Add new Badge variants (warning, code)
- Add shadow prop to Table, Card, Tabs
- Add TableSectionHeader for grouped table rows

## Dependencies
This PR is based on #89 (docs/design-system-rules) which must be merged first.

## Changes

### Button
- Offset shadow: default 2px, hover 3px, active 1px
- New `warning` variant with signal-amber
- New `mono` prop for monospace CTA text

### Badge
- New `warning` variant
- New `code` variant with mono font

### Table
- New `shadow` prop
- New `TableSectionHeader` component for grouped rows
- Denser cell padding

### Card, Tabs
- New optional `shadow` prop

### Dialog, Sheet, Dropdown, Tooltip
- Add offset shadows for depth

## Test plan
- [x] TypeScript type check passes
- [x] All Storybook tests pass
- [ ] Visual review of shadow states

🤖 Generated with [Claude Code](https://claude.com/claude-code)