### PR TITLE
fix: consistent form control borders and navigation active text

### DIFF
--- a/.changeset/consistent-form-borders.md
+++ b/.changeset/consistent-form-borders.md
@@ -1,0 +1,10 @@
+---
+"@beaket/ui": patch
+---
+
+Fix consistent form control borders and navigation active text
+
+- Standardize border color to --graphite for Checkbox, Select, Textarea
+- Remove meaningless hover border changes
+- Add text-inverse utility for navigation active state
+- Fix docs global styles conflicting with component styles

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -129,17 +129,17 @@ pre code {
   padding: 0;
 }
 
-a {
+a:not([data-slot]) {
   color: var(--ink);
   text-decoration: none;
 }
-.main a {
+.main a:not([data-slot]) {
   text-decoration: underline;
 }
-.main a:hover {
+.main a:not([data-slot]):hover {
   background: var(--frost);
 }
-.main a:focus {
+.main a:not([data-slot]):focus {
   outline: 2px solid var(--ink);
   outline-offset: 2px;
 }

--- a/src/components/checkbox.tsx
+++ b/src/components/checkbox.tsx
@@ -15,9 +15,8 @@ export function Checkbox({ className, ...props }: Props) {
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer size-4 shrink-0 border border-[var(--chrome)]",
+        "peer size-4 shrink-0 border border-[var(--graphite)]",
         "bg-[var(--paper)]",
-        "hover:border-[var(--steel)]",
         "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--signal-blue)]",
         "data-[state=checked]:border-[var(--ink)] data-[state=checked]:bg-[var(--ink)] data-[state=checked]:text-[var(--paper)]",
         "disabled:cursor-not-allowed disabled:border-dashed disabled:border-[var(--chrome)] disabled:bg-[var(--frost)] disabled:text-[var(--steel)] disabled:hover:border-[var(--chrome)]",

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -18,7 +18,6 @@ export function Input({ className, type = "text", ...props }: Props) {
         "bg-white text-[var(--ink)]",
         "border border-[var(--graphite)]",
         "placeholder:text-[var(--steel)]",
-        "hover:border-[var(--ink)]",
         "focus:ring-2 focus:ring-[var(--signal-blue)] focus:ring-offset-1 focus:outline-none",
         "disabled:cursor-not-allowed disabled:border-dashed disabled:border-[var(--chrome)] disabled:bg-[var(--frost)] disabled:text-[var(--steel)]",
         "aria-[invalid=true]:border-[var(--signal-red)] aria-[invalid=true]:focus:ring-[var(--signal-red)]",

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -36,7 +36,7 @@ function NavigationLink({ className, active, ...props }: NavigationLinkProps) {
         "border border-[var(--graphite)] bg-white text-[var(--ink)]",
         "shadow-offset hover:shadow-offset-hover",
         "hover:bg-[var(--frost)]",
-        "data-[active]:bg-[var(--ink)] data-[active]:text-[var(--paper)]",
+        "data-[active]:text-inverse data-[active]:bg-[var(--ink)]",
         className,
       )}
       aria-current={active ? "page" : undefined}

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -31,7 +31,7 @@ function SelectTrigger({ className, size = "default", children, ...props }: Sele
       data-size={size}
       className={cn(
         "flex w-full items-center justify-between gap-2",
-        "border border-[var(--chrome)] bg-[var(--paper)] px-3 py-2 text-sm text-[var(--ink)]",
+        "border border-[var(--graphite)] bg-[var(--paper)] px-3 py-2 text-sm text-[var(--ink)]",
         "focus:border-[var(--signal-blue)] focus:outline-none",
         "disabled:cursor-not-allowed disabled:border-dashed disabled:bg-[var(--frost)] disabled:text-[var(--steel)]",
         "aria-[invalid=true]:border-[var(--signal-red)]",

--- a/src/components/textarea.tsx
+++ b/src/components/textarea.tsx
@@ -15,7 +15,7 @@ export function Textarea({ className, ...props }: Props) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border border-[var(--chrome)] bg-[var(--paper)] px-3 py-2 text-sm text-[var(--ink)]",
+        "border border-[var(--graphite)] bg-[var(--paper)] px-3 py-2 text-sm text-[var(--ink)]",
         "placeholder:text-[var(--steel)]",
         "focus:border-[var(--signal-blue)] focus:outline-none",
         "disabled:cursor-not-allowed disabled:border-dashed disabled:bg-[var(--frost)] disabled:text-[var(--steel)]",

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,6 +2,12 @@
 
 @theme {
   /* ===========================================
+   * COLOR UTILITIES
+   * Text colors based on design tokens
+   * =========================================== */
+  --color-inverse: var(--paper);
+
+  /* ===========================================
    * SHADOW UTILITIES
    * Offset shadows for brutalist design
    * =========================================== */


### PR DESCRIPTION
## Summary
- Standardize border color to `--graphite` for Checkbox, Select, Textarea (matching Input)
- Remove meaningless hover border changes (`--graphite` → `--ink` is barely visible)
- Add `text-inverse` utility for proper Navigation active state text color
- Exclude `data-slot` elements from docs global link styles to prevent style conflicts

## Test plan
- [ ] Verify Checkbox, Select, Textarea have consistent dark borders
- [ ] Verify Navigation active link shows white text on dark background in docs
- [ ] Verify no hover border flash on form controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)