### PR TITLE
ci(chromatic): auto-accept changes on main branch

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           buildScriptName: build-storybook
+          autoAcceptChanges: "main"
           onlyChanged: true
           exitZeroOnChanges: true
           exitOnceUploaded: true


### PR DESCRIPTION
## Summary
- Add `autoAcceptChanges: "main"` to Chromatic workflow
- Merge commits on main will auto-accept visual changes as new baseline
- PRs still require manual review for visual diffs

## Test plan
- [ ] Verify Chromatic still runs on PRs with visual diff review
- [ ] Verify merge to main auto-accepts changes without blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)