### PR TITLE
fix(docs): improve responsive layout for component detail pages

### DIFF
--- a/docs/src/components/example-section.astro
+++ b/docs/src/components/example-section.astro
@@ -18,11 +18,8 @@ const { componentName, storyName, displayName, source } = Astro.props;
     <StoryPreview componentName={componentName} storyName={storyName} client:visible />
   </div>
   {source && (
-    <details class="mt-2">
-      <summary class="cursor-pointer text-xs tracking-wide text-[var(--steel)] uppercase">
-        Code
-      </summary>
+    <div class="mt-2">
       <CodeBlock code={source} />
-    </details>
+    </div>
   )}
 </div>

--- a/docs/src/components/example-section.astro
+++ b/docs/src/components/example-section.astro
@@ -14,7 +14,7 @@ const { componentName, storyName, displayName, source } = Astro.props;
 
 <div>
   <h3>{displayName}</h3>
-  <div class="mt-2 border border-[var(--chrome)] bg-[var(--paper)] p-4">
+  <div class="preview-box mt-2 border border-[var(--chrome)] bg-[var(--paper)] p-4">
     <StoryPreview componentName={componentName} storyName={storyName} client:visible />
   </div>
   {source && (

--- a/docs/src/components/props-table.astro
+++ b/docs/src/components/props-table.astro
@@ -17,7 +17,8 @@ const { props } = Astro.props;
 {props.length === 0 ? (
   <p class="text-sm text-[var(--steel)]">—</p>
 ) : (
-  <table class="w-full font-mono text-xs">
+  <div class="overflow-x-auto">
+  <table class="w-full min-w-[500px] font-mono text-xs">
     <thead>
       <tr class="border-b border-[var(--chrome)] text-left tracking-wide text-[var(--steel)] uppercase">
         <th class="py-1.5 pr-3 font-medium">Name</th>
@@ -40,4 +41,5 @@ const { props } = Astro.props;
       ))}
     </tbody>
   </table>
+  </div>
 )}

--- a/docs/src/layouts/doc.astro
+++ b/docs/src/layouts/doc.astro
@@ -22,26 +22,33 @@ const components = registry.components;
   <body>
     <div class="layout">
       <nav class="sidebar">
-        <a href="/ui/" class="sidebar-title">Beaket UI</a>
-        <div class="sidebar-version">v{pkg.version}</div>
-
-        <div class="sidebar-section">
-          <div class="sidebar-section-title">Getting Started</div>
-          <a href="/ui/" class:list={["sidebar-link", { active: currentPath === '/ui/' }]}>Introduction</a>
-          <a href="/ui/installation" class:list={["sidebar-link", { active: currentPath.includes('/installation') }]}>Installation</a>
+        <div class="sidebar-header">
+          <a href="/ui/" class="sidebar-title">Beaket UI</a>
+          <span class="sidebar-version">v{pkg.version}</span>
+          <button class="sidebar-toggle" aria-label="Toggle menu" aria-expanded="false">
+            <span class="sidebar-toggle-icon"></span>
+          </button>
         </div>
 
-        <div class="sidebar-section">
-          <div class="sidebar-section-title">Components</div>
-          {components.map((component) => (
-            <a href={`/ui/components/${component.name}`} class:list={["sidebar-link", { active: currentPath.includes(`/components/${component.name}`) }]}>{component.docs.title}</a>
-          ))}
-        </div>
+        <div class="sidebar-nav">
+          <div class="sidebar-section">
+            <div class="sidebar-section-title">Getting Started</div>
+            <a href="/ui/" class:list={["sidebar-link", { active: currentPath === '/ui/' }]}>Introduction</a>
+            <a href="/ui/installation" class:list={["sidebar-link", { active: currentPath.includes('/installation') }]}>Installation</a>
+          </div>
 
-        <div class="sidebar-section">
-          <div class="sidebar-section-title">Links</div>
-          <a href="https://github.com/beaket/ui" class="sidebar-link">GitHub</a>
-          <a href="https://www.npmjs.com/package/@beaket/ui" class="sidebar-link">npm</a>
+          <div class="sidebar-section">
+            <div class="sidebar-section-title">Components</div>
+            {components.map((component) => (
+              <a href={`/ui/components/${component.name}`} class:list={["sidebar-link", { active: currentPath.includes(`/components/${component.name}`) }]}>{component.docs.title}</a>
+            ))}
+          </div>
+
+          <div class="sidebar-section">
+            <div class="sidebar-section-title">Links</div>
+            <a href="https://github.com/beaket/ui" class="sidebar-link">GitHub</a>
+            <a href="https://www.npmjs.com/package/@beaket/ui" class="sidebar-link">npm</a>
+          </div>
         </div>
       </nav>
 
@@ -49,5 +56,14 @@ const components = registry.components;
         <slot />
       </main>
     </div>
+    <script>
+      const toggle = document.querySelector('.sidebar-toggle');
+      const nav = document.querySelector('.sidebar-nav');
+      toggle?.addEventListener('click', () => {
+        const expanded = toggle.getAttribute('aria-expanded') === 'true';
+        toggle.setAttribute('aria-expanded', String(!expanded));
+        nav?.classList.toggle('open');
+      });
+    </script>
   </body>
 </html>

--- a/docs/src/pages/components/[name].astro
+++ b/docs/src/pages/components/[name].astro
@@ -56,7 +56,7 @@ const sectionData = sections.map((sectionName) => ({
     <header>
       <h1>{docs?.title ?? name}</h1>
       <p class="tagline">{docs?.tagline ?? component.description}</p>
-      <div class="mt-2 border border-[var(--chrome)] bg-[var(--paper)] p-4">
+      <div class="preview-box mt-2 border border-[var(--chrome)] bg-[var(--paper)] p-4">
         <StoryPreview componentName={name} client:visible />
       </div>
     </header>

--- a/docs/src/pages/components/[name].astro
+++ b/docs/src/pages/components/[name].astro
@@ -62,7 +62,7 @@ const nextComponent = currentIndex < registry.components.length - 1 ? registry.c
       <h1>{docs?.title ?? name}</h1>
       <p class="tagline">{docs?.tagline ?? component.description}</p>
       <div class="preview-box mt-2 border border-[var(--chrome)] bg-[var(--paper)] p-4">
-        <StoryPreview componentName={name} client:visible />
+        <StoryPreview componentName={name} storyName={docs?.previewStory} client:visible />
       </div>
     </header>
 

--- a/docs/src/pages/components/[name].astro
+++ b/docs/src/pages/components/[name].astro
@@ -48,6 +48,11 @@ const sectionData = sections.map((sectionName) => ({
   displayName: formatExportName(sectionName),
   source: parsedSources.get(sectionName) ?? '',
 }));
+
+// Get prev/next components
+const currentIndex = registry.components.findIndex((c) => c.name === name);
+const prevComponent = currentIndex > 0 ? registry.components[currentIndex - 1] : null;
+const nextComponent = currentIndex < registry.components.length - 1 ? registry.components[currentIndex + 1] : null;
 ---
 
 <Layout title={docs?.title ?? name}>
@@ -93,5 +98,19 @@ const sectionData = sections.map((sectionName) => ({
       <h2>Props</h2>
       <PropsTable props={props} />
     </section>
+
+    <!-- Prev/Next Navigation -->
+    <nav class="component-nav">
+      {prevComponent ? (
+        <a href={`/ui/components/${prevComponent.name}`} class="component-nav-link">
+          ← {prevComponent.docs.title}
+        </a>
+      ) : <div />}
+      {nextComponent ? (
+        <a href={`/ui/components/${nextComponent.name}`} class="component-nav-link next">
+          {nextComponent.docs.title} →
+        </a>
+      ) : <div />}
+    </nav>
   </div>
 </Layout>

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -178,7 +178,7 @@ summary:focus-visible {
 /* Sidebar toggle (hidden on desktop) */
 .sidebar-header {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   gap: 0.5rem;
 }
 

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -175,6 +175,30 @@ summary:focus-visible {
   border-bottom: none;
 }
 
+/* Component prev/next navigation */
+.component-nav {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--chrome);
+}
+
+.component-nav-link {
+  font-size: 0.75rem;
+  color: var(--ink);
+  text-decoration: none;
+}
+
+.component-nav-link.next {
+  text-align: right;
+}
+
+.component-nav-link:hover {
+  text-decoration: underline;
+}
+
 /* Sidebar toggle (hidden on desktop) */
 .sidebar-header {
   display: flex;

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -175,6 +175,48 @@ summary:focus-visible {
   border-bottom: none;
 }
 
+/* Sidebar toggle (hidden on desktop) */
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.sidebar-toggle {
+  display: none;
+  background: none;
+  border: 1px solid var(--chrome);
+  padding: 0.25rem;
+  cursor: pointer;
+  margin-left: auto;
+}
+
+.sidebar-toggle-icon {
+  display: block;
+  width: 14px;
+  height: 2px;
+  background: var(--ink);
+  position: relative;
+}
+
+.sidebar-toggle-icon::before,
+.sidebar-toggle-icon::after {
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 2px;
+  background: var(--ink);
+  left: 0;
+}
+
+.sidebar-toggle-icon::before {
+  top: -5px;
+}
+
+.sidebar-toggle-icon::after {
+  top: 5px;
+}
+
 /* Responsive: Mobile (<768px) */
 @media (max-width: 767px) {
   .layout {
@@ -191,9 +233,12 @@ summary:focus-visible {
     overflow-y: visible;
   }
 
+  .sidebar-header {
+    margin-bottom: 0;
+  }
+
   .sidebar-title {
     display: inline;
-    margin-right: 0.5rem;
   }
 
   .sidebar-version {
@@ -201,20 +246,32 @@ summary:focus-visible {
     margin-bottom: 0;
   }
 
+  .sidebar-toggle {
+    display: block;
+  }
+
+  .sidebar-nav {
+    display: none;
+    padding-top: 0.75rem;
+  }
+
+  .sidebar-nav.open {
+    display: block;
+  }
+
   .sidebar-section {
-    display: inline;
-    margin-bottom: 0;
-    margin-right: 1rem;
+    display: block;
+    margin-bottom: 0.5rem;
   }
 
   .sidebar-section-title {
-    display: none;
+    display: block;
+    margin-top: 0.5rem;
   }
 
   .sidebar-link {
-    display: inline;
-    padding: 0.25rem 0.5rem;
-    margin-right: 0.25rem;
+    display: block;
+    padding: 0.25rem 0;
   }
 
   .main {
@@ -225,5 +282,10 @@ summary:focus-visible {
 
   pre {
     font-size: 0.75rem;
+  }
+
+  /* Responsive preview boxes */
+  .preview-box {
+    padding: 0.75rem;
   }
 }

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -24,7 +24,7 @@
         "title": "Breadcrumb",
         "tagline": "A navigation trail showing the user's location within a site hierarchy.",
         "sections": ["AllVariants"],
-        "usage": "<Breadcrumb><Breadcrumb.List><Breadcrumb.Item><Breadcrumb.Link href=\"/\">Home</Breadcrumb.Link></Breadcrumb.Item></Breadcrumb.List></Breadcrumb>",
+        "usage": "<Breadcrumb>\n  <Breadcrumb.List>\n    <Breadcrumb.Item>\n      <Breadcrumb.Link href=\"/\">Home</Breadcrumb.Link>\n    </Breadcrumb.Item>\n  </Breadcrumb.List>\n</Breadcrumb>",
         "previewStory": "Default"
       }
     },
@@ -38,7 +38,7 @@
         "title": "Navigation",
         "tagline": "A primary navigation component with active state indicators.",
         "sections": ["AllVariants"],
-        "usage": "<Navigation><Navigation.List><Navigation.Item><Navigation.Link href=\"/\" active>Home</Navigation.Link></Navigation.Item></Navigation.List></Navigation>",
+        "usage": "<Navigation>\n  <Navigation.List>\n    <Navigation.Item>\n      <Navigation.Link href=\"/\" active>Home</Navigation.Link>\n    </Navigation.Item>\n  </Navigation.List>\n</Navigation>",
         "previewStory": "Default"
       }
     },
@@ -66,7 +66,7 @@
         "title": "Avatar",
         "tagline": "A visual representation of a user with image and fallback support.",
         "sections": ["AllStates", "CustomSizes", "AvatarGroup"],
-        "usage": "<Avatar><Avatar.Image src=\"/user.png\" alt=\"User\" /><Avatar.Fallback>JD</Avatar.Fallback></Avatar>",
+        "usage": "<Avatar>\n  <Avatar.Image src=\"/user.png\" alt=\"User\" />\n  <Avatar.Fallback>JD</Avatar.Fallback>\n</Avatar>",
         "previewStory": "AvatarGroup"
       }
     },
@@ -155,7 +155,7 @@
         "title": "Radio",
         "tagline": "A control for selecting one option from a set of choices.",
         "sections": ["AllStates"],
-        "usage": "<RadioGroup defaultValue=\"option1\"><RadioItem value=\"option1\" /><RadioItem value=\"option2\" /></RadioGroup>",
+        "usage": "<RadioGroup defaultValue=\"option1\">\n  <RadioItem value=\"option1\" />\n  <RadioItem value=\"option2\" />\n</RadioGroup>",
         "previewStory": "AllStates"
       }
     },
@@ -169,7 +169,7 @@
         "title": "Select",
         "tagline": "A dropdown for selecting from a list of options.",
         "sections": ["AllStates", "WithGroups"],
-        "usage": "<Select><Select.Trigger><Select.Value placeholder=\"Select...\" /></Select.Trigger><Select.Content><Select.Item value=\"1\">Option</Select.Item></Select.Content></Select>",
+        "usage": "<Select>\n  <Select.Trigger>\n    <Select.Value placeholder=\"Select...\" />\n  </Select.Trigger>\n  <Select.Content>\n    <Select.Item value=\"1\">Option</Select.Item>\n  </Select.Content>\n</Select>",
         "previewStory": "Default"
       }
     },
@@ -216,7 +216,7 @@
         "title": "Table",
         "tagline": "A semantic HTML table with styled components.",
         "sections": ["AllVariants"],
-        "usage": "<Table><TableHeader><TableRow><TableHead>Column</TableHead></TableRow></TableHeader><TableBody><TableRow><TableCell>Data</TableCell></TableRow></TableBody></Table>",
+        "usage": "<Table>\n  <TableHeader>\n    <TableRow>\n      <TableHead>Column</TableHead>\n    </TableRow>\n  </TableHeader>\n  <TableBody>\n    <TableRow>\n      <TableCell>Data</TableCell>\n    </TableRow>\n  </TableBody>\n</Table>",
         "previewStory": "Default",
         "span": 2
       }
@@ -231,7 +231,7 @@
         "title": "Card",
         "tagline": "A versatile container for grouping related content and actions.",
         "sections": ["AllStates"],
-        "usage": "<Card><Card.Header><Card.Title>Title</Card.Title></Card.Header><Card.Content>Content</Card.Content></Card>",
+        "usage": "<Card>\n  <Card.Header>\n    <Card.Title>Title</Card.Title>\n  </Card.Header>\n  <Card.Content>Content</Card.Content>\n</Card>",
         "previewStory": "Default"
       }
     },
@@ -245,7 +245,7 @@
         "title": "Tabs",
         "tagline": "A set of layered sections of content that display one panel at a time.",
         "sections": ["AllStates"],
-        "usage": "<Tabs defaultValue=\"tab1\"><Tabs.List><Tabs.Trigger value=\"tab1\">Tab 1</Tabs.Trigger></Tabs.List><Tabs.Content value=\"tab1\">Content</Tabs.Content></Tabs>",
+        "usage": "<Tabs defaultValue=\"tab1\">\n  <Tabs.List>\n    <Tabs.Trigger value=\"tab1\">Tab 1</Tabs.Trigger>\n  </Tabs.List>\n  <Tabs.Content value=\"tab1\">Content</Tabs.Content>\n</Tabs>",
         "previewStory": "Default"
       }
     },
@@ -273,7 +273,7 @@
         "title": "Tooltip",
         "tagline": "A popup that displays information related to an element on hover.",
         "sections": ["AllStates", "Positions"],
-        "usage": "<TooltipProvider><Tooltip><Tooltip.Trigger>Hover me</Tooltip.Trigger><Tooltip.Content>Tooltip text</Tooltip.Content></Tooltip></TooltipProvider>",
+        "usage": "<TooltipProvider>\n  <Tooltip>\n    <Tooltip.Trigger>Hover me</Tooltip.Trigger>\n    <Tooltip.Content>Tooltip text</Tooltip.Content>\n  </Tooltip>\n</TooltipProvider>",
         "previewStory": "Default"
       }
     },
@@ -301,7 +301,7 @@
         "title": "Dialog",
         "tagline": "A modal dialog for confirmations, forms, and alerts.",
         "sections": ["AllStates"],
-        "usage": "<Dialog trigger={<Button>Open</Button>}><Dialog.Header><Dialog.Title>Title</Dialog.Title></Dialog.Header></Dialog>",
+        "usage": "<Dialog trigger={<Button>Open</Button>}>\n  <Dialog.Header>\n    <Dialog.Title>Title</Dialog.Title>\n  </Dialog.Header>\n</Dialog>",
         "previewStory": "Default"
       }
     },
@@ -315,7 +315,7 @@
         "title": "Sheet",
         "tagline": "A slide-out panel that can appear from any edge of the screen.",
         "sections": ["AllStates"],
-        "usage": "<Sheet trigger={<Button>Open</Button>}><Sheet.Header><Sheet.Title>Title</Sheet.Title></Sheet.Header></Sheet>",
+        "usage": "<Sheet trigger={<Button>Open</Button>}>\n  <Sheet.Header>\n    <Sheet.Title>Title</Sheet.Title>\n  </Sheet.Header>\n</Sheet>",
         "previewStory": "Default"
       }
     },
@@ -329,7 +329,7 @@
         "title": "DropdownMenu",
         "tagline": "A menu of actions or options triggered by a button.",
         "sections": ["AllStates"],
-        "usage": "<DropdownMenu><DropdownMenu.Trigger asChild><Button>Open</Button></DropdownMenu.Trigger><DropdownMenu.Content><DropdownMenu.Item>Action</DropdownMenu.Item></DropdownMenu.Content></DropdownMenu>",
+        "usage": "<DropdownMenu>\n  <DropdownMenu.Trigger asChild>\n    <Button>Open</Button>\n  </DropdownMenu.Trigger>\n  <DropdownMenu.Content>\n    <DropdownMenu.Item>Action</DropdownMenu.Item>\n  </DropdownMenu.Content>\n</DropdownMenu>",
         "previewStory": "Default"
       }
     },


### PR DESCRIPTION
## Summary
- Add horizontal scroll wrapper to props table for mobile viewports
- Add collapsible hamburger menu for sidebar navigation on mobile
- Add responsive padding for preview boxes on mobile

## Test plan
- [ ] Resize browser to mobile width (<768px)
- [ ] Verify props table scrolls horizontally
- [ ] Verify hamburger menu toggles navigation visibility
- [ ] Verify preview boxes have reduced padding on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)