### PR TITLE
chore: add MIT LICENSE and docs footer

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Beaket
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/src/layouts/doc.astro
+++ b/docs/src/layouts/doc.astro
@@ -9,6 +9,7 @@ interface Props {
 const { title = 'Beaket UI' } = Astro.props;
 const currentPath = Astro.url.pathname;
 const components = registry.components;
+const currentYear = new Date().getFullYear();
 ---
 
 <!doctype html>
@@ -54,6 +55,15 @@ const components = registry.components;
 
       <main class="main">
         <slot />
+        <footer class="site-footer">
+          <span>© {currentYear} Beaket</span>
+          <span class="footer-sep">·</span>
+          <a href="https://github.com/beaket/ui/blob/main/LICENSE">MIT License</a>
+          <span class="footer-sep">·</span>
+          <a href="https://github.com/beaket/ui">GitHub</a>
+          <span class="footer-sep">·</span>
+          <a href="https://www.npmjs.com/package/@beaket/ui">npm</a>
+        </footer>
       </main>
     </div>
     <script>

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -3,6 +3,8 @@ import '../styles/global.css';
 import { ComponentShowcase } from '../components/component-showcase';
 import registry from '../../../registry/registry.json';
 import pkg from '../../../packages/cli/package.json';
+
+const currentYear = new Date().getFullYear();
 ---
 
 <!doctype html>
@@ -16,6 +18,15 @@ import pkg from '../../../packages/cli/package.json';
   <body class="min-h-screen bg-[var(--paper)]">
     <main class="mx-auto max-w-4xl p-4">
       <ComponentShowcase client:load components={registry.components} version={pkg.version} />
+      <footer class="site-footer mt-8">
+        <span>© {currentYear} Beaket</span>
+        <span class="footer-sep">·</span>
+        <a href="https://github.com/beaket/ui/blob/main/LICENSE">MIT License</a>
+        <span class="footer-sep">·</span>
+        <a href="https://github.com/beaket/ui">GitHub</a>
+        <span class="footer-sep">·</span>
+        <a href="https://www.npmjs.com/package/@beaket/ui">npm</a>
+      </footer>
     </main>
   </body>
 </html>

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -199,6 +199,29 @@ summary:focus-visible {
   text-decoration: underline;
 }
 
+/* Site footer */
+.site-footer {
+  margin-top: 3rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--chrome);
+  font-size: 0.6875rem;
+  color: var(--steel);
+}
+
+.site-footer a {
+  color: var(--steel);
+  text-decoration: none;
+}
+
+.site-footer a:hover {
+  color: var(--ink);
+  text-decoration: underline;
+}
+
+.footer-sep {
+  margin: 0 0.5rem;
+}
+
 /* Sidebar toggle (hidden on desktop) */
 .sidebar-header {
   display: flex;


### PR DESCRIPTION
## Summary
- Add MIT LICENSE file to repo root
- Add footer with `© {year} Beaket · MIT License · GitHub · npm`
- Footer appears on both showcase and component detail pages
- Year is dynamically generated

## Test plan
- [ ] Verify LICENSE file exists at repo root
- [ ] Verify footer displays on showcase page
- [ ] Verify footer displays on component detail pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)