### PR TITLE
chore: automerge only non-major updates in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
-  "automerge": true
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Update Renovate config to only automerge minor and patch updates
- Major updates will require manual review

## Reference
https://docs.renovatebot.com/key-concepts/automerge/#automerge-non-major-updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)