### PR TITLE
feat(cli): auto-detect component path based on tsconfig alias

### DIFF
--- a/.changeset/cli-alias-detection.md
+++ b/.changeset/cli-alias-detection.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": minor
+---
+
+Auto-detect component path based on tsconfig alias configuration

--- a/docs/src/pages/components/[name].astro
+++ b/docs/src/pages/components/[name].astro
@@ -38,7 +38,7 @@ const parsedSources = storySource ? extractExports(storySource) : new Map();
 
 // Generate usage code
 const pascalName = name.charAt(0).toUpperCase() + name.slice(1);
-const usageCode = `import { ${pascalName} } from "@beaket/ui/${name}"
+const usageCode = `import { ${pascalName} } from "@/components/ui/${name}"
 
 ${docs?.usage ?? `<${pascalName} />`}`;
 

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -14,7 +14,7 @@ export async function add(componentName: string, options: AddOptions) {
   // Read config
   const config = await getConfig();
   if (!config) {
-    console.log(pc.red("Error:"), "beaket.json not found.");
+    console.log(pc.red("Error:"), "beaket.ui.json not found.");
     console.log("Run", pc.cyan("npx @beaket/ui init"), "first.");
     process.exit(1);
   }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -24,7 +24,7 @@ async function detectAliasPath(): Promise<string> {
         if (paths?.["@/*"]) {
           const aliasPath = paths["@/*"][0];
           // "./src/*" -> "src", "./*" -> ""
-          const prefix = aliasPath.replace(/^\.\//, "").replace(/\/\*$/, "");
+          const prefix = aliasPath.replace(/^\.\/|\/?\*$/g, "");
           return prefix ? `${prefix}/components/ui` : "components/ui";
         }
       } catch {

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -4,6 +4,75 @@ import pc from "picocolors";
 import prompts from "prompts";
 import { writeConfig, type BeaketConfig } from "../utils/config.ts";
 
+interface TsConfig {
+  compilerOptions?: {
+    paths?: Record<string, string[]>;
+  };
+}
+
+async function detectAliasPath(): Promise<string> {
+  const cwd = process.cwd();
+
+  // Try to read tsconfig.json or tsconfig.app.json
+  for (const configFile of ["tsconfig.json", "tsconfig.app.json"]) {
+    const configPath = path.join(cwd, configFile);
+    if (await fs.pathExists(configPath)) {
+      try {
+        const content = await fs.readFile(configPath, "utf-8");
+        const tsconfig: TsConfig = JSON.parse(content);
+        const paths = tsconfig.compilerOptions?.paths;
+        if (paths?.["@/*"]) {
+          const aliasPath = paths["@/*"][0];
+          // "./src/*" -> "src", "./*" -> ""
+          const prefix = aliasPath.replace(/^\.\//, "").replace(/\/\*$/, "");
+          return prefix ? `${prefix}/components/ui` : "components/ui";
+        }
+      } catch {
+        // Ignore parse errors
+      }
+    }
+  }
+
+  // Fallback: detect from package.json
+  const pkgPath = path.join(cwd, "package.json");
+  if (await fs.pathExists(pkgPath)) {
+    try {
+      const content = await fs.readFile(pkgPath, "utf-8");
+      const pkg = JSON.parse(content);
+      const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+      // Next.js uses root alias by default
+      if (deps.next) {
+        return "components/ui";
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  // Default to src/components/ui (Vite style)
+  return "src/components/ui";
+}
+
+async function detectCssPath(): Promise<string> {
+  const cwd = process.cwd();
+  const pkgPath = path.join(cwd, "package.json");
+
+  if (await fs.pathExists(pkgPath)) {
+    try {
+      const content = await fs.readFile(pkgPath, "utf-8");
+      const pkg = JSON.parse(content);
+      const deps = { ...pkg.dependencies, ...pkg.devDependencies };
+      if (deps.next) {
+        return "app/globals.css";
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }
+
+  return "src/index.css";
+}
+
 const CSS_VARIABLES = `
 /* Beaket UI Design System */
 @theme {
@@ -42,18 +111,22 @@ export async function init() {
   console.log(pc.bold("Initializing Beaket UI..."));
   console.log();
 
+  // Auto-detect defaults based on project structure
+  const detectedComponentsPath = await detectAliasPath();
+  const detectedCssPath = await detectCssPath();
+
   const response = await prompts([
     {
       type: "text",
       name: "components",
       message: "Where should components be installed?",
-      initial: "src/components/ui",
+      initial: detectedComponentsPath,
     },
     {
       type: "text",
       name: "css",
       message: "Where is your Tailwind CSS file?",
-      initial: "src/index.css",
+      initial: detectedCssPath,
     },
   ]);
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -135,14 +135,14 @@ export async function init() {
     process.exit(1);
   }
 
-  // Write beaket.json (only components path)
+  // Write beaket.ui.json (only components path)
   const config: BeaketConfig = {
     $schema: "https://beaket.dev/schema.json",
     components: response.components,
   };
 
   await writeConfig(config);
-  console.log(pc.green("✔"), "Created beaket.json");
+  console.log(pc.green("✔"), "Created beaket.ui.json");
 
   // Inject CSS variables into Tailwind CSS file
   if (response.css) {

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -6,7 +6,7 @@ export interface BeaketConfig {
   components: string;
 }
 
-const CONFIG_FILE = "beaket.json";
+const CONFIG_FILE = "beaket.ui.json";
 
 export async function getConfig(): Promise<BeaketConfig | null> {
   const configPath = path.join(process.cwd(), CONFIG_FILE);


### PR DESCRIPTION
## Summary

- CLI now auto-detects the correct component installation path based on tsconfig alias configuration
- Supports both Vite (`@/` = `./src/`) and Next.js (`@/` = `./`) projects
- Also auto-detects CSS file path (`src/index.css` for Vite, `app/globals.css` for Next.js)
- Updates docs to use `@/components/ui/` import path instead of `@beaket/ui/`

## Detection Logic

1. Read `tsconfig.json` or `tsconfig.app.json` for `compilerOptions.paths`
2. If `@/*` maps to `./src/*` → use `src/components/ui`
3. If `@/*` maps to `./*` → use `components/ui`
4. Fallback: check `package.json` for `next` dependency
5. Default: `src/components/ui`

## Result

| Framework | `@/` alias | Install path | Import |
|-----------|-----------|--------------|--------|
| Vite | `./src/*` | `src/components/ui/` | `@/components/ui/button` |
| Next.js | `./*` | `components/ui/` | `@/components/ui/button` |

Users can copy the import directly from docs - it works for both frameworks.

## Test plan

- [ ] Run `npx @beaket/ui init` in a Vite project - should default to `src/components/ui`
- [ ] Run `npx @beaket/ui init` in a Next.js project - should default to `components/ui`
- [ ] Verify docs show `@/components/ui/` import path

🤖 Generated with [Claude Code](https://claude.ai/code)