### PR TITLE
docs: simplify component pages by showing import only

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,27 @@ pnpm dev
 2. Create `src/components/[name].stories.tsx`
 3. Add entry to `registry/registry.json`
 
+### registry.json format
+
+```json
+{
+  "name": "component-name",
+  "description": "Brief description",
+  "dependencies": ["npm-packages"],
+  "registryDependencies": [],
+  "files": ["components/component-name.tsx"],
+  "docs": {
+    "title": "ComponentName",
+    "tagline": "One-line description for docs",
+    "sections": ["AllStates"],
+    "previewStory": "Default"
+  }
+}
+```
+
+- `sections`: Story export names to show in docs Examples section
+- `previewStory`: Story to show in the preview box
+
 ## Commands
 
 | Command          | Description     |

--- a/docs/src/pages/components/[name].astro
+++ b/docs/src/pages/components/[name].astro
@@ -36,11 +36,9 @@ const storyPath = Object.keys(storySources).find((path) =>
 const storySource = storyPath ? storySources[storyPath] : '';
 const parsedSources = storySource ? extractExports(storySource) : new Map();
 
-// Generate usage code
+// Generate import statement
 const pascalName = name.charAt(0).toUpperCase() + name.slice(1);
-const usageCode = `import { ${pascalName} } from "@/components/ui/${name}"
-
-${docs?.usage ?? `<${pascalName} />`}`;
+const importCode = `import { ${pascalName} } from "@/components/ui/${name}"`;
 
 // Prepare section data
 const sectionData = sections.map((sectionName) => ({
@@ -72,10 +70,10 @@ const nextComponent = currentIndex < registry.components.length - 1 ? registry.c
       <CodeBlock code={`npx @beaket/ui add ${name}`} lang="bash" />
     </section>
 
-    <!-- Usage -->
+    <!-- Import -->
     <section>
-      <h2>Usage</h2>
-      <CodeBlock code={usageCode} />
+      <h2>Import</h2>
+      <CodeBlock code={importCode} />
     </section>
 
     <!-- Examples -->

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -10,7 +10,6 @@
         "title": "Blockquote",
         "tagline": "A styled quotation block with optional author and source attribution.",
         "sections": ["AllVariants"],
-        "usage": "<Blockquote author=\"Author Name\">Quote text here.</Blockquote>",
         "previewStory": "Default"
       }
     },
@@ -24,7 +23,6 @@
         "title": "Breadcrumb",
         "tagline": "A navigation trail showing the user's location within a site hierarchy.",
         "sections": ["AllVariants"],
-        "usage": "<Breadcrumb>\n  <Breadcrumb.List>\n    <Breadcrumb.Item>\n      <Breadcrumb.Link href=\"/\">Home</Breadcrumb.Link>\n    </Breadcrumb.Item>\n  </Breadcrumb.List>\n</Breadcrumb>",
         "previewStory": "Default"
       }
     },
@@ -38,7 +36,6 @@
         "title": "Navigation",
         "tagline": "A primary navigation component with active state indicators.",
         "sections": ["AllVariants"],
-        "usage": "<Navigation>\n  <Navigation.List>\n    <Navigation.Item>\n      <Navigation.Link href=\"/\" active>Home</Navigation.Link>\n    </Navigation.Item>\n  </Navigation.List>\n</Navigation>",
         "previewStory": "Default"
       }
     },
@@ -52,7 +49,6 @@
         "title": "Alert",
         "tagline": "A callout for displaying important information with semantic variants.",
         "sections": ["AllStates", "AllVariants"],
-        "usage": "<Alert variant=\"warning\">Important message here.</Alert>",
         "previewStory": "Default"
       }
     },
@@ -66,7 +62,6 @@
         "title": "Avatar",
         "tagline": "A visual representation of a user with image and fallback support.",
         "sections": ["AllStates", "CustomSizes", "AvatarGroup"],
-        "usage": "<Avatar>\n  <Avatar.Image src=\"/user.png\" alt=\"User\" />\n  <Avatar.Fallback>JD</Avatar.Fallback>\n</Avatar>",
         "previewStory": "AvatarGroup"
       }
     },
@@ -80,7 +75,6 @@
         "title": "Badge",
         "tagline": "A compact label for status indicators, categories, and counts.",
         "sections": ["AllVariants"],
-        "usage": "<Badge>Label</Badge>",
         "previewStory": "AllVariants"
       }
     },
@@ -99,7 +93,6 @@
         "title": "Button",
         "tagline": "Clickable button with multiple variants and sizes.",
         "sections": ["AllVariants", "AllSizes", "AllStates"],
-        "usage": "<Button>Click me</Button>",
         "previewStory": "AllVariants"
       }
     },
@@ -113,7 +106,6 @@
         "title": "Checkbox",
         "tagline": "A control for boolean input with checked and unchecked states.",
         "sections": ["AllStates"],
-        "usage": "<Checkbox />",
         "previewStory": "AllStates"
       }
     },
@@ -127,7 +119,6 @@
         "title": "Input",
         "tagline": "A text input field for capturing user data.",
         "sections": ["AllStates", "AllTypes"],
-        "usage": "<Input placeholder=\"Email address\" />",
         "previewStory": "AllStates"
       }
     },
@@ -141,7 +132,6 @@
         "title": "Label",
         "tagline": "A semantic label for form controls with proper accessibility.",
         "sections": ["AllStates"],
-        "usage": "<Label htmlFor=\"email\">Email</Label>",
         "previewStory": "AllStates"
       }
     },
@@ -155,7 +145,6 @@
         "title": "Radio",
         "tagline": "A control for selecting one option from a set of choices.",
         "sections": ["AllStates"],
-        "usage": "<RadioGroup defaultValue=\"option1\">\n  <RadioItem value=\"option1\" />\n  <RadioItem value=\"option2\" />\n</RadioGroup>",
         "previewStory": "AllStates"
       }
     },
@@ -169,7 +158,6 @@
         "title": "Select",
         "tagline": "A dropdown for selecting from a list of options.",
         "sections": ["AllStates", "WithGroups"],
-        "usage": "<Select>\n  <Select.Trigger>\n    <Select.Value placeholder=\"Select...\" />\n  </Select.Trigger>\n  <Select.Content>\n    <Select.Item value=\"1\">Option</Select.Item>\n  </Select.Content>\n</Select>",
         "previewStory": "Default"
       }
     },
@@ -188,7 +176,6 @@
         "title": "Switch",
         "tagline": "A toggle for binary on/off states.",
         "sections": ["AllStates", "Sizes"],
-        "usage": "<Switch />",
         "previewStory": "Default"
       }
     },
@@ -202,7 +189,6 @@
         "title": "Textarea",
         "tagline": "A multi-line text input field for longer content.",
         "sections": ["AllStates"],
-        "usage": "<Textarea placeholder=\"Enter description...\" />",
         "previewStory": "Default"
       }
     },
@@ -216,7 +202,6 @@
         "title": "Table",
         "tagline": "A semantic HTML table with styled components.",
         "sections": ["AllVariants"],
-        "usage": "<Table>\n  <TableHeader>\n    <TableRow>\n      <TableHead>Column</TableHead>\n    </TableRow>\n  </TableHeader>\n  <TableBody>\n    <TableRow>\n      <TableCell>Data</TableCell>\n    </TableRow>\n  </TableBody>\n</Table>",
         "previewStory": "Default",
         "span": 2
       }
@@ -231,7 +216,6 @@
         "title": "Card",
         "tagline": "A versatile container for grouping related content and actions.",
         "sections": ["AllStates"],
-        "usage": "<Card>\n  <Card.Header>\n    <Card.Title>Title</Card.Title>\n  </Card.Header>\n  <Card.Content>Content</Card.Content>\n</Card>",
         "previewStory": "Default"
       }
     },
@@ -245,7 +229,6 @@
         "title": "Tabs",
         "tagline": "A set of layered sections of content that display one panel at a time.",
         "sections": ["AllStates"],
-        "usage": "<Tabs defaultValue=\"tab1\">\n  <Tabs.List>\n    <Tabs.Trigger value=\"tab1\">Tab 1</Tabs.Trigger>\n  </Tabs.List>\n  <Tabs.Content value=\"tab1\">Content</Tabs.Content>\n</Tabs>",
         "previewStory": "Default"
       }
     },
@@ -259,7 +242,6 @@
         "title": "Separator",
         "tagline": "A visual divider that separates content into distinct sections.",
         "sections": ["AllStates"],
-        "usage": "<Separator />",
         "previewStory": "Default"
       }
     },
@@ -273,7 +255,6 @@
         "title": "Tooltip",
         "tagline": "A popup that displays information related to an element on hover.",
         "sections": ["AllStates", "Positions"],
-        "usage": "<TooltipProvider>\n  <Tooltip>\n    <Tooltip.Trigger>Hover me</Tooltip.Trigger>\n    <Tooltip.Content>Tooltip text</Tooltip.Content>\n  </Tooltip>\n</TooltipProvider>",
         "previewStory": "Default"
       }
     },
@@ -287,7 +268,6 @@
         "title": "Pagination",
         "tagline": "A navigation component for paginated content with ellipsis support.",
         "sections": ["AllStates"],
-        "usage": "<Pagination page={1} totalPages={10} buildPageUrl={(p) => `?page=${p}`} />",
         "previewStory": "Default"
       }
     },
@@ -301,7 +281,6 @@
         "title": "Dialog",
         "tagline": "A modal dialog for confirmations, forms, and alerts.",
         "sections": ["AllStates"],
-        "usage": "<Dialog trigger={<Button>Open</Button>}>\n  <Dialog.Header>\n    <Dialog.Title>Title</Dialog.Title>\n  </Dialog.Header>\n</Dialog>",
         "previewStory": "Default"
       }
     },
@@ -315,7 +294,6 @@
         "title": "Sheet",
         "tagline": "A slide-out panel that can appear from any edge of the screen.",
         "sections": ["AllStates"],
-        "usage": "<Sheet trigger={<Button>Open</Button>}>\n  <Sheet.Header>\n    <Sheet.Title>Title</Sheet.Title>\n  </Sheet.Header>\n</Sheet>",
         "previewStory": "Default"
       }
     },
@@ -329,7 +307,6 @@
         "title": "DropdownMenu",
         "tagline": "A menu of actions or options triggered by a button.",
         "sections": ["AllStates"],
-        "usage": "<DropdownMenu>\n  <DropdownMenu.Trigger asChild>\n    <Button>Open</Button>\n  </DropdownMenu.Trigger>\n  <DropdownMenu.Content>\n    <DropdownMenu.Item>Action</DropdownMenu.Item>\n  </DropdownMenu.Content>\n</DropdownMenu>",
         "previewStory": "Default"
       }
     },
@@ -343,7 +320,6 @@
         "title": "BlankSlate",
         "tagline": "An empty state component for when there is no data to display.",
         "sections": ["AllStates"],
-        "usage": "<BlankSlate icon=\"inbox\" title=\"No messages\" description=\"Your inbox is empty.\" />",
         "previewStory": "Default"
       }
     },
@@ -357,7 +333,6 @@
         "title": "DataTable",
         "tagline": "A powerful data table with sorting, filtering, pagination, and selection.",
         "sections": ["AllFeatures"],
-        "usage": "<DataTable columns={columns} data={data} />",
         "previewStory": "FullFeatured",
         "span": 3
       }


### PR DESCRIPTION
## Summary

- Remove `usage` field from registry.json
- Rename "Usage" section to "Import" in docs (shows only import statement)
- Examples section already shows actual code, so no duplication needed
- Update CONTRIBUTING.md with cleaner format

## Before

Contributors had to write JSON-escaped usage code:
```json
"usage": "<Breadcrumb>\n  <Breadcrumb.List>\n    <Breadcrumb.Item>\n      <Breadcrumb.Link href=\"/\">Home</Breadcrumb.Link>\n    </Breadcrumb.Item>\n  </Breadcrumb.List>\n</Breadcrumb>"
```

## After

No `usage` field needed. Docs automatically shows:
```tsx
import { Breadcrumb } from "@/components/ui/breadcrumb"
```

Actual usage examples are in the Examples section.

## Test plan

- [ ] Verify component pages show Import section correctly
- [ ] Verify Examples section still works

🤖 Generated with [Claude Code](https://claude.ai/code)