### PR TITLE
feat(switch, textarea): improve sizing and add auto-resize

### DIFF
--- a/.changeset/switch-textarea-improvements.md
+++ b/.changeset/switch-textarea-improvements.md
@@ -1,0 +1,16 @@
+---
+"@beaket/ui": minor
+---
+
+Improve Switch and Textarea components
+
+Switch:
+
+- Flatter, more horizontal proportions (reduced height by ~40%)
+- Uniform 2px padding on all sides
+- Corrected thumb translate values for symmetric left/right states
+
+Textarea:
+
+- Add `autoResize` prop (default: true) for automatic height adjustment based on content
+- Unify focus styling with Input component (ring-2 instead of border-only)

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -181,14 +181,14 @@
     },
     {
       "name": "textarea",
-      "description": "Multi-line text input component with validation states",
+      "description": "Multi-line text input with auto-resize support",
       "dependencies": ["clsx", "tailwind-merge"],
       "registryDependencies": [],
       "files": ["components/textarea.tsx"],
       "docs": {
         "title": "Textarea",
-        "tagline": "A multi-line text input field for longer content.",
-        "sections": ["AllStates"],
+        "tagline": "A multi-line text input that automatically grows with content.",
+        "sections": ["AutoResize", "AllStates"],
         "previewStory": "Default"
       }
     },

--- a/src/components/switch.tsx
+++ b/src/components/switch.tsx
@@ -10,9 +10,9 @@ const switchVariants = cva(
   {
     variants: {
       size: {
-        sm: "h-5 w-9",
-        md: "h-6 w-11",
-        lg: "h-7 w-14",
+        sm: "h-3 w-7",
+        md: "h-4 w-9",
+        lg: "h-5 w-11",
       },
     },
     defaultVariants: {
@@ -26,9 +26,9 @@ const switchThumbVariants = cva(
   {
     variants: {
       size: {
-        sm: "size-4 data-[state=checked]:translate-x-4",
-        md: "size-5 data-[state=checked]:translate-x-5",
-        lg: "size-6 data-[state=checked]:translate-x-6",
+        sm: "size-1.5 data-[state=checked]:translate-x-4",
+        md: "size-2.5 data-[state=checked]:translate-x-5",
+        lg: "size-3.5 data-[state=checked]:translate-x-6",
       },
     },
     defaultVariants: {

--- a/src/components/textarea.stories.tsx
+++ b/src/components/textarea.stories.tsx
@@ -14,7 +14,7 @@ const meta: Meta<typeof Textarea> = {
     docs: {
       description: {
         component:
-          "A multi-line text input component with support for validation states. Extends native textarea with consistent styling and accessibility features.",
+          "A multi-line text input component with auto-resize support. Automatically grows based on content by default.",
       },
     },
   },
@@ -27,6 +27,18 @@ export const Default: Story = {
   args: {
     placeholder: "Type something...",
     disabled: false,
+    autoResize: true,
+    rows: 2,
+  },
+  argTypes: {
+    autoResize: {
+      control: "boolean",
+      description: "Automatically resize based on content",
+    },
+    rows: {
+      control: { type: "number", min: 1, max: 20 },
+      description: "Initial number of visible rows",
+    },
   },
 };
 
@@ -53,16 +65,25 @@ export const AllStates: Story = {
   ),
 };
 
-export const WithRows: Story = {
+export const AutoResize: Story = {
   render: () => (
     <div className="flex max-w-sm flex-col gap-4">
       <div className="space-y-1.5">
-        <Label htmlFor="textarea-small">Small (3 rows)</Label>
-        <Textarea id="textarea-small" rows={3} placeholder="3 rows" />
+        <Label htmlFor="textarea-auto">Auto Resize (default)</Label>
+        <Textarea
+          id="textarea-auto"
+          placeholder="Type multiple lines and watch it grow..."
+          defaultValue={"Line 1\nLine 2\nLine 3"}
+        />
       </div>
       <div className="space-y-1.5">
-        <Label htmlFor="textarea-large">Large (8 rows)</Label>
-        <Textarea id="textarea-large" rows={8} placeholder="8 rows" />
+        <Label htmlFor="textarea-fixed">Fixed Height (autoResize=false)</Label>
+        <Textarea
+          id="textarea-fixed"
+          autoResize={false}
+          rows={4}
+          placeholder="Fixed height with manual resize handle"
+        />
       </div>
     </div>
   ),

--- a/src/components/textarea.tsx
+++ b/src/components/textarea.tsx
@@ -1,4 +1,5 @@
 import { type ClassValue, clsx } from "clsx";
+import { useCallback, useEffect, useRef } from "react";
 import { twMerge } from "tailwind-merge";
 
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
@@ -8,21 +9,46 @@ interface Props extends React.ComponentProps<"textarea"> {
    * Additional CSS classes to apply to the textarea
    */
   className?: string;
+  /**
+   * Automatically resize the textarea based on content
+   * @default true
+   */
+  autoResize?: boolean;
 }
 
-export function Textarea({ className, ...props }: Props) {
+export function Textarea({ className, autoResize = true, onInput, ...props }: Props) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const adjustHeight = useCallback(() => {
+    const textarea = textareaRef.current;
+    if (!textarea || !autoResize) return;
+
+    textarea.style.height = "auto";
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }, [autoResize]);
+
+  useEffect(() => {
+    adjustHeight();
+  }, [adjustHeight, props.value, props.defaultValue]);
+
   return (
     <textarea
+      ref={textareaRef}
       data-slot="textarea"
       className={cn(
-        "border border-[var(--graphite)] bg-[var(--paper)] px-3 py-2 text-sm text-[var(--ink)]",
+        "w-full border border-[var(--graphite)] bg-[var(--paper)] px-3 py-2 text-sm text-[var(--ink)]",
         "placeholder:text-[var(--steel)]",
-        "focus:border-[var(--signal-blue)] focus:outline-none",
-        "disabled:cursor-not-allowed disabled:border-dashed disabled:bg-[var(--frost)] disabled:text-[var(--steel)]",
+        "focus:ring-2 focus:ring-[var(--signal-blue)] focus:ring-offset-1 focus:outline-none",
+        "disabled:cursor-not-allowed disabled:border-dashed disabled:border-[var(--chrome)] disabled:bg-[var(--frost)] disabled:text-[var(--steel)]",
         "read-only:cursor-default read-only:bg-[var(--frost)]",
-        "aria-[invalid=true]:border-[var(--signal-red)] aria-[invalid=true]:focus:border-[var(--signal-red)]",
+        "aria-[invalid=true]:border-[var(--signal-red)] aria-[invalid=true]:focus:ring-[var(--signal-red)]",
+        autoResize && "resize-none overflow-hidden",
         className,
       )}
+      onInput={(e) => {
+        adjustHeight();
+        onInput?.(e);
+      }}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

- **Switch**: Flatter, more horizontal proportions with uniform 2px padding and correct thumb positioning
- **Textarea**: Add `autoResize` prop (default: true) that automatically adjusts height based on content
- Unified focus styling between Input and Textarea components

## Test plan

- [ ] Verify Switch looks balanced in all sizes (sm, md, lg)
- [ ] Verify Switch thumb position is symmetric in checked/unchecked states
- [ ] Verify Textarea auto-resizes when typing multiple lines
- [ ] Verify `autoResize={false}` disables auto-resize and shows resize handle
- [ ] Check docs page for Textarea shows AutoResize example

🤖 Generated with [Claude Code](https://claude.com/claude-code)