### PR TITLE
fix(cli): detect bun.lock instead of bun.lockb

### DIFF
--- a/.changeset/fix-bun-lock.md
+++ b/.changeset/fix-bun-lock.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+Fix bun detection to use bun.lock instead of bun.lockb

--- a/packages/cli/src/utils/files.ts
+++ b/packages/cli/src/utils/files.ts
@@ -74,7 +74,7 @@ async function detectPackageManager(): Promise<"npm" | "pnpm" | "yarn" | "bun"> 
   if (await fs.pathExists(path.join(cwd, "yarn.lock"))) {
     return "yarn";
   }
-  if (await fs.pathExists(path.join(cwd, "bun.lockb"))) {
+  if (await fs.pathExists(path.join(cwd, "bun.lock"))) {
     return "bun";
   }
 


### PR DESCRIPTION
## Summary
- Bun 1.2+ uses `bun.lock` (text format) as default
- Previously only checked for `bun.lockb` (binary format)
- This caused bun users to get `npm install` instead of `bun add`

🤖 Generated with [Claude Code](https://claude.com/claude-code)