### PR TITLE
feat(cli): add -y flag to init and E2E test

### DIFF
--- a/.changeset/feat-cli-test.md
+++ b/.changeset/feat-cli-test.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": minor
+---
+
+Add -y flag to init command for non-interactive mode

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,5 @@ jobs:
         run: pnpm format:check
       - name: Typecheck
         run: pnpm typecheck
+      - name: Test CLI
+        run: pnpm test:cli

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "format:check": "prettier --check .",
     "typecheck": "tsc --noEmit && pnpm -r typecheck",
     "test": "vitest",
+    "test:cli": "./scripts/test-cli.sh",
     "build-storybook": "storybook build",
     "release": "changeset publish",
     "prepare": "husky"

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -106,33 +106,42 @@ const CSS_VARIABLES = `
 }
 `;
 
-export async function init() {
+interface InitOptions {
+  yes?: boolean;
+}
+
+export async function init(options: InitOptions) {
   console.log();
   console.log(pc.bold("Initializing Beaket UI..."));
   console.log();
 
-  // Auto-detect defaults based on project structure
   const detectedComponentsPath = await detectAliasPath();
   const detectedCssPath = await detectCssPath();
 
-  const response = await prompts([
-    {
-      type: "text",
-      name: "components",
-      message: "Where should components be installed?",
-      initial: detectedComponentsPath,
-    },
-    {
-      type: "text",
-      name: "css",
-      message: "Where is your Tailwind CSS file?",
-      initial: detectedCssPath,
-    },
-  ]);
+  let response: { components: string; css: string };
 
-  if (!response.components) {
-    console.log(pc.red("Cancelled."));
-    process.exit(1);
+  if (options.yes) {
+    response = { components: detectedComponentsPath, css: detectedCssPath };
+  } else {
+    response = await prompts([
+      {
+        type: "text",
+        name: "components",
+        message: "Where should components be installed?",
+        initial: detectedComponentsPath,
+      },
+      {
+        type: "text",
+        name: "css",
+        message: "Where is your Tailwind CSS file?",
+        initial: detectedCssPath,
+      },
+    ]);
+
+    if (!response.components) {
+      console.log(pc.red("Cancelled."));
+      process.exit(1);
+    }
   }
 
   // Write beaket.ui.json (only components path)

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -15,7 +15,11 @@ program
   .description("CLI for adding Beaket UI components to your project")
   .version(version);
 
-program.command("init").description("Initialize Beaket UI in your project").action(init);
+program
+  .command("init")
+  .description("Initialize Beaket UI in your project")
+  .option("-y, --yes", "Use defaults without prompting")
+  .action(init);
 
 program
   .command("add")

--- a/scripts/test-cli.sh
+++ b/scripts/test-cli.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+CLI="node $(pwd)/packages/cli/bin/cli.js"
+TEMP_DIR=$(mktemp -d)
+cd "$TEMP_DIR"
+
+echo '{"name":"test"}' > package.json
+echo '{"compilerOptions":{"paths":{"@/*":["./*"]}}}' > tsconfig.json
+
+$CLI init -y
+$CLI add button
+
+test -f beaket.ui.json
+test -f components/ui/button.tsx
+grep -q "clsx" package.json
+
+rm -rf "$TEMP_DIR"
+echo "CLI tests passed"


### PR DESCRIPTION
## Summary
- Add `-y`/`--yes` flag to `init` command for non-interactive mode
- Add `test:cli` script for E2E testing before publish
- Add CLI test to CI workflow

## Test plan
- [x] `pnpm test:cli` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)