### PR TITLE
chore: change version bump from major to minor

### DIFF
--- a/.changeset/beaket-ui-improvements.md
+++ b/.changeset/beaket-ui-improvements.md
@@ -1,5 +1,5 @@
 ---
-"@beaket/ui": major
+"@beaket/ui": minor
 ---
 
 ### Breaking Changes


### PR DESCRIPTION
Breaking change (Table compound pattern) is a v1 design fix, not a v2 redesign.

This changes the next release from 2.0.0 to 1.9.0.