### PR TITLE
docs: improve documentation structure and add changelog

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
-  "changelog": "@changesets/cli/changelog",
+  "changelog": ["@changesets/changelog-github", { "repo": "beaket/ui" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.changeset/docs-structure-update.md
+++ b/.changeset/docs-structure-update.md
@@ -1,0 +1,4 @@
+---
+---
+
+Docs only: improve documentation structure and add changelog page

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,41 @@ This is a **copy-paste component library** (like shadcn/ui). Users copy individu
    - `dependencies`: External packages (e.g., `@radix-ui/react-checkbox`)
    - `registryDependencies`: Other components from this library (e.g., `button`)
 
+## CSS Architecture
+
+### File Structure
+
+```
+src/
+├── css-variables.css   # Core tokens (colors, shadows) - injected by CLI
+└── styles.css          # Full design system (imports css-variables.css)
+```
+
+### Ownership Model
+
+When users run `npx @beaket/ui init`, the CLI injects `css-variables.css` content into their main CSS file.
+
+**After init, this CSS belongs to the user:**
+
+- Users are free to modify colors, shadows, and tokens
+- The library will not automatically update these values
+- When the library updates tokens, users should check the CHANGELOG and manually update if needed
+
+**Why this design:**
+
+- Users own their design tokens completely
+- No unexpected style changes from library updates
+- Clear boundary: library provides initial tokens, user maintains them
+
+### Core vs Extended Tokens
+
+| File                | Contents                                 | User Gets           |
+| ------------------- | ---------------------------------------- | ------------------- |
+| `css-variables.css` | Neutral palette, signal colors, shadows  | Yes (via init)      |
+| `styles.css`        | Functional mappings, typography, spacing | No (Storybook only) |
+
+This separation keeps the injected CSS minimal (~44 lines) while the full design system is available for reference.
+
 ## Design Philosophy (Brutalist)
 
 This library follows a **brutalist design system**:

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,0 +1,11 @@
+import { glob } from "astro/loaders";
+import { defineCollection } from "astro:content";
+
+const changelog = defineCollection({
+  loader: glob({
+    pattern: "CHANGELOG.md",
+    base: "../packages/cli",
+  }),
+});
+
+export const collections = { changelog };

--- a/docs/src/layouts/doc.astro
+++ b/docs/src/layouts/doc.astro
@@ -35,6 +35,8 @@ const currentYear = new Date().getFullYear();
           <div class="sidebar-section">
             <div class="sidebar-section-title">Getting Started</div>
             <a href="/ui/installation" class:list={["sidebar-link", { active: currentPath.includes('/installation') }]}>Installation</a>
+            <a href="/ui/cli" class:list={["sidebar-link", { active: currentPath.includes('/cli') }]}>CLI</a>
+            <a href="/ui/tokens" class:list={["sidebar-link", { active: currentPath.includes('/tokens') }]}>Design Tokens</a>
           </div>
 
           <div class="sidebar-section">
@@ -42,6 +44,10 @@ const currentYear = new Date().getFullYear();
             {components.map((component) => (
               <a href={`/ui/components/${component.name}`} class:list={["sidebar-link", { active: currentPath.includes(`/components/${component.name}`) }]}>{component.docs.title}</a>
             ))}
+          </div>
+
+          <div class="sidebar-section">
+            <a href="/ui/changelog" class:list={["sidebar-link", { active: currentPath.includes('/changelog') }]}>Changelog</a>
           </div>
 
         </div>

--- a/docs/src/pages/changelog.astro
+++ b/docs/src/pages/changelog.astro
@@ -1,0 +1,61 @@
+---
+import Layout from '../layouts/doc.astro';
+import { getCollection, render } from 'astro:content';
+
+// Get changelog from content collection
+const entries = await getCollection('changelog');
+const entry = entries[0];
+const { Content } = await render(entry);
+---
+
+<Layout title="Changelog">
+  <h1>Changelog</h1>
+  <p class="changelog-intro">All notable changes to Beaket UI are documented here.</p>
+
+  <div class="changelog-content">
+    <Content />
+  </div>
+</Layout>
+
+<style>
+  .changelog-intro {
+    color: var(--steel);
+    margin-bottom: 28px;
+  }
+
+  .changelog-content :global(h1) {
+    display: none;
+  }
+
+  .changelog-content :global(h2) {
+    margin-top: 28px;
+    padding-top: 14px;
+    border-top: 1px solid var(--chrome);
+  }
+
+  .changelog-content :global(h3) {
+    margin-top: 14px;
+    color: var(--slate);
+  }
+
+  .changelog-content :global(ul) {
+    margin: 7px 0;
+    padding-left: 14px;
+  }
+
+  .changelog-content :global(li) {
+    margin: 5.6px 0;
+  }
+
+  .changelog-content :global(code) {
+    background: var(--frost);
+    padding: 2px 4px;
+    font-family: var(--font-mono);
+    font-size: 13px;
+  }
+
+  .changelog-content :global(pre code) {
+    background: none;
+    padding: 0;
+  }
+</style>

--- a/docs/src/pages/cli.md
+++ b/docs/src/pages/cli.md
@@ -1,0 +1,56 @@
+---
+layout: ../layouts/doc.astro
+title: CLI
+---
+
+# CLI
+
+## Commands
+
+### init
+
+Initialize Beaket UI in your project.
+
+```bash
+npx @beaket/ui init
+```
+
+This command:
+
+- Detects your project type (Vite, Next.js)
+- Creates `beaket.ui.json` config file
+- Adds CSS design tokens to your stylesheet
+
+### add
+
+Add components to your project.
+
+```bash
+# Add a single component
+npx @beaket/ui add button
+
+# Add multiple components
+npx @beaket/ui add alert button label
+```
+
+## Options
+
+### init
+
+| Option | Description                   |
+| ------ | ----------------------------- |
+| `-y`   | Skip prompts and use defaults |
+
+### add
+
+| Option              | Description                        |
+| ------------------- | ---------------------------------- |
+| `--overwrite`, `-o` | Overwrite existing component files |
+
+## Help
+
+```bash
+npx @beaket/ui --help
+npx @beaket/ui init --help
+npx @beaket/ui add --help
+```

--- a/docs/src/pages/installation.md
+++ b/docs/src/pages/installation.md
@@ -57,6 +57,8 @@ export default defineConfig({
 npx @beaket/ui init
 ```
 
+This adds [design tokens](/ui/tokens) (colors, shadows) to your CSS file.
+
 6. Add components:
 
 ```bash
@@ -83,17 +85,4 @@ npx @beaket/ui init
 npx @beaket/ui add button
 ```
 
-## CLI Options
-
-Use `--help` to see available options:
-
-```bash
-npx @beaket/ui --help
-npx @beaket/ui init --help
-npx @beaket/ui add --help
-```
-
-Common options:
-
-- `init -y` - Skip prompts and use defaults
-- `add --overwrite` - Overwrite existing component files
+See [CLI](/ui/cli) for all available options.

--- a/docs/src/pages/tokens.md
+++ b/docs/src/pages/tokens.md
@@ -1,0 +1,62 @@
+---
+layout: ../layouts/doc.astro
+title: Design Tokens
+---
+
+# Design Tokens
+
+The `init` command adds design tokens to your CSS file. After initialization, these tokens belong to you and can be customized freely.
+
+## Color Palette
+
+### Neutral
+
+| Token        | Value     | Usage                 |
+| ------------ | --------- | --------------------- |
+| `--graphite` | `#0d0d0d` | Darkest, text primary |
+| `--ink`      | `#1a1a1a` | Dark backgrounds      |
+| `--branch`   | `#1c1f24` | Dark UI elements      |
+| `--iron`     | `#2d2d2d` | Dark borders          |
+| `--slate`    | `#404040` | Dark secondary        |
+| `--zinc`     | `#525252` | Dark muted            |
+| `--steel`    | `#595959` | Mid-tone text         |
+| `--aluminum` | `#9e9e9e` | Muted text, shadows   |
+| `--chrome`   | `#d0d0d0` | Borders, shadows      |
+| `--silver`   | `#dedede` | Light borders         |
+| `--platinum` | `#e8e8e8` | Light backgrounds     |
+| `--frost`    | `#f5f5f5` | Subtle backgrounds    |
+| `--paper`    | `#fafafa` | Primary background    |
+
+### Signal Colors
+
+| Token             | Value     | Usage              |
+| ----------------- | --------- | ------------------ |
+| `--signal-blue`   | `#00449e` | Links, info        |
+| `--signal-red`    | `#c41e1e` | Error, destructive |
+| `--signal-green`  | `#00794c` | Success            |
+| `--signal-amber`  | `#b8860b` | Warning            |
+| `--signal-purple` | `#6f2da8` | Accent             |
+| `--signal-cyan`   | `#1a6b7c` | Info alternate     |
+
+Signal colors include hover and active variants (e.g., `--signal-red-hover`, `--signal-red-active`).
+
+## Shadows
+
+Brutalist offset shadows with no blur:
+
+| Token                    | Value                         | Usage                    |
+| ------------------------ | ----------------------------- | ------------------------ |
+| `--shadow-offset`        | `2px 2px 0 0 var(--chrome)`   | Default interactive      |
+| `--shadow-offset-hover`  | `3px 3px 0 0 var(--chrome)`   | Hover state              |
+| `--shadow-offset-active` | `1px 1px 0 0 var(--chrome)`   | Active/pressed           |
+| `--shadow-offset-dark`   | `2px 2px 0 0 var(--aluminum)` | Overlays (Dialog, Sheet) |
+
+## Customization
+
+After running `init`, you own these tokens:
+
+- Modify colors to match your brand
+- Adjust shadow offsets for different visual weight
+- Add new tokens as needed
+
+The library will not automatically update these values. Check the [Changelog](/ui/changelog) when updating to see if tokens have changed.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.27.0",
   "devDependencies": {
+    "@changesets/changelog-github": "^0.5.2",
     "@changesets/cli": "^2.29.8",
     "@chromatic-com/storybook": "4.1.3",
     "@storybook/addon-a11y": "10.1.11",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -4,17 +4,17 @@
 
 ### Minor Changes
 
-- 6460127: Add -y flag to init command for non-interactive mode
+- [`6460127`](https://github.com/beaket/ui/commit/6460127): Add -y flag to init command for non-interactive mode
 
 ### Patch Changes
 
-- dca002d: Fix bun detection to use bun.lock instead of bun.lockb
+- [`dca002d`](https://github.com/beaket/ui/commit/dca002d): Fix bun detection to use bun.lock instead of bun.lockb
 
 ## 1.7.0
 
 ### Minor Changes
 
-- ed42b5d: Improve Switch and Textarea components
+- [`ed42b5d`](https://github.com/beaket/ui/commit/ed42b5d): Improve Switch and Textarea components
 
   Switch:
   - Flatter, more horizontal proportions (reduced height by ~40%)
@@ -29,17 +29,17 @@
 
 ### Minor Changes
 
-- 1b61c60: Auto-detect component path based on tsconfig alias configuration
+- [`1b61c60`](https://github.com/beaket/ui/commit/1b61c60): Auto-detect component path based on tsconfig alias configuration
 
 ### Patch Changes
 
-- 6ffa8c6: Fix CLI init to include @theme block with shadow utilities for Tailwind CSS 4
+- [`6ffa8c6`](https://github.com/beaket/ui/commit/6ffa8c6): Fix CLI init to include @theme block with shadow utilities for Tailwind CSS 4
 
 ## 1.5.1
 
 ### Patch Changes
 
-- 1d6083e: Fix consistent form control borders and navigation active text
+- [`1d6083e`](https://github.com/beaket/ui/commit/1d6083e): Fix consistent form control borders and navigation active text
   - Standardize border color to --graphite for Checkbox, Select, Textarea
   - Remove meaningless hover border changes
   - Add text-inverse utility for navigation active state
@@ -49,14 +49,14 @@
 
 ### Minor Changes
 
-- 2fa9067: Add offset shadow system and new component variants
+- [`2fa9067`](https://github.com/beaket/ui/commit/2fa9067): Add offset shadow system and new component variants
   - Button: Add offset shadow states, warning variant, mono prop
   - Badge: Add warning and code variants
   - Table: Add shadow prop, TableSectionHeader component
   - Card, Tabs: Add optional shadow prop
   - Dialog, Sheet, Dropdown, Tooltip: Add offset shadows
 
-- df80cc1: Add Blockquote, Breadcrumb, and Navigation components
+- [`df80cc1`](https://github.com/beaket/ui/commit/df80cc1): Add Blockquote, Breadcrumb, and Navigation components
   - Blockquote: Styled quotation with author attribution support
   - Breadcrumb: Compound component for navigation hierarchy
   - Navigation: Primary site navigation with offset shadow styling
@@ -65,14 +65,14 @@
 
 ### Minor Changes
 
-- 1b26167: Add Avatar component for displaying user profile images with fallback support
-- 69a50f4: Add form components: Label, Textarea, Select, and Switch
+- [`1b26167`](https://github.com/beaket/ui/commit/1b26167): Add Avatar component for displaying user profile images with fallback support
+- [`69a50f4`](https://github.com/beaket/ui/commit/69a50f4): Add form components: Label, Textarea, Select, and Switch
   - Label: Form label with accessibility support via @radix-ui/react-label
   - Textarea: Multi-line text input with validation states
   - Select: Dropdown select with grouped options using compound pattern (Select.Trigger, Select.Content, Select.Item, etc.)
   - Switch: Toggle switch with size variants (sm, md, lg) via @radix-ui/react-switch
 
-- 0a6eb92: Add Phase 2 components: Tooltip, Separator, Card, Tabs, Sheet, and Alert
+- [`0a6eb92`](https://github.com/beaket/ui/commit/0a6eb92): Add Phase 2 components: Tooltip, Separator, Card, Tabs, Sheet, and Alert
   - **Tooltip**: Popup that displays information on hover or focus
   - **Separator**: Visual divider for horizontal or vertical separation
   - **Card**: Container component with Header, Title, Description, Action, Content, and Footer sub-components
@@ -80,52 +80,52 @@
   - **Sheet**: Slide-out panel from any edge of the screen (left, right, top, bottom)
   - **Alert**: Callout component with semantic variants (note, tip, important, warning, caution)
 
-- 21e60c3: Add Table and DataTable components
+- [`21e60c3`](https://github.com/beaket/ui/commit/21e60c3): Add Table and DataTable components
   - Table: Semantic HTML table components (TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell, TableCaption)
   - DataTable: TanStack Table-based component with sorting, filtering, pagination, and row selection
   - Update Button to use design tokens
   - Update CLAUDE.md with library architecture and design philosophy
 
-- 2304fb0: Add Dialog component with compound pattern, controlled/uncontrolled modes, and Storybook tests
-- 4028bf6: Add DropdownMenu component with compound pattern, checkbox/radio items, submenus, and keyboard shortcuts support
-- 27f74ac: Add Pagination and BlankSlate components (Phase 3 migration)
+- [`2304fb0`](https://github.com/beaket/ui/commit/2304fb0): Add Dialog component with compound pattern, controlled/uncontrolled modes, and Storybook tests
+- [`4028bf6`](https://github.com/beaket/ui/commit/4028bf6): Add DropdownMenu component with compound pattern, checkbox/radio items, submenus, and keyboard shortcuts support
+- [`27f74ac`](https://github.com/beaket/ui/commit/27f74ac): Add Pagination and BlankSlate components (Phase 3 migration)
   - Pagination: Server-side pagination with ellipsis support for SSR-friendly navigation
   - BlankSlate: Empty state component with preset icons and custom icon support
 
 ### Patch Changes
 
-- 86722d0: Make Tooltip self-contained by including TooltipProvider internally
+- [`86722d0`](https://github.com/beaket/ui/commit/86722d0): Make Tooltip self-contained by including TooltipProvider internally
 
 ## 1.3.0
 
 ### Minor Changes
 
-- 495bc3c: Add Input component with brutalist design
-- 2633dec: Add Radio component for single-choice selection
+- [`495bc3c`](https://github.com/beaket/ui/commit/495bc3c): Add Input component with brutalist design
+- [`2633dec`](https://github.com/beaket/ui/commit/2633dec): Add Radio component for single-choice selection
 
 ## 1.2.0
 
 ### Minor Changes
 
-- 11f945c: Add Badge component with 6 variants: default, secondary, success, error, info, outline
+- [`11f945c`](https://github.com/beaket/ui/commit/11f945c): Add Badge component with 6 variants: default, secondary, success, error, info, outline
 
 ## 1.1.1
 
 ### Patch Changes
 
-- 6916e4e: Add usage field to registry.json for component documentation
+- [`6916e4e`](https://github.com/beaket/ui/commit/6916e4e): Add usage field to registry.json for component documentation
 
 ## 1.1.0
 
 ### Minor Changes
 
-- 4901272: Add Checkbox component with Radix UI primitives
+- [`4901272`](https://github.com/beaket/ui/commit/4901272): Add Checkbox component with Radix UI primitives
 
 ## 1.0.0
 
 ### Major Changes
 
-- 5dfc775: Simplify CLI and component structure
+- [`5dfc775`](https://github.com/beaket/ui/commit/5dfc775): Simplify CLI and component structure
 
   **Breaking changes:**
   - `beaket.json` now only requires `components` path (removed `tailwind`, `aliases`, `paths.utils`)
@@ -147,7 +147,7 @@
 
 ### Minor Changes
 
-- 12e1451: Add overwrite prompt for existing files in CLI add command
+- [`12e1451`](https://github.com/beaket/ui/commit/12e1451): Add overwrite prompt for existing files in CLI add command
   - Add `--overwrite` (`-o`) flag to force overwrite without prompting
   - Prompt user for confirmation when a file already exists
   - Show skipped files with instructions to use `--overwrite`
@@ -157,27 +157,27 @@
 
 ### Patch Changes
 
-- 6ecf976: Update CLI package description
+- [`6ecf976`](https://github.com/beaket/ui/commit/6ecf976): Update CLI package description
 
 ## 0.1.7
 
 ### Patch Changes
 
-- e30519c: Add JSDoc comments to Button component props
+- [`e30519c`](https://github.com/beaket/ui/commit/e30519c): Add JSDoc comments to Button component props
 
 ## 0.1.6
 
 ### Patch Changes
 
-- e453371: docs: add JSDoc comment to Button component
-- e180d0f: docs: add JSDoc comment to Button props
-- 14c4706: docs: add JSDoc comment to Spinner component
-- 51771f8: Rename ButtonProps to Props internally
-- 26470e9: fix: trigger auto-changeset only on PR open and use PR title
-- 7b1fb93: chore: apply code formatting and cleanup
+- [`e453371`](https://github.com/beaket/ui/commit/e453371): docs: add JSDoc comment to Button component
+- [`e180d0f`](https://github.com/beaket/ui/commit/e180d0f): docs: add JSDoc comment to Button props
+- [`14c4706`](https://github.com/beaket/ui/commit/14c4706): docs: add JSDoc comment to Spinner component
+- [`51771f8`](https://github.com/beaket/ui/commit/51771f8): Rename ButtonProps to Props internally
+- [`26470e9`](https://github.com/beaket/ui/commit/26470e9): fix: trigger auto-changeset only on PR open and use PR title
+- [`7b1fb93`](https://github.com/beaket/ui/commit/7b1fb93): chore: apply code formatting and cleanup
 
 ## 0.1.5
 
 ### Patch Changes
 
-- 04f0200: Test changeset for verification
+- [`04f0200`](https://github.com/beaket/ui/commit/04f0200): Test changeset for verification

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
         specifier: 3.4.0
         version: 3.4.0
     devDependencies:
+      '@changesets/changelog-github':
+        specifier: ^0.5.2
+        version: 0.5.2
       '@changesets/cli':
         specifier: ^2.29.8
         version: 2.29.8(@types/node@25.0.3)
@@ -372,6 +375,9 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
+  '@changesets/changelog-github@0.5.2':
+    resolution: {integrity: sha512-HeGeDl8HaIGj9fQHo/tv5XKQ2SNEi9+9yl1Bss1jttPqeiASRXhfi0A2wv8yFKCp07kR1gpOI5ge6+CWNm1jPw==}
+
   '@changesets/cli@2.29.8':
     resolution: {integrity: sha512-1weuGZpP63YWUYjay/E84qqwcnt5yJMM0tep10Up7Q5cS/DGe2IZ0Uj3HNMxGhCINZuR7aO9WBMdKnPit5ZDPA==}
     hasBin: true
@@ -384,6 +390,9 @@ packages:
 
   '@changesets/get-dependents-graph@2.1.3':
     resolution: {integrity: sha512-gphr+v0mv2I3Oxt19VdWRRUxq3sseyUpX9DaHpTUmLj92Y10AGy+XOtV+kbM6L/fDcpx7/ISDFK6T8A/P3lOdQ==}
+
+  '@changesets/get-github-info@0.7.0':
+    resolution: {integrity: sha512-+i67Bmhfj9V4KfDeS1+Tz3iF32btKZB2AAx+cYMqDSRFP7r3/ZdGbjCo+c6qkyViN9ygDuBjzageuPGJtKGe5A==}
 
   '@changesets/get-release-plan@4.0.14':
     resolution: {integrity: sha512-yjZMHpUHgl4Xl5gRlolVuxDkm4HgSJqT93Ri1Uz8kGrQb+5iJ8dkXJ20M2j/Y4iV5QzS2c5SeTxVSKX+2eMI0g==}
@@ -2418,6 +2427,9 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -2510,6 +2522,10 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
 
   dset@3.1.4:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
@@ -3243,6 +3259,15 @@ packages:
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
 
@@ -3904,6 +3929,9 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
@@ -4353,8 +4381,14 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-pm-runs@1.1.0:
     resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==}
@@ -4725,6 +4759,14 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
+  '@changesets/changelog-github@0.5.2':
+    dependencies:
+      '@changesets/get-github-info': 0.7.0
+      '@changesets/types': 6.1.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
+
   '@changesets/cli@2.29.8(@types/node@25.0.3)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.14
@@ -4778,6 +4820,13 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.7.3
+
+  '@changesets/get-github-info@0.7.0':
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@changesets/get-release-plan@4.0.14':
     dependencies:
@@ -6712,6 +6761,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  dataloader@1.4.0: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -6786,6 +6837,8 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
+
+  dotenv@8.6.0: {}
 
   dset@3.1.4: {}
 
@@ -7715,6 +7768,10 @@ snapshots:
 
   node-fetch-native@1.6.7: {}
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-mock-http@1.0.4: {}
 
   node-releases@2.0.27: {}
@@ -8413,6 +8470,8 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tr46@0.0.3: {}
+
   tree-kill@1.2.2: {}
 
   trim-lines@3.0.1: {}
@@ -8781,7 +8840,14 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  webidl-conversions@3.0.1: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-pm-runs@1.1.0: {}
 


### PR DESCRIPTION
## Summary

- Add dynamic changelog page using Astro Content Collections (reads from `packages/cli/CHANGELOG.md` at build time)
- Create separate CLI and Design Tokens reference pages
- Document CSS ownership model in CLAUDE.md
- Add GitHub links to existing CHANGELOG entries
- Configure `@changesets/changelog-github` for future releases
- Reorganize sidebar navigation

## New Documentation Structure

```
Getting Started
├── Installation
├── CLI
└── Design Tokens

Components
└── ...

Changelog
```

## Test plan

- [ ] Verify docs build succeeds
- [ ] Check changelog page renders correctly with GitHub links
- [ ] Verify CLI and Design Tokens pages display properly
- [ ] Confirm sidebar navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)