### PR TITLE
Replace hardcoded white with palette tokens

### DIFF
--- a/.changeset/replace-hardcoded-white.md
+++ b/.changeset/replace-hardcoded-white.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+Replace hardcoded `white` with palette tokens in Input, Table, and Badge components

--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -20,11 +20,11 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-[var(--ink)] text-white border-[var(--ink)]",
+        default: "bg-[var(--ink)] text-[var(--paper)] border-[var(--ink)]",
         secondary: "bg-[var(--frost)] text-[var(--ink)] border-[var(--chrome)]",
-        success: "bg-[var(--signal-green)] text-white border-[var(--signal-green)]",
-        error: "bg-[var(--signal-red)] text-white border-[var(--signal-red)]",
-        info: "bg-[var(--signal-blue)] text-white border-[var(--signal-blue)]",
+        success: "bg-[var(--signal-green)] text-[var(--paper)] border-[var(--signal-green)]",
+        error: "bg-[var(--signal-red)] text-[var(--paper)] border-[var(--signal-red)]",
+        info: "bg-[var(--signal-blue)] text-[var(--paper)] border-[var(--signal-blue)]",
         outline: "bg-transparent text-[var(--ink)] border-[var(--chrome)]",
         warning: "bg-[var(--signal-amber)] text-[var(--graphite)] border-[var(--signal-amber)]",
         code: "font-mono bg-[var(--frost)] text-[var(--ink)] border-[var(--chrome)]",

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -14,7 +14,7 @@ export interface Props extends Omit<React.InputHTMLAttributes<HTMLInputElement>,
 
 const inputBaseStyles = [
   "h-9 w-full px-3 text-sm",
-  "bg-white text-[var(--ink)]",
+  "bg-[var(--paper)] text-[var(--ink)]",
   "border border-[var(--graphite)]",
   "placeholder:text-[var(--steel)]",
   "focus:ring-2 focus:ring-[var(--signal-blue)] focus:ring-offset-1 focus:outline-none",

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -63,7 +63,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "border-b border-[var(--chrome)] bg-white hover:bg-[var(--frost)] data-[state=selected]:bg-[var(--platinum)]",
+        "border-b border-[var(--chrome)] bg-[var(--paper)] hover:bg-[var(--frost)] data-[state=selected]:bg-[var(--platinum)]",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
This PR replaces hardcoded `white` color values with the `--paper` CSS custom property across the Badge, Input, and Table components to improve design system consistency and maintainability.

## Changes
- **Badge component**: Updated `default`, `success`, `error`, and `info` variants to use `text-[var(--paper)]` instead of `text-white`
- **Input component**: Changed background from `bg-white` to `bg-[var(--paper)]`
- **Table component**: Updated TableRow background from `bg-white` to `bg-[var(--paper)]`

## Details
These changes ensure that all text and background colors are sourced from the design system's CSS custom properties rather than hardcoded values. This makes the components more flexible for theming and maintains consistency with the existing design token architecture (which already uses `--ink`, `--frost`, `--chrome`, etc.).

https://claude.ai/code/session_01VJidQaPFNRQPx2QkPfgF5T