### PR TITLE
Improve focus visibility for Switch and Tabs components

### DIFF
--- a/.changeset/improve-focus-visibility.md
+++ b/.changeset/improve-focus-visibility.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+Improve focus visibility for Switch and Tabs components by using outline-based focus indicators instead of subtle border color changes

--- a/src/components/switch.tsx
+++ b/src/components/switch.tsx
@@ -6,7 +6,7 @@ import { twMerge } from "tailwind-merge";
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
 const switchVariants = cva(
-  "peer inline-flex shrink-0 cursor-pointer items-center p-0.5 transition-colors outline-none data-[state=checked]:bg-[var(--signal-green)] data-[state=unchecked]:bg-[var(--chrome)] focus-visible:border-[var(--signal-blue)] disabled:cursor-not-allowed disabled:opacity-50 border border-[var(--chrome)]",
+  "peer inline-flex shrink-0 cursor-pointer items-center p-0.5 transition-colors outline-none data-[state=checked]:bg-[var(--signal-green)] data-[state=unchecked]:bg-[var(--chrome)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--signal-blue)] disabled:cursor-not-allowed disabled:opacity-50 border border-[var(--chrome)]",
   {
     variants: {
       size: {

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -41,7 +41,7 @@ function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPr
         "inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 px-2 py-1 text-sm font-medium whitespace-nowrap transition-colors",
         "border border-transparent text-[var(--ink)]",
         "data-[state=active]:bg-[var(--ink)] data-[state=active]:text-[var(--paper)]",
-        "focus-visible:border-[var(--signal-blue)] focus-visible:outline-none",
+        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--signal-blue)]",
         "disabled:pointer-events-none disabled:text-[var(--steel)]",
         "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,


### PR DESCRIPTION
## Summary
Enhanced focus visibility for the Switch and Tabs components by replacing subtle border color changes with more prominent outline-based focus indicators, improving accessibility and user experience.

## Key Changes
- **Switch component**: Replaced `focus-visible:border-[var(--signal-blue)]` with `focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--signal-blue)]` to provide a clearer, more visible focus indicator
- **Tabs component**: Updated TabsTrigger focus styling from `focus-visible:border-[var(--signal-blue)] focus-visible:outline-none` to `focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--signal-blue)]` for consistent and improved focus visibility

## Implementation Details
- Both components now use a 2px outline with 2px offset for focus states, creating a more noticeable visual indicator
- The outline approach is more accessible than border-based focus indicators as it doesn't affect component layout
- Maintains the signal-blue color scheme for consistency with the design system
- Changes are marked as a patch version bump in the changeset

https://claude.ai/code/session_017Rk45g11jiWY91cyGadkfx