### PR TITLE
Include package.json and pnpm-lock.yaml in release workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
       - "src/**"
       - "packages/**"
       - ".changeset/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
## Summary
Updated the release workflow to trigger on changes to `package.json` and `pnpm-lock.yaml` files, in addition to the existing source code and changeset paths.

## Changes
- Added `package.json` to the release workflow trigger paths
- Added `pnpm-lock.yaml` to the release workflow trigger paths

## Details
This ensures that the release workflow will automatically run when package metadata or dependency lock files are modified, allowing releases to be triggered by dependency updates or version changes in the root package configuration.

https://claude.ai/code/session_014ruDxBb43CM8YqDNfCWoZB