### PR TITLE
fix: add explicit permissions to Chromatic workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,4 +1,7 @@
 name: Upload Chromatic
+permissions:
+  contents: read
+  statuses: write
 on:
   push:
     branches:


### PR DESCRIPTION
## Summary
- Add `permissions` block to `.github/workflows/chromatic.yml` restricting `GITHUB_TOKEN` to `contents: read` and `statuses: write`
- Resolves [CodeQL alert #3](https://github.com/beaket/ui/security/code-scanning/3) (`actions/missing-workflow-permissions`)

## Test plan
- [ ] Verify Chromatic workflow still runs successfully on a PR with component changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)