### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/changeset-check.yml
+++ b/.github/workflows/changeset-check.yml
@@ -1,5 +1,8 @@
 name: Changeset Check
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/beaket/ui/security/code-scanning/2](https://github.com/beaket/ui/security/code-scanning/2)

Generally, this problem is fixed by adding an explicit `permissions` block at either the workflow root (applies to all jobs without their own `permissions`) or at the specific job that needs restricted permissions. For this workflow, the steps only read code (via `actions/checkout` and `git diff`), so `contents: read` is sufficient. No write permissions are required.

The best minimal fix without changing functionality is to add `permissions: contents: read` at the workflow root, just below the `name:` (or above `jobs:`). This will apply to the `check` job and any future jobs unless they override it. Concretely, in `.github/workflows/changeset-check.yml`, insert:

```yaml
permissions:
  contents: read
```

after line 2 (the blank line following `name: Changeset Check`) and before the `on:` block. No additional imports, actions, or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
