### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/beaket/ui/security/code-scanning/1](https://github.com/beaket/ui/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block that grants only what the workflow needs, either at the top level (affecting all jobs) or inside the specific job. Since this workflow only runs dependency installation and various checks, it does not require write access and in most cases only needs read access to repository contents.

The best minimal fix, without changing functionality, is to add a workflow-level `permissions` block setting `contents: read`. This documents the intent and ensures the `GITHUB_TOKEN` cannot be used to write to the repository even if defaults are broad. Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: CI` line and the `on:` block. No other changes, imports, or definitions are required, and this will satisfy CodeQL’s requirement while preserving all existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
