### PR TITLE
fix: skip Chromatic workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   test:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Add `if: github.actor != 'dependabot[bot]'` to Chromatic workflow job
- Dependabot PRs don't have access to repo secrets, causing "Missing project token" failures
- These PRs only update dependencies — no visual component changes to test

Fixes the failing check on #208 and future Dependabot PRs.

## Test plan
- [ ] Verify Chromatic still runs on regular PRs with component changes
- [ ] Verify Dependabot PRs no longer show Chromatic failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)