### PR TITLE
ci: auto-merge Dependabot PRs when CI passes

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,17 @@
+name: Dependabot Auto-Merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge
+        run: gh pr merge "$PR_URL" --auto --squash
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `dependabot-auto-merge.yml` workflow that enables auto-merge (squash) on Dependabot PRs
- When a Dependabot PR is opened, the workflow runs `gh pr merge --auto --squash`
- The PR will automatically merge once all required status checks pass

## How it works
1. Dependabot opens a PR
2. This workflow triggers and sets auto-merge on the PR
3. CI runs (changeset check, CodeQL, etc.)
4. Once all required checks pass, GitHub auto-merges via squash

## Test plan
- [ ] Verify workflow triggers on Dependabot PRs
- [ ] Verify regular PRs are not affected (`if: github.actor == 'dependabot[bot]'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)