### PR TITLE
feat!: migrate CSS tokens to Tailwind v4 convention and improve accessibility

### DIFF
--- a/.changeset/redesign-token-unification.md
+++ b/.changeset/redesign-token-unification.md
@@ -1,0 +1,18 @@
+---
+"@beaket/ui": major
+---
+
+BREAKING: Migrate CSS variables to Tailwind v4 `@theme` convention with `--color-*` prefix
+
+- CSS tokens moved from `:root` to `@theme` block with `--color-*` prefix
+- Components now use clean Tailwind utilities (`bg-paper` instead of `bg-[var(--paper)]`)
+- Unified color token values with Beaket app (chrome, platinum, signal-blue)
+- Added `--color-muted` (#737373) for WCAG AA-compliant muted text (replaces aluminum for text)
+- Added `--color-signal-red-text` (#b91c1c) for accessible red text on light backgrounds
+- Accessibility improvements across all components:
+  - BlankSlate: decorative icons marked `aria-hidden`
+  - Navigation: default `aria-label` on nav landmark
+  - Button: spinner wrapped with `aria-live="polite"`
+  - Switch: disabled state uses border-dashed pattern instead of opacity
+  - DataTable: search input has `aria-label`
+  - Checkbox: indeterminate state with Minus icon and ARIA support

--- a/src/components/alert.tsx
+++ b/src/components/alert.tsx
@@ -10,14 +10,14 @@ const alertVariants = cva(
   {
     variants: {
       variant: {
-        note: "bg-[var(--paper)] text-[var(--ink)] border-[var(--signal-blue)] [&>svg]:text-[var(--signal-blue)] [&_[data-slot=alert-description]]:text-[var(--steel)]",
-        tip: "bg-[var(--paper)] text-[var(--ink)] border-[var(--signal-green)] [&>svg]:text-[var(--signal-green)] [&_[data-slot=alert-description]]:text-[var(--steel)]",
+        note: "bg-paper text-ink border-signal-blue [&>svg]:text-signal-blue [&_[data-slot=alert-description]]:text-steel",
+        tip: "bg-paper text-ink border-signal-green [&>svg]:text-signal-green [&_[data-slot=alert-description]]:text-steel",
         important:
-          "bg-[var(--paper)] text-[var(--ink)] border-[var(--signal-purple)] [&>svg]:text-[var(--signal-purple)] [&_[data-slot=alert-description]]:text-[var(--steel)]",
+          "bg-paper text-ink border-signal-purple [&>svg]:text-signal-purple [&_[data-slot=alert-description]]:text-steel",
         warning:
-          "bg-[var(--paper)] text-[var(--ink)] border-[var(--signal-amber)] [&>svg]:text-[var(--signal-amber)] [&_[data-slot=alert-description]]:text-[var(--steel)]",
+          "bg-paper text-ink border-signal-amber [&>svg]:text-signal-amber [&_[data-slot=alert-description]]:text-steel",
         caution:
-          "bg-[var(--paper)] text-[var(--ink)] border-[var(--signal-red)] [&>svg]:text-[var(--signal-red)] [&_[data-slot=alert-description]]:text-[var(--steel)]",
+          "bg-paper text-ink border-signal-red [&>svg]:text-signal-red [&_[data-slot=alert-description]]:text-steel",
       },
     },
     defaultVariants: {

--- a/src/components/avatar.stories.tsx
+++ b/src/components/avatar.stories.tsx
@@ -45,19 +45,19 @@ export const AllStates = () => (
         <Avatar.Image src="https://github.com/beaket.png" alt="@beaket" />
         <Avatar.Fallback>BK</Avatar.Fallback>
       </Avatar>
-      <span className="text-xs text-[var(--steel)]">With Image</span>
+      <span className="text-steel text-xs">With Image</span>
     </div>
     <div className="flex flex-col items-center gap-2">
       <Avatar>
         <Avatar.Fallback>JD</Avatar.Fallback>
       </Avatar>
-      <span className="text-xs text-[var(--steel)]">Fallback</span>
+      <span className="text-steel text-xs">Fallback</span>
     </div>
     <div className="flex flex-col items-center gap-2">
       <Avatar>
         <Avatar.Fallback>A</Avatar.Fallback>
       </Avatar>
-      <span className="text-xs text-[var(--steel)]">Single Letter</span>
+      <span className="text-steel text-xs">Single Letter</span>
     </div>
   </div>
 );
@@ -68,48 +68,48 @@ export const CustomSizes = () => (
       <Avatar className="size-6">
         <Avatar.Fallback className="text-xs">XS</Avatar.Fallback>
       </Avatar>
-      <span className="text-xs text-[var(--steel)]">24px</span>
+      <span className="text-steel text-xs">24px</span>
     </div>
     <div className="flex flex-col items-center gap-2">
       <Avatar className="size-8">
         <Avatar.Fallback className="text-sm">SM</Avatar.Fallback>
       </Avatar>
-      <span className="text-xs text-[var(--steel)]">32px</span>
+      <span className="text-steel text-xs">32px</span>
     </div>
     <div className="flex flex-col items-center gap-2">
       <Avatar>
         <Avatar.Fallback>MD</Avatar.Fallback>
       </Avatar>
-      <span className="text-xs text-[var(--steel)]">40px (default)</span>
+      <span className="text-steel text-xs">40px (default)</span>
     </div>
     <div className="flex flex-col items-center gap-2">
       <Avatar className="size-12">
         <Avatar.Fallback className="text-lg">LG</Avatar.Fallback>
       </Avatar>
-      <span className="text-xs text-[var(--steel)]">48px</span>
+      <span className="text-steel text-xs">48px</span>
     </div>
     <div className="flex flex-col items-center gap-2">
       <Avatar className="size-16">
         <Avatar.Fallback className="text-xl">XL</Avatar.Fallback>
       </Avatar>
-      <span className="text-xs text-[var(--steel)]">64px</span>
+      <span className="text-steel text-xs">64px</span>
     </div>
   </div>
 );
 
 export const AvatarGroup = () => (
   <div className="flex -space-x-2">
-    <Avatar className="border-2 border-[var(--paper)]">
+    <Avatar className="border-paper border-2">
       <Avatar.Image src="https://github.com/beaket.png" alt="@beaket" />
       <Avatar.Fallback>BK</Avatar.Fallback>
     </Avatar>
-    <Avatar className="border-2 border-[var(--paper)]">
+    <Avatar className="border-paper border-2">
       <Avatar.Fallback>JD</Avatar.Fallback>
     </Avatar>
-    <Avatar className="border-2 border-[var(--paper)]">
+    <Avatar className="border-paper border-2">
       <Avatar.Fallback>AB</Avatar.Fallback>
     </Avatar>
-    <Avatar className="border-2 border-[var(--paper)]">
+    <Avatar className="border-paper border-2">
       <Avatar.Fallback>+3</Avatar.Fallback>
     </Avatar>
   </div>

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -16,7 +16,7 @@ export function Avatar({ className, ...props }: Props) {
     <AvatarPrimitive.Root
       data-slot="avatar"
       className={cn(
-        "relative flex size-10 shrink-0 overflow-hidden border border-[var(--chrome)]",
+        "border-chrome relative flex size-10 shrink-0 overflow-hidden border",
         className,
       )}
       {...props}
@@ -41,10 +41,7 @@ function AvatarFallback({
   return (
     <AvatarPrimitive.Fallback
       data-slot="avatar-fallback"
-      className={cn(
-        "flex size-full items-center justify-center bg-[var(--frost)] text-[var(--ink)]",
-        className,
-      )}
+      className={cn("bg-frost text-ink flex size-full items-center justify-center", className)}
       {...props}
     />
   );

--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -20,14 +20,14 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default: "bg-[var(--ink)] text-[var(--paper)] border-[var(--ink)]",
-        secondary: "bg-[var(--frost)] text-[var(--ink)] border-[var(--chrome)]",
-        success: "bg-[var(--signal-green)] text-[var(--paper)] border-[var(--signal-green)]",
-        error: "bg-[var(--signal-red)] text-[var(--paper)] border-[var(--signal-red)]",
-        info: "bg-[var(--signal-blue)] text-[var(--paper)] border-[var(--signal-blue)]",
-        outline: "bg-transparent text-[var(--ink)] border-[var(--chrome)]",
-        warning: "bg-[var(--signal-amber)] text-[var(--graphite)] border-[var(--signal-amber)]",
-        code: "font-mono bg-[var(--frost)] text-[var(--ink)] border-[var(--chrome)]",
+        default: "bg-ink text-paper border-ink",
+        secondary: "bg-frost text-ink border-chrome",
+        success: "bg-signal-green text-paper border-signal-green",
+        error: "bg-signal-red text-paper border-signal-red",
+        info: "bg-signal-blue text-paper border-signal-blue",
+        outline: "bg-transparent text-ink border-chrome",
+        warning: "bg-signal-amber text-graphite border-signal-amber",
+        code: "font-mono bg-frost text-ink border-chrome",
       },
     },
     defaultVariants: {

--- a/src/components/blank-slate.tsx
+++ b/src/components/blank-slate.tsx
@@ -64,14 +64,14 @@ export function BlankSlate({ icon, title, description, children, className }: Bl
   return (
     <div data-slot="blank-slate" className={cn("py-12 text-center", className)}>
       {IconComponent && (
-        <div data-slot="blank-slate-icon" className="mb-4 flex justify-center text-[var(--steel)]">
-          <IconComponent size={48} />
+        <div data-slot="blank-slate-icon" className="text-steel mb-4 flex justify-center">
+          <IconComponent size={48} aria-hidden="true" />
         </div>
       )}
-      <h1 data-slot="blank-slate-title" className="mb-2 text-2xl font-bold text-[var(--ink)]">
+      <h1 data-slot="blank-slate-title" className="text-ink mb-2 text-2xl font-bold">
         {title}
       </h1>
-      <p data-slot="blank-slate-description" className="mb-4 text-[var(--steel)]">
+      <p data-slot="blank-slate-description" className="text-steel mb-4">
         {description}
       </p>
       {children && (

--- a/src/components/blockquote.tsx
+++ b/src/components/blockquote.tsx
@@ -23,14 +23,14 @@ export function Blockquote({
   return (
     <blockquote
       data-slot="blockquote"
-      className={cn("my-4 border-l border-[var(--graphite)] py-1 pl-3", className)}
+      className={cn("border-graphite my-4 border-l py-1 pl-3", className)}
       cite={cite}
       {...props}
     >
       <div className="text-sm leading-relaxed italic">{children}</div>
       {(author || authorTitle) && (
-        <footer className="mt-2 text-sm text-[var(--steel)]">
-          {author && <strong className="block text-[var(--ink)]">{author}</strong>}
+        <footer className="text-steel mt-2 text-sm">
+          {author && <strong className="text-ink block">{author}</strong>}
           {authorTitle && <span>{authorTitle}</span>}
         </footer>
       )}

--- a/src/components/breadcrumb.stories.tsx
+++ b/src/components/breadcrumb.stories.tsx
@@ -95,7 +95,7 @@ export const CustomSeparator: Story = {
 export const AllVariants = () => (
   <div className="space-y-4">
     <div>
-      <p className="mb-2 text-xs text-[var(--steel)]">Default separator</p>
+      <p className="text-steel mb-2 text-xs">Default separator</p>
       <Breadcrumb>
         <Breadcrumb.List>
           <Breadcrumb.Item>
@@ -109,7 +109,7 @@ export const AllVariants = () => (
       </Breadcrumb>
     </div>
     <div>
-      <p className="mb-2 text-xs text-[var(--steel)]">Chevron separator</p>
+      <p className="text-steel mb-2 text-xs">Chevron separator</p>
       <Breadcrumb>
         <Breadcrumb.List>
           <Breadcrumb.Item>

--- a/src/components/breadcrumb.tsx
+++ b/src/components/breadcrumb.tsx
@@ -38,7 +38,7 @@ function BreadcrumbLink({ className, ...props }: React.ComponentProps<"a">) {
   return (
     <a
       data-slot="breadcrumb-link"
-      className={cn("text-[var(--signal-blue)] underline hover:text-[var(--ink)]", className)}
+      className={cn("text-signal-blue hover:text-ink underline", className)}
       {...props}
     />
   );
@@ -48,7 +48,7 @@ function BreadcrumbSeparator({ className, children, ...props }: React.ComponentP
   return (
     <span
       data-slot="breadcrumb-separator"
-      className={cn("text-[var(--steel)]", className)}
+      className={cn("text-steel", className)}
       aria-hidden="true"
       {...props}
     >
@@ -61,7 +61,7 @@ function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
   return (
     <span
       data-slot="breadcrumb-page"
-      className={cn("font-medium text-[var(--ink)]", className)}
+      className={cn("text-ink font-medium", className)}
       aria-current="page"
       {...props}
     />

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -50,7 +50,11 @@ export function Button({
         children
       ) : (
         <>
-          {loading && <Spinner />}
+          {loading && (
+            <span aria-live="polite">
+              <Spinner />
+            </span>
+          )}
           {children}
         </>
       )}
@@ -66,8 +70,8 @@ const buttonVariants = cva(
     "shadow-offset",
     "hover:shadow-offset-hover",
     "active:shadow-offset-active",
-    "disabled:shadow-none disabled:cursor-not-allowed disabled:border-dashed disabled:border-[var(--chrome)] disabled:bg-[var(--frost)] disabled:text-[var(--steel)]",
-    "focus-visible:outline-2 focus-visible:outline-[var(--signal-blue)] focus-visible:outline-offset-2",
+    "disabled:shadow-none disabled:cursor-not-allowed disabled:border-dashed disabled:border-chrome disabled:bg-frost disabled:text-steel",
+    "focus-visible:outline-2 focus-visible:outline-signal-blue focus-visible:outline-offset-2",
     "[&_svg]:size-4",
     "transition-shadow duration-100",
   ].join(" "),
@@ -75,22 +79,20 @@ const buttonVariants = cva(
     variants: {
       variant: {
         primary:
-          "bg-[var(--branch)] text-[var(--paper)] border border-[var(--branch)] hover:bg-[var(--iron)] hover:border-[var(--iron)] active:bg-[var(--ink)] disabled:text-[var(--steel)] no-underline",
+          "bg-branch text-paper border border-branch hover:bg-iron hover:border-iron active:bg-ink disabled:text-steel no-underline",
         destructive:
-          "bg-[var(--signal-red)] text-[var(--paper)] border border-[var(--signal-red)] hover:bg-[var(--signal-red-hover)] hover:border-[var(--signal-red-hover)] active:bg-[var(--signal-red-active)] disabled:text-[var(--steel)] no-underline",
-        outline:
-          "border border-[var(--chrome)] bg-transparent text-[var(--ink)] hover:bg-[var(--frost)] active:bg-[var(--platinum)]",
-        secondary:
-          "bg-[var(--frost)] text-[var(--ink)] border border-[var(--chrome)] hover:bg-[var(--platinum)] active:bg-[var(--silver)]",
+          "bg-signal-red text-paper border border-signal-red hover:bg-signal-red-hover hover:border-signal-red-hover active:bg-signal-red-active disabled:text-steel no-underline",
+        outline: "border border-chrome bg-transparent text-ink hover:bg-frost active:bg-platinum",
+        secondary: "bg-frost text-ink border border-chrome hover:bg-platinum active:bg-silver",
         ghost:
-          "text-[var(--ink)] hover:bg-[var(--frost)] active:bg-[var(--platinum)] shadow-none hover:shadow-none active:shadow-none",
-        link: "text-[var(--signal-blue)] underline-offset-4 hover:underline shadow-none hover:shadow-none active:shadow-none",
+          "text-ink hover:bg-frost active:bg-platinum shadow-none hover:shadow-none active:shadow-none",
+        link: "text-signal-blue underline-offset-4 hover:underline shadow-none hover:shadow-none active:shadow-none",
         success:
-          "bg-[var(--signal-green)] text-[var(--paper)] border border-[var(--signal-green)] hover:bg-[var(--signal-green-hover)] hover:border-[var(--signal-green-hover)] active:bg-[var(--signal-green-active)] disabled:text-[var(--steel)] no-underline",
+          "bg-signal-green text-paper border border-signal-green hover:bg-signal-green-hover hover:border-signal-green-hover active:bg-signal-green-active disabled:text-steel no-underline",
         stark:
-          "border border-[var(--ink)] bg-transparent text-[var(--ink)] hover:bg-[var(--ink)] hover:text-[var(--paper)] active:bg-[var(--graphite)]",
+          "border border-ink bg-transparent text-ink hover:bg-ink hover:text-paper active:bg-graphite",
         warning:
-          "bg-[var(--signal-amber)] text-[var(--graphite)] border border-[var(--signal-amber)] hover:bg-[var(--signal-amber-hover)] hover:border-[var(--signal-amber-hover)] active:bg-[var(--signal-amber-active)] disabled:text-[var(--steel)] no-underline",
+          "bg-signal-amber text-graphite border border-signal-amber hover:bg-signal-amber-hover hover:border-signal-amber-hover active:bg-signal-amber-active disabled:text-steel no-underline",
       },
       size: {
         sm: "h-8 px-3 text-xs",

--- a/src/components/card.stories.tsx
+++ b/src/components/card.stories.tsx
@@ -28,7 +28,7 @@ export const Default: Story = {
         <Card.Description>Card description text goes here.</Card.Description>
       </Card.Header>
       <Card.Content>
-        <p className="text-sm text-[var(--steel)]">
+        <p className="text-steel text-sm">
           This is the card content. You can put any content here.
         </p>
       </Card.Content>
@@ -52,7 +52,7 @@ export const WithAction: Story = {
         </Card.Action>
       </Card.Header>
       <Card.Content>
-        <p className="text-sm text-[var(--steel)]">
+        <p className="text-steel text-sm">
           Configure project name, description, and visibility settings.
         </p>
       </Card.Content>
@@ -78,7 +78,7 @@ export const AllStates = () => (
         <Card.Description>A simple card with header and content.</Card.Description>
       </Card.Header>
       <Card.Content>
-        <p className="text-sm text-[var(--steel)]">Card content goes here.</p>
+        <p className="text-steel text-sm">Card content goes here.</p>
       </Card.Content>
     </Card>
 
@@ -88,7 +88,7 @@ export const AllStates = () => (
         <Card.Description>Card with action buttons in footer.</Card.Description>
       </Card.Header>
       <Card.Content>
-        <p className="text-sm text-[var(--steel)]">Some content here.</p>
+        <p className="text-steel text-sm">Some content here.</p>
       </Card.Content>
       <Card.Footer className="gap-2">
         <Button variant="outline">Cancel</Button>
@@ -107,17 +107,17 @@ export const AllStates = () => (
         </Card.Action>
       </Card.Header>
       <Card.Content>
-        <p className="text-sm text-[var(--steel)]">Content with header action.</p>
+        <p className="text-steel text-sm">Content with header action.</p>
       </Card.Content>
     </Card>
 
     <Card>
-      <Card.Header className="border-b border-[var(--chrome)]">
+      <Card.Header className="border-chrome border-b">
         <Card.Title>With Bordered Header</Card.Title>
         <Card.Description>The header has a bottom border.</Card.Description>
       </Card.Header>
       <Card.Content>
-        <p className="text-sm text-[var(--steel)]">Content below bordered header.</p>
+        <p className="text-steel text-sm">Content below bordered header.</p>
       </Card.Content>
     </Card>
   </div>

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -13,7 +13,7 @@ function CardRoot({ className, shadow, ...props }: CardRootProps) {
     <div
       data-slot="card"
       className={cn(
-        "flex flex-col gap-0 border border-[var(--chrome)] bg-[var(--paper)] text-[var(--ink)]",
+        "border-chrome bg-paper text-ink flex flex-col gap-0 border",
         shadow && "shadow-offset",
         className,
       )}
@@ -42,9 +42,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"h4">) {
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"p">) {
-  return (
-    <p data-slot="card-description" className={cn("text-[var(--steel)]", className)} {...props} />
-  );
+  return <p data-slot="card-description" className={cn("text-steel", className)} {...props} />;
 }
 
 function CardAction({ className, ...props }: React.ComponentProps<"div">) {

--- a/src/components/checkbox.tsx
+++ b/src/components/checkbox.tsx
@@ -1,6 +1,6 @@
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox";
 import { type ClassValue, clsx } from "clsx";
-import { Check } from "lucide-react";
+import { Check, Minus } from "lucide-react";
 import { twMerge } from "tailwind-merge";
 
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
@@ -15,13 +15,14 @@ export function Checkbox({ className, ...props }: Props) {
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "peer size-4 shrink-0 border border-[var(--graphite)]",
-        "bg-[var(--paper)]",
-        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--signal-blue)]",
-        "data-[state=checked]:border-[var(--ink)] data-[state=checked]:bg-[var(--ink)] data-[state=checked]:text-[var(--paper)]",
-        "disabled:cursor-not-allowed disabled:border-dashed disabled:border-[var(--chrome)] disabled:bg-[var(--frost)] disabled:text-[var(--steel)] disabled:hover:border-[var(--chrome)]",
-        "disabled:data-[state=checked]:border-[var(--chrome)] disabled:data-[state=checked]:bg-[var(--frost)] disabled:data-[state=checked]:text-[var(--steel)]",
-        "aria-[invalid=true]:border-[var(--signal-red)]",
+        "group peer border-graphite size-4 shrink-0 border",
+        "bg-paper",
+        "focus-visible:outline-signal-blue focus-visible:outline-2 focus-visible:outline-offset-2",
+        "data-[state=checked]:border-ink data-[state=checked]:bg-ink data-[state=checked]:text-paper",
+        "data-[state=indeterminate]:border-ink data-[state=indeterminate]:bg-ink data-[state=indeterminate]:text-paper",
+        "disabled:border-chrome disabled:bg-frost disabled:text-steel disabled:hover:border-chrome disabled:cursor-not-allowed disabled:border-dashed",
+        "disabled:data-[state=checked]:border-chrome disabled:data-[state=checked]:bg-frost disabled:data-[state=checked]:text-steel",
+        "aria-[invalid=true]:border-signal-red",
         className,
       )}
       {...props}
@@ -30,7 +31,8 @@ export function Checkbox({ className, ...props }: Props) {
         data-slot="checkbox-indicator"
         className="flex items-center justify-center text-current"
       >
-        <Check className="size-3" />
+        <Check className="size-3 group-data-[state=indeterminate]:hidden" />
+        <Minus className="hidden size-3 group-data-[state=indeterminate]:block" />
       </CheckboxPrimitive.Indicator>
     </CheckboxPrimitive.Root>
   );

--- a/src/components/colors.stories.tsx
+++ b/src/components/colors.stories.tsx
@@ -1,28 +1,35 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
 const colors = {
-  brand: [{ name: "Branch", variable: "--branch", hex: "#1c1f24", usage: "Brand identity" }],
+  brand: [{ name: "Branch", variable: "--color-branch", hex: "#1c1f24", usage: "Brand identity" }],
   neutral: [
-    { name: "Graphite", variable: "--graphite", hex: "#0d0d0d", usage: "Darkest tone" },
-    { name: "Ink", variable: "--ink", hex: "#1a1a1a", usage: "Primary text" },
-    { name: "Iron", variable: "--iron", hex: "#2d2d2d", usage: "Dark accent" },
-    { name: "Slate", variable: "--slate", hex: "#404040", usage: "Dark secondary" },
-    { name: "Zinc", variable: "--zinc", hex: "#525252", usage: "Medium dark" },
-    { name: "Steel", variable: "--steel", hex: "#595959", usage: "Secondary text" },
-    { name: "Aluminum", variable: "--aluminum", hex: "#9e9e9e", usage: "Tertiary text" },
-    { name: "Silver", variable: "--silver", hex: "#dedede", usage: "Light border" },
-    { name: "Chrome", variable: "--chrome", hex: "#e0e0e0", usage: "Primary border" },
-    { name: "Platinum", variable: "--platinum", hex: "#f0f0f0", usage: "Light accent" },
-    { name: "Frost", variable: "--frost", hex: "#f5f5f5", usage: "Hover state" },
-    { name: "Paper", variable: "--paper", hex: "#f8f8f8", usage: "Primary surface" },
+    { name: "Graphite", variable: "--color-graphite", hex: "#0d0d0d", usage: "Darkest tone" },
+    { name: "Ink", variable: "--color-ink", hex: "#1a1a1a", usage: "Primary text" },
+    { name: "Iron", variable: "--color-iron", hex: "#2d2d2d", usage: "Dark accent" },
+    { name: "Slate", variable: "--color-slate", hex: "#404040", usage: "Dark secondary" },
+    { name: "Zinc", variable: "--color-zinc", hex: "#525252", usage: "Medium dark" },
+    { name: "Steel", variable: "--color-steel", hex: "#595959", usage: "Secondary text" },
+    { name: "Muted", variable: "--color-muted", hex: "#737373", usage: "Accessible muted text" },
+    { name: "Aluminum", variable: "--color-aluminum", hex: "#9e9e9e", usage: "Decorative only" },
+    { name: "Chrome", variable: "--color-chrome", hex: "#d4d4d4", usage: "Primary border" },
+    { name: "Silver", variable: "--color-silver", hex: "#dedede", usage: "Light border" },
+    { name: "Platinum", variable: "--color-platinum", hex: "#ebebeb", usage: "Light accent" },
+    { name: "Frost", variable: "--color-frost", hex: "#f5f5f5", usage: "Hover state" },
+    { name: "Paper", variable: "--color-paper", hex: "#fafafa", usage: "Primary surface" },
   ],
   signal: [
-    { name: "Blue", variable: "--signal-blue", hex: "#2b6cb0", usage: "Information, links" },
-    { name: "Red", variable: "--signal-red", hex: "#d32f2f", usage: "Error, destructive" },
-    { name: "Green", variable: "--signal-green", hex: "#137752", usage: "Success, positive" },
-    { name: "Amber", variable: "--signal-amber", hex: "#a86800", usage: "Warning, caution" },
-    { name: "Purple", variable: "--signal-purple", hex: "#6f2da8", usage: "Accent, special" },
-    { name: "Cyan", variable: "--signal-cyan", hex: "#1a6b7c", usage: "Info alternate" },
+    { name: "Blue", variable: "--color-signal-blue", hex: "#1a56a0", usage: "Information, links" },
+    { name: "Red", variable: "--color-signal-red", hex: "#c41e1e", usage: "Error, destructive" },
+    {
+      name: "Red (text)",
+      variable: "--color-signal-red-text",
+      hex: "#b91c1c",
+      usage: "Red text (AAA on paper)",
+    },
+    { name: "Green", variable: "--color-signal-green", hex: "#00794c", usage: "Success, positive" },
+    { name: "Amber", variable: "--color-signal-amber", hex: "#b8860b", usage: "Warning, caution" },
+    { name: "Purple", variable: "--color-signal-purple", hex: "#6f2da8", usage: "Accent, special" },
+    { name: "Cyan", variable: "--color-signal-cyan", hex: "#1a6b7c", usage: "Info alternate" },
   ],
 };
 
@@ -40,22 +47,19 @@ function ColorSwatch({
   const isLight = ["Paper", "Frost", "Platinum", "Silver", "Chrome"].includes(name);
 
   return (
-    <div className="border border-[var(--chrome)]">
+    <div className="border-chrome border">
       <div
-        className="flex h-16 items-end border-b border-[var(--chrome)] p-2"
+        className="border-chrome flex h-16 items-end border-b p-2"
         style={{ backgroundColor: hex }}
       >
-        <span
-          className={isLight ? "text-[var(--ink)]" : "text-[var(--paper)]"}
-          style={{ fontSize: 11 }}
-        >
+        <span className={isLight ? "text-ink" : "text-paper"} style={{ fontSize: 11 }}>
           {hex}
         </span>
       </div>
-      <div className="bg-[var(--paper)] p-2">
-        <div className="text-xs font-medium text-[var(--ink)]">{name}</div>
-        <code className="block text-xs text-[var(--steel)]">{variable}</code>
-        <div className="mt-1 text-xs text-[var(--aluminum)]">{usage}</div>
+      <div className="bg-paper p-2">
+        <div className="text-ink text-xs font-medium">{name}</div>
+        <code className="text-steel block text-xs">{variable}</code>
+        <div className="text-muted mt-1 text-xs">{usage}</div>
       </div>
     </div>
   );
@@ -63,21 +67,19 @@ function ColorSwatch({
 
 function Colors() {
   return (
-    <div className="min-h-screen bg-[var(--paper)] p-6">
+    <div className="bg-paper min-h-screen p-6">
       <div className="max-w-4xl">
         {/* Header */}
-        <div className="mb-8 border-b border-[var(--chrome)] pb-4">
-          <h1 className="text-2xl font-bold text-[var(--ink)]">Color System</h1>
-          <p className="mt-1 text-sm text-[var(--steel)]">
+        <div className="border-chrome mb-8 border-b pb-4">
+          <h1 className="text-ink text-2xl font-bold">Color System</h1>
+          <p className="text-steel mt-1 text-sm">
             Brutalist palette. Colors serve function, not decoration.
           </p>
         </div>
 
         {/* Brand */}
         <section className="mb-8">
-          <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">
-            Brand
-          </h2>
+          <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">Brand</h2>
           <div className="grid grid-cols-4 gap-3">
             {colors.brand.map((color) => (
               <ColorSwatch key={color.variable} {...color} />
@@ -87,12 +89,10 @@ function Colors() {
 
         {/* Neutral Palette */}
         <section className="mb-8">
-          <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">
+          <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">
             Neutral Palette
           </h2>
-          <p className="mb-3 text-xs text-[var(--aluminum)]">
-            Dark to light. Ordered by luminance.
-          </p>
+          <p className="text-muted mb-3 text-xs">Dark to light. Ordered by luminance.</p>
           <div className="grid grid-cols-4 gap-3">
             {colors.neutral.map((color) => (
               <ColorSwatch key={color.variable} {...color} />
@@ -102,12 +102,10 @@ function Colors() {
 
         {/* Signal Colors */}
         <section className="mb-8">
-          <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">
+          <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">
             Signal Colors
           </h2>
-          <p className="mb-3 text-xs text-[var(--aluminum)]">
-            Semantic colors for states and feedback.
-          </p>
+          <p className="text-muted mb-3 text-xs">Semantic colors for states and feedback.</p>
           <div className="grid grid-cols-3 gap-3">
             {colors.signal.map((color) => (
               <ColorSwatch key={color.variable} {...color} />
@@ -117,23 +115,23 @@ function Colors() {
 
         {/* Design Rules */}
         <section className="mb-8">
-          <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">
+          <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">
             Design Rules
           </h2>
-          <div className="border border-[var(--chrome)] bg-[var(--frost)] p-4">
-            <ul className="space-y-2 text-xs text-[var(--ink)]">
+          <div className="border-chrome bg-frost border p-4">
+            <ul className="text-ink space-y-2 text-xs">
               <li>
                 <strong>No gradients</strong> — Flat colors only
               </li>
               <li>
-                <strong>No shadows</strong> — No box-shadow, drop-shadow
+                <strong>No blur shadows</strong> — Offset shadows only for interactive elements
               </li>
               <li>
                 <strong>No opacity for styling</strong> — Use explicit color tokens
               </li>
               <li>
-                <strong>Use variables</strong> — Always{" "}
-                <code className="text-[var(--signal-blue)]">var(--token)</code>, never raw hex
+                <strong>Use Tailwind utilities</strong> — Always{" "}
+                <code className="text-signal-blue">bg-paper</code>, never raw hex
               </li>
             </ul>
           </div>
@@ -141,29 +139,25 @@ function Colors() {
 
         {/* Usage Examples */}
         <section>
-          <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">
+          <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">
             Usage Examples
           </h2>
           <div className="grid grid-cols-2 gap-3">
-            <div className="border border-[var(--chrome)] bg-[var(--paper)] p-4">
-              <div className="text-sm text-[var(--ink)]">Primary text on paper</div>
-              <code className="text-xs text-[var(--aluminum)]">
-                text-[var(--ink)] bg-[var(--paper)]
-              </code>
+            <div className="border-chrome bg-paper border p-4">
+              <div className="text-ink text-sm">Primary text on paper</div>
+              <code className="text-muted text-xs">text-ink bg-paper</code>
             </div>
-            <div className="border border-[var(--chrome)] bg-[var(--branch)] p-4">
-              <div className="text-sm text-[var(--paper)]">Inverted: paper on branch</div>
-              <code className="text-xs text-[var(--aluminum)]">
-                text-[var(--paper)] bg-[var(--branch)]
-              </code>
+            <div className="border-chrome bg-branch border p-4">
+              <div className="text-paper text-sm">Inverted: paper on branch</div>
+              <code className="text-muted text-xs">text-paper bg-branch</code>
             </div>
-            <div className="border border-[var(--chrome)] bg-[var(--paper)] p-4">
-              <div className="text-sm text-[var(--signal-blue)]">Link color</div>
-              <code className="text-xs text-[var(--aluminum)]">text-[var(--signal-blue)]</code>
+            <div className="border-chrome bg-paper border p-4">
+              <div className="text-signal-blue text-sm">Link color</div>
+              <code className="text-muted text-xs">text-signal-blue</code>
             </div>
-            <div className="border border-[var(--chrome)] bg-[var(--frost)] p-4">
-              <div className="text-sm text-[var(--ink)]">Hover state surface</div>
-              <code className="text-xs text-[var(--aluminum)]">bg-[var(--frost)]</code>
+            <div className="border-chrome bg-frost border p-4">
+              <div className="text-ink text-sm">Hover state surface</div>
+              <code className="text-muted text-xs">bg-frost</code>
             </div>
           </div>
         </section>
@@ -181,7 +175,7 @@ const meta: Meta<typeof Colors> = {
     docs: {
       description: {
         component:
-          "Brutalist color system. Colors serve function, not decoration. No gradients, no shadows, no opacity effects.",
+          "Brutalist color system. Colors serve function, not decoration. No gradients, no blur shadows, no opacity effects.",
       },
     },
   },
@@ -193,8 +187,8 @@ type Story = StoryObj<typeof Colors>;
 export const Default: Story = {};
 
 export const BrandColor = () => (
-  <div className="bg-[var(--paper)] p-6">
-    <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">Brand</h2>
+  <div className="bg-paper p-6">
+    <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">Brand</h2>
     <div className="w-48">
       <ColorSwatch {...colors.brand[0]} />
     </div>
@@ -202,10 +196,8 @@ export const BrandColor = () => (
 );
 
 export const NeutralPalette = () => (
-  <div className="bg-[var(--paper)] p-6">
-    <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">
-      Neutral Palette
-    </h2>
+  <div className="bg-paper p-6">
+    <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">Neutral Palette</h2>
     <div className="grid max-w-2xl grid-cols-4 gap-3">
       {colors.neutral.map((color) => (
         <ColorSwatch key={color.variable} {...color} />
@@ -215,10 +207,8 @@ export const NeutralPalette = () => (
 );
 
 export const SignalColors = () => (
-  <div className="bg-[var(--paper)] p-6">
-    <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">
-      Signal Colors
-    </h2>
+  <div className="bg-paper p-6">
+    <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">Signal Colors</h2>
     <div className="grid max-w-xl grid-cols-3 gap-3">
       {colors.signal.map((color) => (
         <ColorSwatch key={color.variable} {...color} />

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -147,19 +147,20 @@ export function DataTable<TData, TValue>({
       {searchable && (
         <div className="mb-4 flex items-center gap-2">
           <div className="relative max-w-sm flex-1">
-            <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-[var(--steel)]" />
+            <Search className="text-steel absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
             <Input
               type="search"
               placeholder={searchPlaceholder}
               value={globalFilter ?? ""}
               onChange={(e) => setGlobalFilter(e.target.value)}
               className="pl-9"
+              aria-label="Search"
             />
           </div>
         </div>
       )}
 
-      <div className="overflow-x-auto border border-[var(--chrome)] bg-[var(--paper)]">
+      <div className="border-chrome bg-paper overflow-x-auto border">
         <Table className="min-w-full">
           <Table.Header>
             {table.getHeaderGroups().map((headerGroup) => (
@@ -197,7 +198,7 @@ export function DataTable<TData, TValue>({
                               ) : sortDirection === "desc" ? (
                                 <ArrowDown className="h-4 w-4" />
                               ) : (
-                                <ArrowUpDown className="h-4 w-4 text-[var(--steel)]" />
+                                <ArrowUpDown className="text-steel h-4 w-4" />
                               )}
                             </div>
                           )}
@@ -253,7 +254,7 @@ export function DataTable<TData, TValue>({
                   colSpan={columns.length + (selectable ? 1 : 0)}
                   className="h-64 text-center"
                 >
-                  {emptyState || <div className="text-[var(--steel)]">{emptyMessage}</div>}
+                  {emptyState || <div className="text-steel">{emptyMessage}</div>}
                 </Table.Cell>
               </Table.Row>
             )}
@@ -263,7 +264,7 @@ export function DataTable<TData, TValue>({
 
       {paginated && (
         <div className="mt-4 flex flex-wrap items-center justify-between gap-4">
-          <div className="text-sm text-[var(--steel)]">
+          <div className="text-steel text-sm">
             Showing{" "}
             {table.getFilteredRowModel().rows.length === 0
               ? 0

--- a/src/components/dialog.stories.tsx
+++ b/src/components/dialog.stories.tsx
@@ -38,7 +38,7 @@ export const Default: Story = {
             This is a dialog description that provides additional context.
           </Dialog.Description>
         </Dialog.Header>
-        <p className="text-sm text-[var(--graphite)]">
+        <p className="text-graphite text-sm">
           Dialog content goes here. You can put any content inside.
         </p>
         <Dialog.Footer>
@@ -114,24 +114,24 @@ export const WithForm: Story = {
         </Dialog.Header>
         <div className="grid gap-4 py-4">
           <div className="grid gap-2">
-            <label htmlFor="name" className="text-sm font-medium text-[var(--ink)]">
+            <label htmlFor="name" className="text-ink text-sm font-medium">
               Name
             </label>
             <input
               id="name"
               defaultValue="John Doe"
-              className="h-9 border border-[var(--chrome)] bg-[var(--paper)] px-3 text-sm text-[var(--ink)] placeholder:text-[var(--steel)] focus:ring-2 focus:ring-[var(--signal-blue)] focus:outline-none"
+              className="border-chrome bg-paper text-ink placeholder:text-steel focus:ring-signal-blue h-9 border px-3 text-sm focus:ring-2 focus:outline-none"
             />
           </div>
           <div className="grid gap-2">
-            <label htmlFor="email" className="text-sm font-medium text-[var(--ink)]">
+            <label htmlFor="email" className="text-ink text-sm font-medium">
               Email
             </label>
             <input
               id="email"
               type="email"
               defaultValue="john@example.com"
-              className="h-9 border border-[var(--chrome)] bg-[var(--paper)] px-3 text-sm text-[var(--ink)] placeholder:text-[var(--steel)] focus:ring-2 focus:ring-[var(--signal-blue)] focus:outline-none"
+              className="border-chrome bg-paper text-ink placeholder:text-steel focus:ring-signal-blue h-9 border px-3 text-sm focus:ring-2 focus:outline-none"
             />
           </div>
         </div>
@@ -176,9 +176,7 @@ function ControlledDialogExample() {
     <div className="flex flex-col gap-4">
       <div className="flex gap-2">
         <Button onClick={() => setOpen(true)}>Open Dialog</Button>
-        <span className="self-center text-sm text-[var(--steel)]">
-          Dialog is {open ? "open" : "closed"}
-        </span>
+        <span className="text-steel self-center text-sm">Dialog is {open ? "open" : "closed"}</span>
       </div>
       <Dialog open={open} onOpenChange={setOpen}>
         <Dialog.Header>
@@ -221,7 +219,7 @@ export const AllStates = () => (
       <div className="py-4">
         <input
           placeholder="Enter something..."
-          className="h-9 w-full border border-[var(--chrome)] bg-[var(--paper)] px-3 text-sm"
+          className="border-chrome bg-paper h-9 w-full border px-3 text-sm"
         />
       </div>
       <Dialog.Footer>

--- a/src/components/dialog.tsx
+++ b/src/components/dialog.tsx
@@ -98,11 +98,11 @@ export function Dialog({
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay
           data-slot="dialog-overlay"
-          className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-40 bg-[var(--ink)]/50"
+          className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 bg-ink/50 fixed inset-0 z-40"
         />
         <DialogPrimitive.Content
           data-slot="dialog-content"
-          className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 shadow-offset-dark fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 border border-[var(--chrome)] bg-[var(--paper)] p-6 sm:max-w-lg"
+          className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 shadow-offset-dark border-chrome bg-paper fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 border p-6 sm:max-w-lg"
           onInteractOutside={preventClose ? (e) => e.preventDefault() : undefined}
           onEscapeKeyDown={preventClose ? (e) => e.preventDefault() : undefined}
         >
@@ -110,7 +110,7 @@ export function Dialog({
           {!hideCloseButton && (
             <DialogPrimitive.Close
               data-slot="dialog-close"
-              className="absolute top-4 right-4 text-[var(--steel)] transition-colors hover:text-[var(--ink)] focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--signal-blue)] disabled:pointer-events-none"
+              className="text-steel hover:text-ink focus-visible:outline-signal-blue absolute top-4 right-4 transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none"
               aria-label="Close dialog"
             >
               <X className="size-4" aria-hidden="true" />
@@ -126,7 +126,7 @@ function DialogTitle({ className, ...props }: React.ComponentProps<typeof Dialog
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn("text-xl leading-7 font-semibold text-[var(--ink)]", className)}
+      className={cn("text-ink text-xl leading-7 font-semibold", className)}
       {...props}
     />
   );
@@ -139,7 +139,7 @@ function DialogDescription({
   return (
     <DialogPrimitive.Description
       data-slot="dialog-description"
-      className={cn("text-sm text-[var(--steel)]", className)}
+      className={cn("text-steel text-sm", className)}
       {...props}
     />
   );

--- a/src/components/dropdown-menu.tsx
+++ b/src/components/dropdown-menu.tsx
@@ -35,7 +35,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "shadow-offset z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] origin-[var(--radix-dropdown-menu-content-transform-origin)] overflow-x-hidden overflow-y-auto border border-[var(--ink)] bg-[var(--paper)] p-1 text-[var(--ink)]",
+          "shadow-offset max-h-radix-dropdown-menu-content-available-height origin-radix-dropdown-menu-content-transform-origin border-ink bg-paper text-ink z-50 min-w-[8rem] overflow-x-hidden overflow-y-auto border p-1",
           "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
@@ -71,10 +71,10 @@ function DropdownMenuItem({
       data-variant={variant}
       className={cn(
         "relative flex cursor-default items-center gap-2 px-2 py-1.5 text-sm outline-none select-none",
-        "focus:bg-[var(--ink)] focus:text-[var(--paper)]",
-        "data-[disabled]:pointer-events-none data-[disabled]:text-[var(--steel)]",
+        "focus:bg-ink focus:text-paper",
+        "data-[disabled]:text-steel data-[disabled]:pointer-events-none",
         "data-[inset]:pl-8",
-        "data-[variant=destructive]:text-[var(--signal-red)] data-[variant=destructive]:focus:bg-[var(--signal-red)] data-[variant=destructive]:focus:text-[var(--paper)]",
+        "data-[variant=destructive]:text-signal-red data-[variant=destructive]:focus:bg-signal-red data-[variant=destructive]:focus:text-paper",
         "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
@@ -94,8 +94,8 @@ function DropdownMenuCheckboxItem({
       data-slot="dropdown-menu-checkbox-item"
       className={cn(
         "relative flex cursor-default items-center gap-2 py-1.5 pr-2 pl-8 text-sm outline-none select-none",
-        "focus:bg-[var(--ink)] focus:text-[var(--paper)]",
-        "data-[disabled]:pointer-events-none data-[disabled]:text-[var(--steel)]",
+        "focus:bg-ink focus:text-paper",
+        "data-[disabled]:text-steel data-[disabled]:pointer-events-none",
         "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
@@ -128,8 +128,8 @@ function DropdownMenuRadioItem({
       data-slot="dropdown-menu-radio-item"
       className={cn(
         "relative flex cursor-default items-center gap-2 py-1.5 pr-2 pl-8 text-sm outline-none select-none",
-        "focus:bg-[var(--ink)] focus:text-[var(--paper)]",
-        "data-[disabled]:pointer-events-none data-[disabled]:text-[var(--steel)]",
+        "focus:bg-ink focus:text-paper",
+        "data-[disabled]:text-steel data-[disabled]:pointer-events-none",
         "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}
@@ -159,10 +159,7 @@ function DropdownMenuLabel({
     <DropdownMenuPrimitive.Label
       data-slot="dropdown-menu-label"
       data-inset={inset}
-      className={cn(
-        "px-2 py-1.5 text-sm font-medium text-[var(--ink)] data-[inset]:pl-8",
-        className,
-      )}
+      className={cn("text-ink px-2 py-1.5 text-sm font-medium data-[inset]:pl-8", className)}
       {...props}
     />
   );
@@ -175,7 +172,7 @@ function DropdownMenuSeparator({
   return (
     <DropdownMenuPrimitive.Separator
       data-slot="dropdown-menu-separator"
-      className={cn("-mx-1 my-1 h-px bg-[var(--chrome)]", className)}
+      className={cn("bg-chrome -mx-1 my-1 h-px", className)}
       {...props}
     />
   );
@@ -185,7 +182,7 @@ function DropdownMenuShortcut({ className, ...props }: React.ComponentProps<"spa
   return (
     <span
       data-slot="dropdown-menu-shortcut"
-      className={cn("ml-auto text-xs tracking-widest text-[var(--steel)]", className)}
+      className={cn("text-steel ml-auto text-xs tracking-widest", className)}
       {...props}
     />
   );
@@ -212,8 +209,8 @@ function DropdownMenuSubTrigger({
       data-inset={inset}
       className={cn(
         "flex cursor-default items-center px-2 py-1.5 text-sm outline-none select-none",
-        "focus:bg-[var(--ink)] focus:text-[var(--paper)]",
-        "data-[state=open]:bg-[var(--ink)] data-[state=open]:text-[var(--paper)]",
+        "focus:bg-ink focus:text-paper",
+        "data-[state=open]:bg-ink data-[state=open]:text-paper",
         "data-[inset]:pl-8",
         className,
       )}
@@ -233,7 +230,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "shadow-offset z-50 min-w-[8rem] origin-[var(--radix-dropdown-menu-content-transform-origin)] overflow-hidden border border-[var(--ink)] bg-[var(--paper)] p-1 text-[var(--ink)]",
+        "shadow-offset origin-radix-dropdown-menu-content-transform-origin border-ink bg-paper text-ink z-50 min-w-[8rem] overflow-hidden border p-1",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}

--- a/src/components/input.stories.tsx
+++ b/src/components/input.stories.tsx
@@ -101,7 +101,7 @@ export const WithPrefixAndSuffix: Story = {
             <button
               type="button"
               onClick={() => setValue("")}
-              className="cursor-pointer hover:text-[var(--ink)]"
+              className="hover:text-ink cursor-pointer"
             >
               <X />
             </button>
@@ -125,7 +125,7 @@ export const PasswordToggle: Story = {
           <button
             type="button"
             onClick={() => setShowPassword(!showPassword)}
-            className="cursor-pointer hover:text-[var(--ink)]"
+            className="hover:text-ink cursor-pointer"
           >
             {showPassword ? <EyeOff /> : <Eye />}
           </button>

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -14,13 +14,13 @@ export interface Props extends Omit<React.InputHTMLAttributes<HTMLInputElement>,
 
 const inputBaseStyles = [
   "h-9 w-full px-3 text-sm",
-  "bg-[var(--paper)] text-[var(--ink)]",
-  "border border-[var(--graphite)]",
-  "placeholder:text-[var(--steel)]",
-  "focus:ring-2 focus:ring-[var(--signal-blue)] focus:ring-offset-1 focus:outline-none",
-  "disabled:cursor-not-allowed disabled:border-dashed disabled:border-[var(--chrome)] disabled:bg-[var(--frost)] disabled:text-[var(--steel)]",
-  "aria-[invalid=true]:border-[var(--signal-red)] aria-[invalid=true]:focus:ring-[var(--signal-red)]",
-  "read-only:bg-[var(--frost)] read-only:text-[var(--steel)]",
+  "bg-paper text-ink",
+  "border border-graphite",
+  "placeholder:text-steel",
+  "focus:ring-2 focus:ring-signal-blue focus:ring-offset-1 focus:outline-none",
+  "disabled:cursor-not-allowed disabled:border-dashed disabled:border-chrome disabled:bg-frost disabled:text-steel",
+  "aria-[invalid=true]:border-signal-red aria-[invalid=true]:focus:ring-signal-red",
+  "read-only:bg-frost read-only:text-steel",
 ].join(" ");
 
 export function Input({ className, type = "text", prefix, suffix, ...props }: Props) {
@@ -35,7 +35,7 @@ export function Input({ className, type = "text", prefix, suffix, ...props }: Pr
       {prefix && (
         <span
           data-slot="input-prefix"
-          className="pointer-events-none absolute left-3 flex items-center text-[var(--steel)] [&_svg]:size-4"
+          className="text-steel pointer-events-none absolute left-3 flex items-center [&_svg]:size-4"
         >
           {prefix}
         </span>
@@ -49,7 +49,7 @@ export function Input({ className, type = "text", prefix, suffix, ...props }: Pr
       {suffix && (
         <span
           data-slot="input-suffix"
-          className="absolute right-3 flex items-center text-[var(--steel)] [&_svg]:size-4"
+          className="text-steel absolute right-3 flex items-center [&_svg]:size-4"
         >
           {suffix}
         </span>

--- a/src/components/label.stories.tsx
+++ b/src/components/label.stories.tsx
@@ -48,7 +48,7 @@ export const Required: Story = {
       <div className="space-y-1.5">
         <Label htmlFor="email-required">
           Email
-          <span className="ml-1 text-[var(--signal-red)]">*</span>
+          <span className="text-signal-red ml-1">*</span>
         </Label>
         <Input id="email-required" type="email" required placeholder="email@example.com" />
       </div>
@@ -70,7 +70,7 @@ export const AllStates: Story = {
       <div className="flex max-w-sm flex-col gap-1.5">
         <Label htmlFor="input-required">
           Required field
-          <span className="ml-1 text-[var(--signal-red)]">*</span>
+          <span className="text-signal-red ml-1">*</span>
         </Label>
         <Input id="input-required" required placeholder="Required" />
       </div>

--- a/src/components/label.tsx
+++ b/src/components/label.tsx
@@ -8,7 +8,7 @@ export function Label({ className, ...props }: React.ComponentProps<typeof Label
   return (
     <LabelPrimitive.Root
       data-slot="label"
-      className={cn("block text-sm font-medium text-[var(--ink)]", className)}
+      className={cn("text-ink block text-sm font-medium", className)}
       {...props}
     />
   );

--- a/src/components/navigation.stories.tsx
+++ b/src/components/navigation.stories.tsx
@@ -103,7 +103,7 @@ export const VerticalLayout: Story = {
 export const AllVariants = () => (
   <div className="space-y-6">
     <div>
-      <p className="mb-2 text-xs text-[var(--steel)]">Horizontal navigation</p>
+      <p className="text-steel mb-2 text-xs">Horizontal navigation</p>
       <Navigation>
         <Navigation.List>
           <Navigation.Item>
@@ -121,7 +121,7 @@ export const AllVariants = () => (
       </Navigation>
     </div>
     <div>
-      <p className="mb-2 text-xs text-[var(--steel)]">Vertical navigation</p>
+      <p className="text-steel mb-2 text-xs">Vertical navigation</p>
       <Navigation>
         <Navigation.List className="w-48 flex-col">
           <Navigation.Item>

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -4,7 +4,7 @@ import { twMerge } from "tailwind-merge";
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
 function NavigationRoot({ className, ...props }: React.ComponentProps<"nav">) {
-  return <nav data-slot="navigation" className={cn("", className)} {...props} />;
+  return <nav data-slot="navigation" aria-label="Main" className={cn("", className)} {...props} />;
 }
 
 function NavigationList({ className, ...props }: React.ComponentProps<"ul">) {
@@ -33,10 +33,10 @@ function NavigationLink({ className, active, ...props }: NavigationLinkProps) {
       data-active={active || undefined}
       className={cn(
         "inline-block min-w-[80px] px-4 py-1 text-center text-sm no-underline",
-        "border border-[var(--graphite)] bg-white text-[var(--ink)]",
+        "border-graphite bg-paper text-ink border",
         "shadow-offset hover:shadow-offset-hover",
-        "hover:bg-[var(--frost)]",
-        "data-[active]:text-inverse data-[active]:bg-[var(--ink)]",
+        "hover:bg-frost",
+        "data-[active]:text-inverse data-[active]:bg-ink",
         className,
       )}
       aria-current={active ? "page" : undefined}

--- a/src/components/pagination.stories.tsx
+++ b/src/components/pagination.stories.tsx
@@ -112,7 +112,7 @@ export const AllStates = () => (
 
     <div>
       <h3 className="mb-4 text-sm font-medium">Single Page (Hidden)</h3>
-      <p className="text-sm text-[var(--steel)]">Pagination is hidden when totalPages = 1</p>
+      <p className="text-steel text-sm">Pagination is hidden when totalPages = 1</p>
       <Pagination page={1} totalPages={1} buildPageUrl={buildPageUrl} />
     </div>
   </div>

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -90,9 +90,9 @@ export function Pagination({
 
   const pageNumbers = getPageNumbers();
   const buttonBaseClass = "px-3 py-1 border text-sm transition-colors";
-  const buttonActiveClass = "bg-[var(--ink)] text-[var(--paper)] border-[var(--ink)]";
-  const buttonInactiveClass = "border-[var(--chrome)] hover:bg-[var(--frost)]";
-  const buttonDisabledClass = "border-[var(--chrome)] text-[var(--steel)] cursor-not-allowed";
+  const buttonActiveClass = "bg-ink text-paper border-ink";
+  const buttonInactiveClass = "border-chrome hover:bg-frost";
+  const buttonDisabledClass = "border-chrome text-steel cursor-not-allowed";
 
   return (
     <nav
@@ -128,7 +128,7 @@ export function Pagination({
             <span
               key={pageNum}
               data-slot="pagination-ellipsis"
-              className="px-2 py-1 text-[var(--steel)]"
+              className="text-steel px-2 py-1"
               aria-hidden="true"
             >
               ...

--- a/src/components/radio.stories.tsx
+++ b/src/components/radio.stories.tsx
@@ -73,7 +73,7 @@ export const DisabledWithValue: Story = {
 export const AllStates = () => (
   <div className="flex flex-col gap-6">
     <div className="flex flex-col gap-2">
-      <span className="text-xs tracking-wide text-[var(--steel)] uppercase">Horizontal</span>
+      <span className="text-steel text-xs tracking-wide uppercase">Horizontal</span>
       <RadioGroup defaultValue="option1" aria-label="Horizontal options">
         <div className="flex items-center gap-1">
           <RadioItem value="option1" id="h-opt1" />
@@ -96,7 +96,7 @@ export const AllStates = () => (
       </RadioGroup>
     </div>
     <div className="flex flex-col gap-2">
-      <span className="text-xs tracking-wide text-[var(--steel)] uppercase">Vertical</span>
+      <span className="text-steel text-xs tracking-wide uppercase">Vertical</span>
       <RadioGroup
         defaultValue="option2"
         orientation="vertical"
@@ -124,17 +124,17 @@ export const AllStates = () => (
       </RadioGroup>
     </div>
     <div className="flex flex-col gap-2">
-      <span className="text-xs tracking-wide text-[var(--steel)] uppercase">Disabled</span>
+      <span className="text-steel text-xs tracking-wide uppercase">Disabled</span>
       <RadioGroup disabled defaultValue="option1" aria-label="Disabled options">
         <div className="flex items-center gap-1">
           <RadioItem value="option1" id="d-opt1" />
-          <label htmlFor="d-opt1" className="text-sm text-[var(--steel)]">
+          <label htmlFor="d-opt1" className="text-steel text-sm">
             Option 1
           </label>
         </div>
         <div className="flex items-center gap-1">
           <RadioItem value="option2" id="d-opt2" />
-          <label htmlFor="d-opt2" className="text-sm text-[var(--steel)]">
+          <label htmlFor="d-opt2" className="text-steel text-sm">
             Option 2
           </label>
         </div>

--- a/src/components/radio.tsx
+++ b/src/components/radio.tsx
@@ -29,14 +29,14 @@ export function RadioItem({ className, ...props }: RadioItemProps) {
     <RadioGroupPrimitive.Item
       data-slot="radio-item"
       className={cn(
-        "peer size-4 shrink-0 rounded-full border border-[var(--chrome)]",
-        "bg-[var(--paper)]",
-        "hover:border-[var(--steel)]",
-        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--signal-blue)]",
-        "data-[state=checked]:border-[var(--ink)]",
-        "disabled:cursor-not-allowed disabled:border-dashed disabled:border-[var(--chrome)] disabled:bg-[var(--frost)] disabled:hover:border-[var(--chrome)]",
-        "disabled:data-[state=checked]:border-[var(--chrome)]",
-        "aria-[invalid=true]:border-[var(--signal-red)]",
+        "peer border-chrome size-4 shrink-0 rounded-full border",
+        "bg-paper",
+        "hover:border-steel",
+        "focus-visible:outline-signal-blue focus-visible:outline-2 focus-visible:outline-offset-2",
+        "data-[state=checked]:border-ink",
+        "disabled:border-chrome disabled:bg-frost disabled:hover:border-chrome disabled:cursor-not-allowed disabled:border-dashed",
+        "disabled:data-[state=checked]:border-chrome",
+        "aria-[invalid=true]:border-signal-red",
         className,
       )}
       {...props}
@@ -45,7 +45,7 @@ export function RadioItem({ className, ...props }: RadioItemProps) {
         data-slot="radio-indicator"
         className="flex items-center justify-center"
       >
-        <span className="size-2 rounded-full bg-[var(--ink)] data-[disabled]:bg-[var(--steel)]" />
+        <span className="bg-ink data-[disabled]:bg-steel size-2 rounded-full" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   );

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -31,10 +31,10 @@ function SelectTrigger({ className, size = "default", children, ...props }: Sele
       data-size={size}
       className={cn(
         "flex w-full items-center justify-between gap-2",
-        "border border-[var(--graphite)] bg-[var(--paper)] px-3 py-2 text-sm text-[var(--ink)]",
-        "focus:border-[var(--signal-blue)] focus:outline-none",
-        "disabled:cursor-not-allowed disabled:border-dashed disabled:bg-[var(--frost)] disabled:text-[var(--steel)]",
-        "aria-[invalid=true]:border-[var(--signal-red)]",
+        "border-graphite bg-paper text-ink border px-3 py-2 text-sm",
+        "focus:border-signal-blue focus:outline-none",
+        "disabled:bg-frost disabled:text-steel disabled:cursor-not-allowed disabled:border-dashed",
+        "aria-[invalid=true]:border-signal-red",
         "[&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,
       )}
@@ -59,7 +59,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "relative z-50 max-h-96 min-w-[8rem] overflow-hidden border border-[var(--chrome)] bg-[var(--paper)]",
+          "border-chrome bg-paper relative z-50 max-h-96 min-w-[8rem] overflow-hidden border",
           "data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1",
           className,
         )}
@@ -68,7 +68,7 @@ function SelectContent({
         {...props}
       >
         <SelectScrollUpButton />
-        <SelectPrimitive.Viewport className="max-h-[var(--radix-select-content-available-height)] p-1">
+        <SelectPrimitive.Viewport className="max-h-radix-select-content-available-height p-1">
           {children}
         </SelectPrimitive.Viewport>
         <SelectScrollDownButton />
@@ -81,7 +81,7 @@ function SelectLabel({ className, ...props }: React.ComponentProps<typeof Select
   return (
     <SelectPrimitive.Label
       data-slot="select-label"
-      className={cn("px-2 py-1.5 text-xs font-semibold text-[var(--steel)]", className)}
+      className={cn("text-steel px-2 py-1.5 text-xs font-semibold", className)}
       {...props}
     />
   );
@@ -97,10 +97,10 @@ function SelectItem({
       data-slot="select-item"
       className={cn(
         "relative flex w-full cursor-default items-center gap-2 select-none",
-        "py-1.5 pr-8 pl-2 text-sm text-[var(--ink)] outline-none",
-        "focus:bg-[var(--frost)]",
-        "data-[highlighted]:bg-[var(--frost)]",
-        "data-[disabled]:pointer-events-none data-[disabled]:text-[var(--steel)]",
+        "text-ink py-1.5 pr-8 pl-2 text-sm outline-none",
+        "focus:bg-frost",
+        "data-[highlighted]:bg-frost",
+        "data-[disabled]:text-steel data-[disabled]:pointer-events-none",
         className,
       )}
       {...props}
@@ -122,7 +122,7 @@ function SelectSeparator({
   return (
     <SelectPrimitive.Separator
       data-slot="select-separator"
-      className={cn("pointer-events-none -mx-1 my-1 h-px bg-[var(--chrome)]", className)}
+      className={cn("bg-chrome pointer-events-none -mx-1 my-1 h-px", className)}
       {...props}
     />
   );

--- a/src/components/separator.stories.tsx
+++ b/src/components/separator.stories.tsx
@@ -23,12 +23,12 @@ export const Default: Story = {
     <div className="max-w-sm">
       <div className="space-y-1">
         <h4 className="text-sm leading-none font-medium">Section Title</h4>
-        <p className="text-sm text-[var(--steel)]">Section description text.</p>
+        <p className="text-steel text-sm">Section description text.</p>
       </div>
       <Separator className="my-4" />
       <div className="space-y-1">
         <h4 className="text-sm leading-none font-medium">Another Section</h4>
-        <p className="text-sm text-[var(--steel)]">More content here.</p>
+        <p className="text-steel text-sm">More content here.</p>
       </div>
     </div>
   ),
@@ -61,29 +61,29 @@ export const AllStates = () => (
     <div>
       <h3 className="mb-4 text-sm font-medium">Horizontal (default)</h3>
       <div className="max-w-sm space-y-4">
-        <p className="text-sm text-[var(--steel)]">Section A</p>
+        <p className="text-steel text-sm">Section A</p>
         <Separator />
-        <p className="text-sm text-[var(--steel)]">Section B</p>
+        <p className="text-steel text-sm">Section B</p>
       </div>
     </div>
 
     <div>
       <h3 className="mb-4 text-sm font-medium">Vertical</h3>
       <div className="flex h-6 items-center gap-4">
-        <span className="text-sm text-[var(--steel)]">Home</span>
+        <span className="text-steel text-sm">Home</span>
         <Separator orientation="vertical" />
-        <span className="text-sm text-[var(--steel)]">About</span>
+        <span className="text-steel text-sm">About</span>
         <Separator orientation="vertical" />
-        <span className="text-sm text-[var(--steel)]">Contact</span>
+        <span className="text-steel text-sm">Contact</span>
       </div>
     </div>
 
     <div>
       <h3 className="mb-4 text-sm font-medium">In a card-like layout</h3>
-      <div className="max-w-sm border border-[var(--chrome)] p-4">
+      <div className="border-chrome max-w-sm border p-4">
         <h4 className="font-medium">Card Title</h4>
         <Separator className="my-3" />
-        <p className="text-sm text-[var(--steel)]">Card content goes here.</p>
+        <p className="text-steel text-sm">Card content goes here.</p>
       </div>
     </div>
   </div>

--- a/src/components/separator.tsx
+++ b/src/components/separator.tsx
@@ -16,7 +16,7 @@ export function Separator({
       decorative={decorative}
       orientation={orientation}
       className={cn(
-        "shrink-0 bg-[var(--chrome)]",
+        "bg-chrome shrink-0",
         "data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full",
         "data-[orientation=vertical]:h-full data-[orientation=vertical]:w-px",
         className,

--- a/src/components/sheet.stories.tsx
+++ b/src/components/sheet.stories.tsx
@@ -44,7 +44,7 @@ export const Default: Story = {
           </Sheet.Description>
         </Sheet.Header>
         <div className="py-4">
-          <p className="text-sm text-[var(--steel)]">Sheet content goes here.</p>
+          <p className="text-steel text-sm">Sheet content goes here.</p>
         </div>
         <Sheet.Footer>
           <Sheet.Close>
@@ -68,7 +68,7 @@ export const LeftSide: Story = {
           <Sheet.Description>This sheet slides in from the left.</Sheet.Description>
         </Sheet.Header>
         <div className="py-4">
-          <p className="text-sm text-[var(--steel)]">Navigation menu or sidebar content.</p>
+          <p className="text-steel text-sm">Navigation menu or sidebar content.</p>
         </div>
       </>
     ),
@@ -139,16 +139,16 @@ export const FullScreen: Story = {
           <Sheet.Description>Full screen sheet for mobile navigation menus.</Sheet.Description>
         </Sheet.Header>
         <div className="flex flex-col gap-2 py-4">
-          <a href="#" className="block py-2 text-[var(--ink)] hover:text-[var(--signal-blue)]">
+          <a href="#" className="text-ink hover:text-signal-blue block py-2">
             Home
           </a>
-          <a href="#" className="block py-2 text-[var(--ink)] hover:text-[var(--signal-blue)]">
+          <a href="#" className="text-ink hover:text-signal-blue block py-2">
             Products
           </a>
-          <a href="#" className="block py-2 text-[var(--ink)] hover:text-[var(--signal-blue)]">
+          <a href="#" className="text-ink hover:text-signal-blue block py-2">
             About
           </a>
-          <a href="#" className="block py-2 text-[var(--ink)] hover:text-[var(--signal-blue)]">
+          <a href="#" className="text-ink hover:text-signal-blue block py-2">
             Contact
           </a>
         </div>
@@ -169,9 +169,7 @@ function ControlledSheetExample() {
     <div className="flex flex-col gap-4">
       <div className="flex gap-2">
         <Button onClick={() => setOpen(true)}>Open Sheet</Button>
-        <span className="self-center text-sm text-[var(--steel)]">
-          Sheet is {open ? "open" : "closed"}
-        </span>
+        <span className="text-steel self-center text-sm">Sheet is {open ? "open" : "closed"}</span>
       </div>
       <Sheet open={open} onOpenChange={setOpen}>
         <Sheet.Header>

--- a/src/components/sheet.tsx
+++ b/src/components/sheet.tsx
@@ -120,12 +120,12 @@ export function Sheet({
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay
           data-slot="sheet-overlay"
-          className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-40 bg-[var(--ink)]/50"
+          className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 bg-ink/50 fixed inset-0 z-40"
         />
         <DialogPrimitive.Content
           data-slot="sheet-content"
           className={cn(
-            "shadow-offset-dark fixed z-50 gap-4 border border-[var(--chrome)] bg-[var(--paper)] p-4",
+            "shadow-offset-dark border-chrome bg-paper fixed z-50 gap-4 border p-4",
             fullScreen ? sidePositionsFullScreen[side] : sidePositions[side],
             sideAnimations[side],
           )}
@@ -135,7 +135,7 @@ export function Sheet({
           {children}
           <DialogPrimitive.Close
             data-slot="sheet-close"
-            className="absolute top-4 right-4 text-[var(--steel)] transition-colors hover:text-[var(--ink)] focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--signal-blue)] disabled:pointer-events-none"
+            className="text-steel hover:text-ink focus-visible:outline-signal-blue absolute top-4 right-4 transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none"
             aria-label="Close sheet"
           >
             <X className="size-4" aria-hidden="true" />
@@ -150,7 +150,7 @@ function SheetTitle({ className, ...props }: React.ComponentProps<typeof DialogP
   return (
     <DialogPrimitive.Title
       data-slot="sheet-title"
-      className={cn("text-xl leading-7 font-semibold text-[var(--ink)]", className)}
+      className={cn("text-ink text-xl leading-7 font-semibold", className)}
       {...props}
     />
   );
@@ -163,7 +163,7 @@ function SheetDescription({
   return (
     <DialogPrimitive.Description
       data-slot="sheet-description"
-      className={cn("text-sm text-[var(--steel)]", className)}
+      className={cn("text-steel text-sm", className)}
       {...props}
     />
   );

--- a/src/components/switch.stories.tsx
+++ b/src/components/switch.stories.tsx
@@ -35,15 +35,15 @@ export const Sizes: Story = {
     <div className="flex items-center gap-4">
       <div className="flex flex-col items-center gap-2">
         <Switch size="sm" defaultChecked aria-label="Small switch" />
-        <span className="text-xs text-[var(--steel)]">Small</span>
+        <span className="text-steel text-xs">Small</span>
       </div>
       <div className="flex flex-col items-center gap-2">
         <Switch size="md" defaultChecked aria-label="Medium switch" />
-        <span className="text-xs text-[var(--steel)]">Medium</span>
+        <span className="text-steel text-xs">Medium</span>
       </div>
       <div className="flex flex-col items-center gap-2">
         <Switch size="lg" defaultChecked aria-label="Large switch" />
-        <span className="text-xs text-[var(--steel)]">Large</span>
+        <span className="text-steel text-xs">Large</span>
       </div>
     </div>
   ),

--- a/src/components/switch.tsx
+++ b/src/components/switch.tsx
@@ -6,7 +6,7 @@ import { twMerge } from "tailwind-merge";
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
 const switchVariants = cva(
-  "peer inline-flex shrink-0 cursor-pointer items-center p-0.5 transition-colors outline-none data-[state=checked]:bg-[var(--signal-green)] data-[state=unchecked]:bg-[var(--chrome)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--signal-blue)] disabled:cursor-not-allowed disabled:opacity-50 border border-[var(--chrome)]",
+  "peer inline-flex shrink-0 cursor-pointer items-center p-0.5 transition-colors outline-none data-[state=checked]:bg-signal-green data-[state=unchecked]:bg-chrome focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-signal-blue disabled:cursor-not-allowed disabled:border-dashed disabled:border-chrome disabled:bg-frost border border-chrome",
   {
     variants: {
       size: {
@@ -22,7 +22,7 @@ const switchVariants = cva(
 );
 
 const switchThumbVariants = cva(
-  "pointer-events-none block bg-[var(--paper)] ring-0 transition-transform data-[state=unchecked]:translate-x-0",
+  "pointer-events-none block bg-paper ring-0 transition-transform data-[state=unchecked]:translate-x-0",
   {
     variants: {
       size: {

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -26,10 +26,7 @@ function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
   return (
     <thead
       data-slot="table-header"
-      className={cn(
-        "[&_tr]:border-b [&_tr]:border-[var(--graphite)] [&_tr]:bg-[var(--frost)]",
-        className,
-      )}
+      className={cn("[&_tr]:border-graphite [&_tr]:bg-frost [&_tr]:border-b", className)}
       {...props}
     />
   );
@@ -50,7 +47,7 @@ function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
     <tfoot
       data-slot="table-footer"
       className={cn(
-        "border-t border-[var(--chrome)] bg-[var(--frost)] font-medium [&>tr]:last:border-b-0",
+        "border-chrome bg-frost border-t font-medium [&>tr]:last:border-b-0",
         className,
       )}
       {...props}
@@ -63,7 +60,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "border-b border-[var(--chrome)] bg-[var(--paper)] hover:bg-[var(--frost)] data-[state=selected]:bg-[var(--platinum)]",
+        "border-chrome bg-paper hover:bg-frost data-[state=selected]:bg-platinum border-b",
         className,
       )}
       {...props}
@@ -76,7 +73,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "h-9 px-1.5 py-1 text-left align-middle font-semibold whitespace-nowrap text-[var(--ink)] [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-ink h-9 px-1.5 py-1 text-left align-middle font-semibold whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}
@@ -102,7 +99,7 @@ function TableSectionHeader({ className, ...props }: React.ComponentProps<"tr">)
     <tr
       data-slot="table-section-header"
       className={cn(
-        "bg-[var(--platinum)] [&>th]:border-y [&>th]:border-[var(--chrome)] [&>th]:px-1.5 [&>th]:py-1 [&>th]:font-semibold",
+        "bg-platinum [&>th]:border-chrome [&>th]:border-y [&>th]:px-1.5 [&>th]:py-1 [&>th]:font-semibold",
         className,
       )}
       {...props}
@@ -114,7 +111,7 @@ function TableCaption({ className, ...props }: React.ComponentProps<"caption">) 
   return (
     <caption
       data-slot="table-caption"
-      className={cn("mt-4 text-sm text-[var(--steel)]", className)}
+      className={cn("text-steel mt-4 text-sm", className)}
       {...props}
     />
   );

--- a/src/components/tabs.stories.tsx
+++ b/src/components/tabs.stories.tsx
@@ -29,17 +29,13 @@ export const Default: Story = {
       <Tabs.Content value="account">
         <div className="p-4">
           <h3 className="font-medium">Account Settings</h3>
-          <p className="mt-2 text-sm text-[var(--steel)]">
-            Manage your account settings and preferences.
-          </p>
+          <p className="text-steel mt-2 text-sm">Manage your account settings and preferences.</p>
         </div>
       </Tabs.Content>
       <Tabs.Content value="password">
         <div className="p-4">
           <h3 className="font-medium">Password Settings</h3>
-          <p className="mt-2 text-sm text-[var(--steel)]">
-            Update your password and security settings.
-          </p>
+          <p className="text-steel mt-2 text-sm">Update your password and security settings.</p>
         </div>
       </Tabs.Content>
     </Tabs>
@@ -56,16 +52,16 @@ export const MultipleTabs: Story = {
         <Tabs.Trigger value="settings">Settings</Tabs.Trigger>
       </Tabs.List>
       <Tabs.Content value="overview">
-        <div className="p-4 text-sm text-[var(--steel)]">Overview content</div>
+        <div className="text-steel p-4 text-sm">Overview content</div>
       </Tabs.Content>
       <Tabs.Content value="analytics">
-        <div className="p-4 text-sm text-[var(--steel)]">Analytics content</div>
+        <div className="text-steel p-4 text-sm">Analytics content</div>
       </Tabs.Content>
       <Tabs.Content value="reports">
-        <div className="p-4 text-sm text-[var(--steel)]">Reports content</div>
+        <div className="text-steel p-4 text-sm">Reports content</div>
       </Tabs.Content>
       <Tabs.Content value="settings">
-        <div className="p-4 text-sm text-[var(--steel)]">Settings content</div>
+        <div className="text-steel p-4 text-sm">Settings content</div>
       </Tabs.Content>
     </Tabs>
   ),
@@ -82,13 +78,13 @@ export const WithDisabled: Story = {
         <Tabs.Trigger value="another">Another</Tabs.Trigger>
       </Tabs.List>
       <Tabs.Content value="active">
-        <div className="p-4 text-sm text-[var(--steel)]">This tab is active.</div>
+        <div className="text-steel p-4 text-sm">This tab is active.</div>
       </Tabs.Content>
       <Tabs.Content value="disabled">
-        <div className="p-4 text-sm text-[var(--steel)]">You cannot see this.</div>
+        <div className="text-steel p-4 text-sm">You cannot see this.</div>
       </Tabs.Content>
       <Tabs.Content value="another">
-        <div className="p-4 text-sm text-[var(--steel)]">Another tab content.</div>
+        <div className="text-steel p-4 text-sm">Another tab content.</div>
       </Tabs.Content>
     </Tabs>
   ),
@@ -104,10 +100,10 @@ export const AllStates = () => (
           <Tabs.Trigger value="tab2">Second</Tabs.Trigger>
         </Tabs.List>
         <Tabs.Content value="tab1">
-          <div className="p-4 text-sm text-[var(--steel)]">First tab content</div>
+          <div className="text-steel p-4 text-sm">First tab content</div>
         </Tabs.Content>
         <Tabs.Content value="tab2">
-          <div className="p-4 text-sm text-[var(--steel)]">Second tab content</div>
+          <div className="text-steel p-4 text-sm">Second tab content</div>
         </Tabs.Content>
       </Tabs>
     </div>
@@ -123,10 +119,10 @@ export const AllStates = () => (
           <Tabs.Trigger value="enabled2">Also Enabled</Tabs.Trigger>
         </Tabs.List>
         <Tabs.Content value="enabled1">
-          <div className="p-4 text-sm text-[var(--steel)]">First enabled tab</div>
+          <div className="text-steel p-4 text-sm">First enabled tab</div>
         </Tabs.Content>
         <Tabs.Content value="enabled2">
-          <div className="p-4 text-sm text-[var(--steel)]">Second enabled tab</div>
+          <div className="text-steel p-4 text-sm">Second enabled tab</div>
         </Tabs.Content>
       </Tabs>
     </div>
@@ -141,16 +137,16 @@ export const AllStates = () => (
           <Tabs.Trigger value="t4">Tab 4</Tabs.Trigger>
         </Tabs.List>
         <Tabs.Content value="t1">
-          <div className="p-4 text-sm text-[var(--steel)]">Content 1</div>
+          <div className="text-steel p-4 text-sm">Content 1</div>
         </Tabs.Content>
         <Tabs.Content value="t2">
-          <div className="p-4 text-sm text-[var(--steel)]">Content 2</div>
+          <div className="text-steel p-4 text-sm">Content 2</div>
         </Tabs.Content>
         <Tabs.Content value="t3">
-          <div className="p-4 text-sm text-[var(--steel)]">Content 3</div>
+          <div className="text-steel p-4 text-sm">Content 3</div>
         </Tabs.Content>
         <Tabs.Content value="t4">
-          <div className="p-4 text-sm text-[var(--steel)]">Content 4</div>
+          <div className="text-steel p-4 text-sm">Content 4</div>
         </Tabs.Content>
       </Tabs>
     </div>

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -24,7 +24,7 @@ function TabsList({ className, shadow, ...props }: TabsListProps) {
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "inline-flex h-9 w-fit items-center justify-center border border-[var(--chrome)] bg-[var(--frost)] p-[3px] text-[var(--ink)]",
+        "border-chrome bg-frost text-ink inline-flex h-9 w-fit items-center justify-center border p-[3px]",
         shadow && "shadow-offset",
         className,
       )}
@@ -39,10 +39,10 @@ function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPr
       data-slot="tabs-trigger"
       className={cn(
         "inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 px-2 py-1 text-sm font-medium whitespace-nowrap transition-colors",
-        "border border-transparent text-[var(--ink)]",
-        "data-[state=active]:bg-[var(--ink)] data-[state=active]:text-[var(--paper)]",
-        "focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--signal-blue)]",
-        "disabled:pointer-events-none disabled:text-[var(--steel)]",
+        "text-ink border border-transparent",
+        "data-[state=active]:bg-ink data-[state=active]:text-paper",
+        "focus-visible:outline-signal-blue focus-visible:outline-2 focus-visible:outline-offset-2",
+        "disabled:text-steel disabled:pointer-events-none",
         "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
         className,
       )}

--- a/src/components/textarea.tsx
+++ b/src/components/textarea.tsx
@@ -36,12 +36,12 @@ export function Textarea({ className, autoResize = true, onInput, ...props }: Pr
       ref={textareaRef}
       data-slot="textarea"
       className={cn(
-        "w-full border border-[var(--graphite)] bg-[var(--paper)] px-3 py-2 text-sm text-[var(--ink)]",
-        "placeholder:text-[var(--steel)]",
-        "focus:ring-2 focus:ring-[var(--signal-blue)] focus:ring-offset-1 focus:outline-none",
-        "disabled:cursor-not-allowed disabled:border-dashed disabled:border-[var(--chrome)] disabled:bg-[var(--frost)] disabled:text-[var(--steel)]",
-        "read-only:cursor-default read-only:bg-[var(--frost)]",
-        "aria-[invalid=true]:border-[var(--signal-red)] aria-[invalid=true]:focus:ring-[var(--signal-red)]",
+        "border-graphite bg-paper text-ink w-full border px-3 py-2 text-sm",
+        "placeholder:text-steel",
+        "focus:ring-signal-blue focus:ring-2 focus:ring-offset-1 focus:outline-none",
+        "disabled:border-chrome disabled:bg-frost disabled:text-steel disabled:cursor-not-allowed disabled:border-dashed",
+        "read-only:bg-frost read-only:cursor-default",
+        "aria-[invalid=true]:border-signal-red aria-[invalid=true]:focus:ring-signal-red",
         autoResize && "resize-none overflow-hidden",
         className,
       )}

--- a/src/components/tooltip.stories.tsx
+++ b/src/components/tooltip.stories.tsx
@@ -78,7 +78,7 @@ export const AllStates = () => (
   <TooltipProvider>
     <div className="flex flex-col gap-8 py-12">
       <div className="flex items-center gap-4">
-        <span className="w-24 text-sm text-[var(--steel)]">Default</span>
+        <span className="text-steel w-24 text-sm">Default</span>
         <Tooltip>
           <Tooltip.Trigger asChild>
             <Button variant="outline">Hover</Button>
@@ -88,11 +88,11 @@ export const AllStates = () => (
       </div>
 
       <div className="flex items-center gap-4">
-        <span className="w-24 text-sm text-[var(--steel)]">On icon</span>
+        <span className="text-steel w-24 text-sm">On icon</span>
         <Tooltip>
           <Tooltip.Trigger asChild>
             <button
-              className="inline-flex size-8 items-center justify-center border border-[var(--chrome)] text-[var(--steel)] hover:text-[var(--ink)]"
+              className="border-chrome text-steel hover:text-ink inline-flex size-8 items-center justify-center border"
               aria-label="Help"
             >
               ?
@@ -103,7 +103,7 @@ export const AllStates = () => (
       </div>
 
       <div className="flex items-center gap-4">
-        <span className="w-24 text-sm text-[var(--steel)]">Long text</span>
+        <span className="text-steel w-24 text-sm">Long text</span>
         <Tooltip>
           <Tooltip.Trigger asChild>
             <Button variant="outline">Long tooltip</Button>

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -49,7 +49,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "shadow-offset z-50 overflow-hidden border border-[var(--ink)] bg-[var(--ink)] px-3 py-1.5 text-xs text-[var(--paper)]",
+          "shadow-offset border-ink bg-ink text-paper z-50 overflow-hidden border px-3 py-1.5 text-xs",
           "animate-in fade-in-0 zoom-in-95",
           "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
           "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",

--- a/src/components/typography.stories.tsx
+++ b/src/components/typography.stories.tsx
@@ -13,48 +13,44 @@ const typeScale = [
 
 function Typography() {
   return (
-    <div className="min-h-screen bg-[var(--paper)] p-6">
+    <div className="bg-paper min-h-screen p-6">
       <div className="max-w-3xl">
         {/* Header */}
-        <div className="mb-8 border-b border-[var(--chrome)] pb-4">
-          <h1 className="text-2xl font-bold text-[var(--ink)]">Typography</h1>
-          <p className="mt-1 text-sm text-[var(--steel)]">
+        <div className="border-chrome mb-8 border-b pb-4">
+          <h1 className="text-ink text-2xl font-bold">Typography</h1>
+          <p className="text-steel mt-1 text-sm">
             System fonts. 4px baseline grid. Functional hierarchy.
           </p>
         </div>
 
         {/* Font Stack */}
         <section className="mb-8">
-          <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">
-            Font Stack
-          </h2>
-          <div className="border border-[var(--chrome)] bg-[var(--frost)] p-4">
-            <code className="block text-xs text-[var(--ink)]">
+          <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">Font Stack</h2>
+          <div className="border-chrome bg-frost border p-4">
+            <code className="text-ink block text-xs">
               -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif
             </code>
-            <code className="mt-2 block text-xs text-[var(--ink)]">
-              <span className="text-[var(--steel)]">Mono:</span> ui-monospace, SFMono-Regular, "SF
-              Mono", Menlo, monospace
+            <code className="text-ink mt-2 block text-xs">
+              <span className="text-steel">Mono:</span> ui-monospace, SFMono-Regular, "SF Mono",
+              Menlo, monospace
             </code>
           </div>
         </section>
 
         {/* Type Scale */}
         <section className="mb-8">
-          <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">
-            Type Scale
-          </h2>
-          <div className="divide-y divide-[var(--chrome)] border border-[var(--chrome)]">
+          <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">Type Scale</h2>
+          <div className="divide-chrome border-chrome divide-y border">
             {typeScale.map((type) => (
-              <div key={type.element} className="bg-[var(--paper)] p-4">
+              <div key={type.element} className="bg-paper p-4">
                 <div className="mb-2 flex items-baseline justify-between">
-                  <code className="text-xs text-[var(--signal-blue)]">&lt;{type.element}&gt;</code>
-                  <span className="text-xs text-[var(--aluminum)]">
+                  <code className="text-signal-blue text-xs">&lt;{type.element}&gt;</code>
+                  <span className="text-muted text-xs">
                     {type.size} / {type.lineHeight}
                   </span>
                 </div>
                 <div
-                  className="text-[var(--ink)]"
+                  className="text-ink"
                   style={{
                     fontSize: type.size,
                     lineHeight: type.lineHeight,
@@ -69,7 +65,7 @@ function Typography() {
                     ? "const brutalist = true;"
                     : "The quick brown fox jumps over the lazy dog"}
                 </div>
-                <div className="mt-2 text-xs text-[var(--aluminum)]">{type.usage}</div>
+                <div className="text-muted mt-2 text-xs">{type.usage}</div>
               </div>
             ))}
           </div>
@@ -77,22 +73,23 @@ function Typography() {
 
         {/* Baseline Grid */}
         <section className="mb-8">
-          <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">
+          <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">
             Baseline Grid
           </h2>
-          <p className="mb-3 text-xs text-[var(--aluminum)]">
+          <p className="text-muted mb-3 text-xs">
             All spacing uses 4px increments. Line heights align to the grid.
           </p>
           <div
-            className="relative border border-[var(--chrome)] p-4"
+            className="border-chrome relative border p-4"
             style={{
-              backgroundImage: "linear-gradient(to bottom, var(--chrome) 1px, transparent 1px)",
+              backgroundImage:
+                "linear-gradient(to bottom, var(--color-chrome) 1px, transparent 1px)",
               backgroundSize: "100% 4px",
             }}
           >
-            <div className="relative bg-[var(--paper)]">
+            <div className="bg-paper relative">
               <h3
-                className="text-[var(--ink)]"
+                className="text-ink"
                 style={{
                   fontSize: "20px",
                   lineHeight: "28px",
@@ -103,13 +100,13 @@ function Typography() {
                 Heading aligns to grid
               </h3>
               <p
-                className="text-[var(--ink)]"
+                className="text-ink"
                 style={{ fontSize: "14px", lineHeight: "24px", marginBottom: "16px" }}
               >
                 Body text with 24px line-height. Each line sits on the 4px baseline grid. Margins
                 are multiples of 4px to maintain vertical rhythm throughout the interface.
               </p>
-              <p className="text-[var(--steel)]" style={{ fontSize: "12px", lineHeight: "16px" }}>
+              <p className="text-steel" style={{ fontSize: "12px", lineHeight: "16px" }}>
                 Small text caption at 12px/16px
               </p>
             </div>
@@ -118,15 +115,15 @@ function Typography() {
 
         {/* Spacing Reference */}
         <section className="mb-8">
-          <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">
+          <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">
             Spacing Scale
           </h2>
-          <div className="divide-y divide-[var(--chrome)] border border-[var(--chrome)]">
+          <div className="divide-chrome border-chrome divide-y border">
             {[4, 8, 12, 16, 20, 24, 32, 40, 48].map((px) => (
-              <div key={px} className="flex items-center bg-[var(--paper)] p-3">
-                <code className="w-16 text-xs text-[var(--ink)]">{px}px</code>
-                <div className="h-3 bg-[var(--signal-blue)]" style={{ width: px * 2 }} />
-                <span className="ml-3 text-xs text-[var(--aluminum)]">{px / 4} baseline units</span>
+              <div key={px} className="bg-paper flex items-center p-3">
+                <code className="text-ink w-16 text-xs">{px}px</code>
+                <div className="bg-signal-blue h-3" style={{ width: px * 2 }} />
+                <span className="text-muted ml-3 text-xs">{px / 4} baseline units</span>
               </div>
             ))}
           </div>
@@ -134,11 +131,11 @@ function Typography() {
 
         {/* Design Rules */}
         <section>
-          <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">
+          <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">
             Typography Rules
           </h2>
-          <div className="border border-[var(--chrome)] bg-[var(--frost)] p-4">
-            <ul className="space-y-2 text-xs text-[var(--ink)]">
+          <div className="border-chrome bg-frost border p-4">
+            <ul className="text-ink space-y-2 text-xs">
               <li>
                 <strong>System fonts only</strong> — No custom web fonts
               </li>
@@ -150,11 +147,11 @@ function Typography() {
               </li>
               <li>
                 <strong>Ink for text</strong> — Primary text uses{" "}
-                <code className="text-[var(--signal-blue)]">var(--ink)</code>
+                <code className="text-signal-blue">text-ink</code>
               </li>
               <li>
                 <strong>Steel for secondary</strong> — Muted text uses{" "}
-                <code className="text-[var(--signal-blue)]">var(--steel)</code>
+                <code className="text-signal-blue">text-steel</code>
               </li>
             </ul>
           </div>
@@ -185,21 +182,19 @@ type Story = StoryObj<typeof Typography>;
 export const Default: Story = {};
 
 export const TypeScale = () => (
-  <div className="bg-[var(--paper)] p-6">
-    <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">
-      Type Scale
-    </h2>
-    <div className="max-w-xl divide-y divide-[var(--chrome)] border border-[var(--chrome)]">
+  <div className="bg-paper p-6">
+    <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">Type Scale</h2>
+    <div className="divide-chrome border-chrome max-w-xl divide-y border">
       {typeScale.map((type) => (
-        <div key={type.element} className="bg-[var(--paper)] p-4">
+        <div key={type.element} className="bg-paper p-4">
           <div className="mb-2 flex items-baseline justify-between">
-            <code className="text-xs text-[var(--signal-blue)]">&lt;{type.element}&gt;</code>
-            <span className="text-xs text-[var(--aluminum)]">
+            <code className="text-signal-blue text-xs">&lt;{type.element}&gt;</code>
+            <span className="text-muted text-xs">
               {type.size} / {type.lineHeight}
             </span>
           </div>
           <div
-            className="text-[var(--ink)]"
+            className="text-ink"
             style={{
               fontSize: type.size,
               lineHeight: type.lineHeight,
@@ -221,33 +216,30 @@ export const TypeScale = () => (
 );
 
 export const BaselineGrid = () => (
-  <div className="bg-[var(--paper)] p-6">
-    <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">
+  <div className="bg-paper p-6">
+    <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">
       Baseline Grid (4px)
     </h2>
     <div
-      className="max-w-xl border border-[var(--chrome)] p-4"
+      className="border-chrome max-w-xl border p-4"
       style={{
-        backgroundImage: "linear-gradient(to bottom, var(--chrome) 1px, transparent 1px)",
+        backgroundImage: "linear-gradient(to bottom, var(--color-chrome) 1px, transparent 1px)",
         backgroundSize: "100% 4px",
       }}
     >
       <h3
-        className="bg-[var(--paper)] text-[var(--ink)]"
+        className="bg-paper text-ink"
         style={{ fontSize: "20px", lineHeight: "28px", fontWeight: 600, marginBottom: "8px" }}
       >
         Heading text
       </h3>
       <p
-        className="bg-[var(--paper)] text-[var(--ink)]"
+        className="bg-paper text-ink"
         style={{ fontSize: "14px", lineHeight: "24px", marginBottom: "16px" }}
       >
         Body text aligns to the 4px grid. Line heights and margins are always multiples of 4.
       </p>
-      <p
-        className="bg-[var(--paper)] text-[var(--steel)]"
-        style={{ fontSize: "12px", lineHeight: "16px" }}
-      >
+      <p className="bg-paper text-steel" style={{ fontSize: "12px", lineHeight: "16px" }}>
         Caption text at 12px/16px
       </p>
     </div>
@@ -255,15 +247,13 @@ export const BaselineGrid = () => (
 );
 
 export const SpacingScale = () => (
-  <div className="bg-[var(--paper)] p-6">
-    <h2 className="mb-3 text-xs font-bold tracking-wider text-[var(--steel)] uppercase">
-      Spacing Scale
-    </h2>
-    <div className="max-w-md divide-y divide-[var(--chrome)] border border-[var(--chrome)]">
+  <div className="bg-paper p-6">
+    <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">Spacing Scale</h2>
+    <div className="divide-chrome border-chrome max-w-md divide-y border">
       {[4, 8, 12, 16, 24, 32, 48].map((px) => (
-        <div key={px} className="flex items-center bg-[var(--paper)] p-3">
-          <code className="w-12 text-xs text-[var(--ink)]">{px}px</code>
-          <div className="h-3 bg-[var(--signal-blue)]" style={{ width: px * 2 }} />
+        <div key={px} className="bg-paper flex items-center p-3">
+          <code className="text-ink w-12 text-xs">{px}px</code>
+          <div className="bg-signal-blue h-3" style={{ width: px * 2 }} />
         </div>
       ))}
     </div>

--- a/src/css-variables.css
+++ b/src/css-variables.css
@@ -2,43 +2,47 @@
  * Beaket UI Design System - Core Variables
  * This file is the single source of truth for CSS variables.
  * Used by: styles.css (via @import) and CLI init command (via build script)
+ *
+ * BREAKING CHANGE: Colors now use --color-* prefix (Tailwind v4 convention).
+ * Components use clean utilities: bg-paper, text-ink, border-chrome
  */
 
 @theme {
-  --color-inverse: var(--paper);
-  --shadow-offset: 2px 2px 0px 0px var(--chrome);
-  --shadow-offset-dark: 2px 2px 0px 0px var(--aluminum);
-  --shadow-offset-hover: 3px 3px 0px 0px var(--chrome);
-  --shadow-offset-active: 1px 1px 0px 0px var(--chrome);
-}
-
-:root {
   /* Neutral palette */
-  --graphite: #0d0d0d;
-  --ink: #1a1a1a;
-  --branch: #1c1f24;
-  --iron: #2d2d2d;
-  --slate: #404040;
-  --zinc: #525252;
-  --steel: #595959;
-  --aluminum: #9e9e9e;
-  --chrome: #d0d0d0;
-  --silver: #dedede;
-  --platinum: #e8e8e8;
-  --frost: #f5f5f5;
-  --paper: #fafafa;
+  --color-graphite: #0d0d0d;
+  --color-ink: #1a1a1a;
+  --color-branch: #1c1f24;
+  --color-iron: #2d2d2d;
+  --color-slate: #404040;
+  --color-zinc: #525252;
+  --color-steel: #595959;
+  --color-muted: #737373;
+  --color-aluminum: #9e9e9e;
+  --color-chrome: #d4d4d4;
+  --color-silver: #dedede;
+  --color-platinum: #ebebeb;
+  --color-frost: #f5f5f5;
+  --color-paper: #fafafa;
+  --color-inverse: var(--color-paper);
 
   /* Signal colors */
-  --signal-blue: #00449e;
-  --signal-red: #c41e1e;
-  --signal-red-hover: #b71c1c;
-  --signal-red-active: #9a1919;
-  --signal-green: #00794c;
-  --signal-green-hover: #0f5f42;
-  --signal-green-active: #0a4a32;
-  --signal-amber: #b8860b;
-  --signal-amber-hover: #9a7209;
-  --signal-amber-active: #7a5a07;
-  --signal-purple: #6f2da8;
-  --signal-cyan: #1a6b7c;
+  --color-signal-blue: #1a56a0;
+  --color-signal-red: #c41e1e;
+  --color-signal-red-hover: #b71c1c;
+  --color-signal-red-active: #9a1919;
+  --color-signal-red-text: #b91c1c;
+  --color-signal-green: #00794c;
+  --color-signal-green-hover: #0f5f42;
+  --color-signal-green-active: #0a4a32;
+  --color-signal-amber: #b8860b;
+  --color-signal-amber-hover: #9a7209;
+  --color-signal-amber-active: #7a5a07;
+  --color-signal-purple: #6f2da8;
+  --color-signal-cyan: #1a6b7c;
+
+  /* Shadows (offset only, no blur) */
+  --shadow-offset: 2px 2px 0px 0px var(--color-chrome);
+  --shadow-offset-dark: 2px 2px 0px 0px var(--color-aluminum);
+  --shadow-offset-hover: 3px 3px 0px 0px var(--color-chrome);
+  --shadow-offset-active: 1px 1px 0px 0px var(--color-chrome);
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -17,34 +17,29 @@
    * =========================================== */
 
   /* Text */
-  --color-text-primary: var(--graphite);
-  --color-text-secondary: var(--steel);
-  --color-text-muted: var(--aluminum);
-  --color-text-inverse: var(--paper);
-  --color-text-link: var(--signal-blue);
+  --color-text-primary: var(--color-graphite);
+  --color-text-secondary: var(--color-steel);
+  --color-text-muted: var(--color-muted);
+  --color-text-inverse: var(--color-paper);
+  --color-text-link: var(--color-signal-blue);
 
   /* Backgrounds */
-  --color-bg-primary: var(--paper);
-  --color-bg-secondary: var(--frost);
-  --color-bg-tertiary: var(--platinum);
-  --color-bg-inverse: var(--ink);
-  --color-bg-hover: var(--frost);
-  --color-bg-active: var(--platinum);
+  --color-bg-primary: var(--color-paper);
+  --color-bg-secondary: var(--color-frost);
+  --color-bg-tertiary: var(--color-platinum);
+  --color-bg-inverse: var(--color-ink);
+  --color-bg-hover: var(--color-frost);
+  --color-bg-active: var(--color-platinum);
 
   /* Borders */
-  --color-border-default: var(--chrome);
-  --color-border-strong: var(--graphite);
-  --color-border-muted: var(--silver);
+  --color-border-default: var(--color-chrome);
+  --color-border-strong: var(--color-graphite);
+  --color-border-muted: var(--color-silver);
 
   /* ===========================================
    * TYPOGRAPHY
    * Type scale and font stacks
    * =========================================== */
-
-  /* Font families */
-  --font-sans:
-    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-  --font-mono: "SF Mono", "Roboto Mono", Menlo, Monaco, Consolas, monospace;
 
   /* Type scale */
   --text-xs: 0.6875rem; /* 11px */
@@ -81,15 +76,6 @@
   --space-6: 1.75rem; /* 28px - large */
   --space-7: 2.625rem; /* 42px - section */
   --space-8: 3.5rem; /* 56px - page */
-
-  /* ===========================================
-   * SHADOWS
-   * Offset shadow system for brutalist depth
-   * =========================================== */
-
-  --shadow-offset: 2px 2px 0px 0px var(--chrome);
-  --shadow-offset-dark: 2px 2px 0px 0px var(--aluminum);
-  --shadow-offset-none: none;
 
   /* ===========================================
    * BORDERS


### PR DESCRIPTION
## Summary

- **CSS token migration**: Move all color tokens from `:root` to `@theme` with `--color-*` prefix (Tailwind v4 convention), enabling clean utilities like `bg-paper` instead of `bg-[var(--paper)]`
- **Token value unification**: Align chrome (`#d4d4d4`), platinum (`#ebebeb`), and signal-blue (`#1a56a0`) with Beaket app values
- **Accessibility tokens**: Add `--color-muted` (`#737373`, WCAG AA 4.5:1+) and `--color-signal-red-text` (`#b91c1c`, AAA on paper)
- **Component accessibility fixes**: aria-hidden on decorative icons, aria-label on nav/search, aria-live on loading spinners, indeterminate checkbox support, disabled states use border-dashed instead of opacity

### Breaking Changes

All CSS variable names changed from `--graphite` to `--color-graphite` (etc.). Components now use Tailwind utilities directly (`bg-paper`) instead of arbitrary values (`bg-[var(--paper)]`). Users who have customized tokens in their CSS need to rename them with the `--color-` prefix.

### Files changed (44)

| Area | Files | Changes |
|------|-------|---------|
| CSS tokens | `css-variables.css`, `styles.css` | Token naming + values |
| Components (25) | `alert.tsx` through `tooltip.tsx` | Utility migration + a11y |
| Stories | `*.stories.tsx`, `colors.stories.tsx`, `typography.stories.tsx` | Updated references |
| Changeset | `redesign-token-unification.md` | Major bump |

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm format:check` — all files pass
- [x] `pnpm build` — Storybook builds successfully
- [ ] `pnpm dev` — visual review of all components in Storybook
- [ ] `pnpm test-storybook` — interaction tests pass
- [ ] Verify no remaining `var(--` references to old token names

🤖 Generated with [Claude Code](https://claude.com/claude-code)