### PR TITLE
fix(a11y): UX audit improvements across 9 components

### DIFF
--- a/.changeset/ux-audit-improvements.md
+++ b/.changeset/ux-audit-improvements.md
@@ -1,0 +1,15 @@
+---
+"@beaket/ui": patch
+---
+
+Fix accessibility and UX issues across 9 components
+
+- DataTable: add `aria-sort` on sortable headers and `scope="col"` for screen reader table navigation
+- ViewToggle: make `label` required for icon-only buttons (a11y)
+- Skeleton: add `role="status"` and `aria-label` for screen readers
+- Select: fix focus ring to use `focus-visible:` consistently
+- Badge: add missing `data-slot="badge"`
+- Avatar: add dev warning when `alt` prop is missing on Avatar.Image
+- Radio: fix broken disabled indicator dot color using `group-disabled` pattern
+- Navigation: add `transition-shadow`, `active:shadow-offset-active`, suppress shadow/hover when active
+- Switch: fix disabled+checked state showing green, improve thumb contrast when disabled

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -24,10 +24,23 @@ export function Avatar({ className, ...props }: Props) {
   );
 }
 
-function AvatarImage({ className, ...props }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+function AvatarImage({
+  className,
+  alt,
+  ...props
+}: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  if (process.env.NODE_ENV !== "production") {
+    if (!alt) {
+      console.warn(
+        "Avatar.Image: `alt` prop is missing. Provide descriptive alt text for accessibility.",
+      );
+    }
+  }
+
   return (
     <AvatarPrimitive.Image
       data-slot="avatar-image"
+      alt={alt}
       className={cn("aspect-square size-full", className)}
       {...props}
     />

--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -10,7 +10,9 @@ export interface Props extends React.HTMLAttributes<HTMLSpanElement> {
 }
 
 export function Badge({ className, variant, ...props }: Props) {
-  return <span className={cn(badgeVariants({ variant }), className)} {...props} />;
+  return (
+    <span data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
 }
 
 const badgeVariants = cva(

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -184,6 +184,7 @@ export function DataTable<TData, TValue>({
                   return (
                     <Table.Head
                       key={header.id}
+                      scope="col"
                       className={canSort ? "cursor-pointer select-none" : ""}
                       style={{ width: header.getSize() }}
                       onClick={canSort ? header.column.getToggleSortingHandler() : undefined}

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -187,6 +187,15 @@ export function DataTable<TData, TValue>({
                       className={canSort ? "cursor-pointer select-none" : ""}
                       style={{ width: header.getSize() }}
                       onClick={canSort ? header.column.getToggleSortingHandler() : undefined}
+                      aria-sort={
+                        canSort
+                          ? sortDirection === "asc"
+                            ? "ascending"
+                            : sortDirection === "desc"
+                              ? "descending"
+                              : "none"
+                          : undefined
+                      }
                     >
                       {header.isPlaceholder ? null : (
                         <div className="flex items-center gap-2">

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -34,9 +34,10 @@ function NavigationLink({ className, active, ...props }: NavigationLinkProps) {
       className={cn(
         "inline-block min-w-[80px] px-4 py-1 text-center text-sm no-underline",
         "border-graphite bg-paper text-ink border",
-        "shadow-offset hover:shadow-offset-hover",
+        "shadow-offset hover:shadow-offset-hover active:shadow-offset-active",
         "hover:bg-frost",
-        "data-[active]:text-inverse data-[active]:bg-ink",
+        "transition-shadow duration-100",
+        "data-[active]:text-inverse data-[active]:bg-ink data-[active]:hover:bg-ink data-[active]:shadow-none data-[active]:hover:shadow-none",
         className,
       )}
       aria-current={active ? "page" : undefined}

--- a/src/components/radio.tsx
+++ b/src/components/radio.tsx
@@ -29,7 +29,7 @@ export function RadioItem({ className, ...props }: RadioItemProps) {
     <RadioGroupPrimitive.Item
       data-slot="radio-item"
       className={cn(
-        "peer border-chrome size-4 shrink-0 rounded-full border",
+        "group peer border-chrome size-4 shrink-0 rounded-full border",
         "bg-paper",
         "hover:border-steel",
         "focus-visible:outline-signal-blue focus-visible:outline-2 focus-visible:outline-offset-2",
@@ -45,7 +45,7 @@ export function RadioItem({ className, ...props }: RadioItemProps) {
         data-slot="radio-indicator"
         className="flex items-center justify-center"
       >
-        <span className="bg-ink data-[disabled]:bg-steel size-2 rounded-full" />
+        <span className="bg-ink group-disabled:bg-steel size-2 rounded-full" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   );

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -32,7 +32,7 @@ function SelectTrigger({ className, size = "default", children, ...props }: Sele
       className={cn(
         "flex w-full items-center justify-between gap-2",
         "border-graphite bg-paper text-ink border px-3 py-2 text-sm",
-        "focus:border-signal-blue focus:outline-none",
+        "focus-visible:border-signal-blue focus-visible:outline-none",
         "disabled:bg-frost disabled:text-steel disabled:cursor-not-allowed disabled:border-dashed",
         "aria-[invalid=true]:border-signal-red",
         "[&_svg]:pointer-events-none [&_svg]:shrink-0",

--- a/src/components/skeleton.tsx
+++ b/src/components/skeleton.tsx
@@ -5,6 +5,12 @@ const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
 export function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <div data-slot="skeleton" className={cn("bg-frost animate-pulse", className)} {...props} />
+    <div
+      data-slot="skeleton"
+      role="status"
+      aria-label="Loading"
+      className={cn("bg-frost animate-pulse", className)}
+      {...props}
+    />
   );
 }

--- a/src/components/switch.tsx
+++ b/src/components/switch.tsx
@@ -6,7 +6,7 @@ import { twMerge } from "tailwind-merge";
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
 const switchVariants = cva(
-  "peer inline-flex shrink-0 cursor-pointer items-center p-0.5 transition-colors outline-none data-[state=checked]:bg-signal-green data-[state=unchecked]:bg-chrome focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-signal-blue disabled:cursor-not-allowed disabled:border-dashed disabled:border-chrome disabled:bg-frost border border-chrome",
+  "group peer inline-flex shrink-0 cursor-pointer items-center p-0.5 transition-colors outline-none data-[state=checked]:bg-signal-green data-[state=unchecked]:bg-chrome focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-signal-blue disabled:cursor-not-allowed disabled:border-dashed disabled:border-chrome disabled:bg-frost disabled:data-[state=checked]:bg-frost border border-chrome",
   {
     variants: {
       size: {
@@ -22,7 +22,7 @@ const switchVariants = cva(
 );
 
 const switchThumbVariants = cva(
-  "pointer-events-none block bg-paper ring-0 transition-transform data-[state=unchecked]:translate-x-0",
+  "pointer-events-none block bg-paper group-disabled:bg-chrome ring-0 transition-transform data-[state=unchecked]:translate-x-0",
   {
     variants: {
       size: {

--- a/src/components/view-toggle.tsx
+++ b/src/components/view-toggle.tsx
@@ -9,8 +9,8 @@ export interface ViewToggleItem<T extends string> {
   value: T;
   /** Icon to display */
   icon: ReactNode;
-  /** Accessible label for the button */
-  label?: string;
+  /** Accessible label for the button (required for icon-only buttons) */
+  label: string;
 }
 
 export interface ViewToggleProps<T extends string> {


### PR DESCRIPTION
## Summary

- **DataTable**: add `aria-sort` on sortable headers + `scope="col"` for screen reader table navigation
- **ViewToggle**: make `label` required for icon-only buttons (WCAG: aria-labels)
- **Skeleton**: add `role="status"` + `aria-label` for screen reader announcement
- **Select**: fix focus ring to `focus-visible:` for consistency with all other components
- **Badge**: add missing `data-slot="badge"` (consistency with all other components)
- **Avatar**: add dev warning when `alt` prop is missing on `Avatar.Image`
- **Radio**: fix broken disabled indicator dot color — `data-[disabled]` on `<span>` never matched because the attribute lives on the parent `Item`, not the span. Fixed with `group`/`group-disabled` pattern
- **Navigation**: add `transition-shadow duration-100` + `active:shadow-offset-active`, suppress shadow and hover bg when active (light chrome shadow on dark ink bg looked wrong)
- **Switch**: add `disabled:data-[state=checked]:bg-frost` so disabled+checked doesn't show green; add `group-disabled:bg-chrome` on thumb for visible contrast against frost track

## Test plan

- [ ] Verify Storybook builds successfully (`pnpm build`)
- [ ] Check DataTable sort headers announce sort direction with screen reader
- [ ] Verify Radio disabled+checked state shows steel dot (not ink)
- [ ] Verify Switch disabled+checked state shows frost track (not green)
- [ ] Verify Navigation active link has no shadow and no hover bg change
- [ ] Verify Select trigger only shows focus ring on keyboard focus (not click)
- [ ] Check Avatar.Image logs dev warning in console when `alt` is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)