### PR TITLE
fix(a11y): harden, normalize, and adapt 14 components

### DIFF
--- a/.changeset/a11y-harden-normalize-adapt.md
+++ b/.changeset/a11y-harden-normalize-adapt.md
@@ -1,0 +1,17 @@
+---
+"@beaket/ui": patch
+---
+
+Fix accessibility and consistency issues across 14 components
+
+- DataTable: add keyboard support (Enter/Space) on clickable rows, optimize selection useEffect
+- Button: add data-slot and default type="button"
+- Alert: remove line-clamp-1 from title
+- NavigationProgress: add aria-valuetext
+- Sheet: add hideCloseButton prop for Dialog API parity
+- Input, Textarea, Select: normalize focus indicators to focus-visible:outline
+- Radio: align border weight with Checkbox (border-graphite)
+- Tooltip: remove shadow-offset from dark surface
+- Blockquote: use border-l-2 to match border-width-medium token
+- Checkbox, Radio, Switch, Dialog/Sheet close: expand touch targets to 44px
+- Select: add disabled:border-chrome to match other form controls

--- a/src/components/alert.tsx
+++ b/src/components/alert.tsx
@@ -62,10 +62,7 @@ export function Alert({ className, variant = "note", title, children, ...props }
       {...props}
     >
       <Icon />
-      <div
-        data-slot="alert-title"
-        className="col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight"
-      >
+      <div data-slot="alert-title" className="col-start-2 min-h-4 font-medium tracking-tight">
         {displayTitle}
       </div>
       {children && (

--- a/src/components/blockquote.tsx
+++ b/src/components/blockquote.tsx
@@ -23,7 +23,7 @@ export function Blockquote({
   return (
     <blockquote
       data-slot="blockquote"
-      className={cn("border-graphite my-4 border-l py-1 pl-3", className)}
+      className={cn("border-graphite my-4 border-l-2 py-1 pl-3", className)}
       cite={cite}
       {...props}
     >

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -36,13 +36,16 @@ export function Button({
   children,
   mono = false,
   asChild = false,
+  type,
   ...props
 }: Props) {
   const Comp = asChild ? Slot : "button";
 
   return (
     <Comp
+      data-slot="button"
       className={cn(buttonVariants({ variant, size, mono }), className)}
+      type={!asChild ? (type ?? "button") : undefined}
       disabled={!asChild ? disabled || loading : undefined}
       {...props}
     >

--- a/src/components/checkbox.tsx
+++ b/src/components/checkbox.tsx
@@ -15,7 +15,7 @@ export function Checkbox({ className, ...props }: Props) {
     <CheckboxPrimitive.Root
       data-slot="checkbox"
       className={cn(
-        "group peer border-graphite size-4 shrink-0 border",
+        "group peer border-graphite relative size-4 shrink-0 border before:absolute before:inset-[-14px] before:content-['']",
         "bg-paper",
         "focus-visible:outline-signal-blue focus-visible:outline-2 focus-visible:outline-offset-2",
         "data-[state=checked]:border-ink data-[state=checked]:bg-ink data-[state=checked]:text-paper",

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -22,7 +22,7 @@ import {
   ChevronsRight,
   Search,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { twMerge } from "tailwind-merge";
 import { Button } from "./button";
 import { Checkbox } from "./checkbox";
@@ -135,12 +135,17 @@ export function DataTable<TData, TValue>({
     },
   });
 
+  const tableRef = useRef(table);
+  tableRef.current = table;
+
   useEffect(() => {
     if (selectable && onSelectionChange) {
-      const selectedRows = table.getFilteredSelectedRowModel().rows.map((row) => row.original);
+      const selectedRows = tableRef.current
+        .getFilteredSelectedRowModel()
+        .rows.map((row) => row.original);
       onSelectionChange(selectedRows);
     }
-  }, [rowSelection, selectable, onSelectionChange, table]);
+  }, [rowSelection, selectable, onSelectionChange]);
 
   return (
     <div className={className}>

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -227,6 +227,18 @@ export function DataTable<TData, TValue>({
                   key={row.id}
                   data-state={row.getIsSelected() && "selected"}
                   onClick={() => onRowClick?.(row.original)}
+                  onKeyDown={
+                    onRowClick
+                      ? (e) => {
+                          if (e.key === "Enter" || e.key === " ") {
+                            e.preventDefault();
+                            onRowClick(row.original);
+                          }
+                        }
+                      : undefined
+                  }
+                  tabIndex={onRowClick ? 0 : undefined}
+                  role={onRowClick ? "button" : undefined}
                   onMouseEnter={() => onRowMouseEnter?.(row.original)}
                   onMouseLeave={() => onRowMouseLeave?.(row.original)}
                   className={cn(

--- a/src/components/dialog.tsx
+++ b/src/components/dialog.tsx
@@ -110,7 +110,7 @@ export function Dialog({
           {!hideCloseButton && (
             <DialogPrimitive.Close
               data-slot="dialog-close"
-              className="text-steel hover:text-ink focus-visible:outline-signal-blue absolute top-4 right-4 transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none"
+              className="text-steel hover:text-ink focus-visible:outline-signal-blue absolute top-4 right-4 transition-colors before:absolute before:inset-[-14px] before:content-[''] focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none"
               aria-label="Close dialog"
             >
               <X className="size-4" aria-hidden="true" />

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -17,9 +17,9 @@ const inputBaseStyles = [
   "bg-paper text-ink",
   "border border-graphite",
   "placeholder:text-steel",
-  "focus:ring-2 focus:ring-signal-blue focus:ring-offset-1 focus:outline-none",
+  "focus-visible:outline-2 focus-visible:outline-signal-blue focus-visible:outline-offset-2",
   "disabled:cursor-not-allowed disabled:border-dashed disabled:border-chrome disabled:bg-frost disabled:text-steel",
-  "aria-[invalid=true]:border-signal-red aria-[invalid=true]:focus:ring-signal-red",
+  "aria-[invalid=true]:border-signal-red aria-[invalid=true]:focus-visible:outline-signal-red",
   "read-only:bg-frost read-only:text-steel",
 ].join(" ");
 

--- a/src/components/navigation-progress.tsx
+++ b/src/components/navigation-progress.tsx
@@ -31,6 +31,7 @@ export function NavigationProgress({ active, className, ...props }: NavigationPr
       data-slot="navigation-progress"
       role="progressbar"
       aria-label="Loading"
+      aria-valuetext="Loading"
       className={cn("bg-chrome fixed top-0 right-0 left-0 z-50 h-0.5 overflow-hidden", className)}
       {...props}
     >

--- a/src/components/radio.tsx
+++ b/src/components/radio.tsx
@@ -29,7 +29,7 @@ export function RadioItem({ className, ...props }: RadioItemProps) {
     <RadioGroupPrimitive.Item
       data-slot="radio-item"
       className={cn(
-        "group peer border-graphite size-4 shrink-0 rounded-full border",
+        "group peer border-graphite relative size-4 shrink-0 rounded-full border before:absolute before:inset-[-14px] before:content-['']",
         "bg-paper",
         "hover:border-steel",
         "focus-visible:outline-signal-blue focus-visible:outline-2 focus-visible:outline-offset-2",

--- a/src/components/radio.tsx
+++ b/src/components/radio.tsx
@@ -29,7 +29,7 @@ export function RadioItem({ className, ...props }: RadioItemProps) {
     <RadioGroupPrimitive.Item
       data-slot="radio-item"
       className={cn(
-        "group peer border-chrome size-4 shrink-0 rounded-full border",
+        "group peer border-graphite size-4 shrink-0 rounded-full border",
         "bg-paper",
         "hover:border-steel",
         "focus-visible:outline-signal-blue focus-visible:outline-2 focus-visible:outline-offset-2",

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -32,7 +32,7 @@ function SelectTrigger({ className, size = "default", children, ...props }: Sele
       className={cn(
         "flex w-full items-center justify-between gap-2",
         "border-graphite bg-paper text-ink border px-3 py-2 text-sm",
-        "focus-visible:border-signal-blue focus-visible:outline-none",
+        "focus-visible:outline-signal-blue focus-visible:outline-2 focus-visible:outline-offset-2",
         "disabled:bg-frost disabled:text-steel disabled:cursor-not-allowed disabled:border-dashed",
         "aria-[invalid=true]:border-signal-red",
         "[&_svg]:pointer-events-none [&_svg]:shrink-0",

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -33,7 +33,7 @@ function SelectTrigger({ className, size = "default", children, ...props }: Sele
         "flex w-full items-center justify-between gap-2",
         "border-graphite bg-paper text-ink border px-3 py-2 text-sm",
         "focus-visible:outline-signal-blue focus-visible:outline-2 focus-visible:outline-offset-2",
-        "disabled:bg-frost disabled:text-steel disabled:cursor-not-allowed disabled:border-dashed",
+        "disabled:bg-frost disabled:text-steel disabled:border-chrome disabled:cursor-not-allowed disabled:border-dashed",
         "aria-[invalid=true]:border-signal-red",
         "[&_svg]:pointer-events-none [&_svg]:shrink-0",
         className,

--- a/src/components/sheet.tsx
+++ b/src/components/sheet.tsx
@@ -143,7 +143,7 @@ export function Sheet({
           {!hideCloseButton && (
             <DialogPrimitive.Close
               data-slot="sheet-close"
-              className="text-steel hover:text-ink focus-visible:outline-signal-blue absolute top-4 right-4 transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none"
+              className="text-steel hover:text-ink focus-visible:outline-signal-blue absolute top-4 right-4 transition-colors before:absolute before:inset-[-14px] before:content-[''] focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none"
               aria-label="Close sheet"
             >
               <X className="size-4" aria-hidden="true" />

--- a/src/components/sheet.tsx
+++ b/src/components/sheet.tsx
@@ -13,6 +13,12 @@ interface Props {
   preventClose?: boolean;
 
   /**
+   * When true, hides the X close button in the top-right corner.
+   * Useful with preventClose when you want users to use only action buttons.
+   */
+  hideCloseButton?: boolean;
+
+  /**
    * Element that opens the sheet when clicked.
    * Optional - if not provided, sheet must be controlled via open/onOpenChange props.
    */
@@ -77,6 +83,7 @@ export function Sheet({
   children,
   trigger,
   preventClose = false,
+  hideCloseButton = false,
   open,
   onOpenChange,
   closeWhen,
@@ -133,13 +140,15 @@ export function Sheet({
           onEscapeKeyDown={preventClose ? (e) => e.preventDefault() : undefined}
         >
           {children}
-          <DialogPrimitive.Close
-            data-slot="sheet-close"
-            className="text-steel hover:text-ink focus-visible:outline-signal-blue absolute top-4 right-4 transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none"
-            aria-label="Close sheet"
-          >
-            <X className="size-4" aria-hidden="true" />
-          </DialogPrimitive.Close>
+          {!hideCloseButton && (
+            <DialogPrimitive.Close
+              data-slot="sheet-close"
+              className="text-steel hover:text-ink focus-visible:outline-signal-blue absolute top-4 right-4 transition-colors focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 disabled:pointer-events-none"
+              aria-label="Close sheet"
+            >
+              <X className="size-4" aria-hidden="true" />
+            </DialogPrimitive.Close>
+          )}
         </DialogPrimitive.Content>
       </DialogPrimitive.Portal>
     </DialogPrimitive.Root>

--- a/src/components/switch.tsx
+++ b/src/components/switch.tsx
@@ -6,7 +6,7 @@ import { twMerge } from "tailwind-merge";
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
 const switchVariants = cva(
-  "group peer inline-flex shrink-0 cursor-pointer items-center p-0.5 transition-colors outline-none data-[state=checked]:bg-signal-green data-[state=unchecked]:bg-chrome focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-signal-blue disabled:cursor-not-allowed disabled:border-dashed disabled:border-chrome disabled:bg-frost disabled:data-[state=checked]:bg-frost border border-chrome",
+  "group peer inline-flex shrink-0 cursor-pointer items-center p-0.5 transition-colors outline-none data-[state=checked]:bg-signal-green data-[state=unchecked]:bg-chrome focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-signal-blue disabled:cursor-not-allowed disabled:border-dashed disabled:border-chrome disabled:bg-frost disabled:data-[state=checked]:bg-frost border border-chrome relative before:absolute before:inset-[-14px] before:content-['']",
   {
     variants: {
       size: {

--- a/src/components/textarea.tsx
+++ b/src/components/textarea.tsx
@@ -38,10 +38,10 @@ export function Textarea({ className, autoResize = true, onInput, ...props }: Pr
       className={cn(
         "border-graphite bg-paper text-ink w-full border px-3 py-2 text-sm",
         "placeholder:text-steel",
-        "focus:ring-signal-blue focus:ring-2 focus:ring-offset-1 focus:outline-none",
+        "focus-visible:outline-signal-blue focus-visible:outline-2 focus-visible:outline-offset-2",
         "disabled:border-chrome disabled:bg-frost disabled:text-steel disabled:cursor-not-allowed disabled:border-dashed",
         "read-only:bg-frost read-only:cursor-default",
-        "aria-[invalid=true]:border-signal-red aria-[invalid=true]:focus:ring-signal-red",
+        "aria-[invalid=true]:border-signal-red aria-[invalid=true]:focus-visible:outline-signal-red",
         autoResize && "resize-none overflow-hidden",
         className,
       )}

--- a/src/components/tooltip.tsx
+++ b/src/components/tooltip.tsx
@@ -49,7 +49,7 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "shadow-offset border-ink bg-ink text-paper z-50 overflow-hidden border px-3 py-1.5 text-xs",
+          "border-ink bg-ink text-paper z-50 overflow-hidden border px-3 py-1.5 text-xs",
           "animate-in fade-in-0 zoom-in-95",
           "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
           "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",


### PR DESCRIPTION
## Summary
- **Harden**: DataTable keyboard support on clickable rows, Button `data-slot` + `type="button"` default, Alert title no longer truncated, NavigationProgress ARIA, Sheet `hideCloseButton` prop
- **Normalize**: Unified `focus-visible:outline` across all form controls (Input, Textarea, Select), Radio border weight aligned with Checkbox, Tooltip shadow removed from dark surface, Blockquote `border-l-2`, Select disabled border
- **Adapt**: 44px touch targets on Checkbox, Radio, Switch, Dialog/Sheet close via invisible `before::` pseudo-elements
- **Optimize**: DataTable selection `useEffect` no longer fires on every render

## Test plan
- [ ] Verify keyboard navigation on DataTable clickable rows (Enter/Space)
- [ ] Verify Button defaults to `type="button"` and allows `type="submit"` override
- [ ] Verify focus outlines are consistent across Input, Textarea, Select, Checkbox, Radio, Switch
- [ ] Verify touch targets on Checkbox, Radio, Switch, Dialog/Sheet close buttons
- [ ] Verify Sheet `hideCloseButton` prop works
- [ ] Verify disabled Select has `border-chrome` matching other disabled controls
- [ ] Run Storybook interaction tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)