### PR TITLE
docs: simplify CLAUDE.md, add design context, polish DataTable focus

### DIFF
--- a/.changeset/polish-datatable-focus-and-docs.md
+++ b/.changeset/polish-datatable-focus-and-docs.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+Add focus-visible indicator to DataTable clickable rows for keyboard navigation

--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,30 @@
+## Design Context
+
+### Users
+
+Indie developers, solo founders, and small product teams at startups who want a UI library with a strong design opinion. They're building SaaS products, side projects, and production apps where visual identity matters. They specifically chose brutalist aesthetics — this isn't a fallback, it's an intentional rejection of the polished-everything trend.
+
+### Brand Personality
+
+**Honest, functional, utilitarian.** Built for purpose, not beauty. The interface doesn't decorate — it communicates. Every element earns its place. No pretense, no filler, no visual sugar-coating.
+
+### Aesthetic Direction
+
+**Brutalist.** Sharp corners, flat colors, offset shadows, system fonts. The design language is industrial: borders are visible, states are obvious, hierarchy is structural not decorative. Think concrete architecture — raw materials, visible construction, beauty through honesty of form.
+
+**Anti-references (what this must NOT look like):**
+
+- shadcn/ui — too soft, too rounded, too similar to what everyone ships
+- Material Design — too corporate, too systematic, too Google
+- Stripe/Linear — too polished, too aspirational, not raw enough
+- Bootstrap — too generic, no design point of view
+
+**Emotional goals:** Users should feel confidence and clarity (I know exactly what's happening), respect for craft (someone cared about this), and edgy distinction (this looks different — in a good way).
+
+### Design Principles
+
+1. **Honesty over decoration** — No gradients, no blur, no rounded corners (except Radio). If it's a border, show the border. If it's a shadow, make it structural (offset, no blur). Raw materials, visible construction.
+2. **Function drives form** — Every visual choice serves usability. Offset shadows signal interactivity and state (hover grows, active shrinks, disabled removes). Design tokens encode meaning, not aesthetics.
+3. **Consistency is kindness** — Same disabled pattern everywhere. Same focus indicator everywhere. Same spacing scale. Users learn the system once and trust it completely.
+4. **Opinionated defaults, flexible overrides** — Strong defaults that look intentional out of the box, but every component accepts className for customization. The library has a point of view but doesn't trap you.
+5. **Craft in the details** — Touch targets that actually work. Keyboard navigation that's complete. ARIA that's correct. The quality is in what you don't see.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,105 +1,30 @@
-# CLAUDE.md - AI Component Development Guidelines
+# CLAUDE.md
 
-## Library Architecture
+Copy-paste component library (like shadcn/ui). Package: `@beaket/ui`.
 
-This is a **copy-paste component library** (like shadcn/ui). Users copy individual component files into their projects.
+**When creating or updating components, read `.impeccable.md` for design context and principles.**
 
-### Key Principles
+## Architecture
 
-1. **Self-contained components** - Each component file must be standalone
-   - Include `cn` utility in every component file
-   - No shared `lib/utils.ts` or similar
-   - Users copy only the files they need
+- **Self-contained**: Each component includes its own `cn` utility. No shared imports.
+- **Dependencies in registry**: List npm packages in `registry/registry.json`.
+- **CSS tokens**: `src/css-variables.css` (injected by CLI), `src/styles.css` (Storybook only).
 
-2. **Dependencies in registry** - List npm packages in `registry.json`
-   - `dependencies`: External packages (e.g., `@radix-ui/react-checkbox`)
-   - `registryDependencies`: Other components from this library (e.g., `button`)
+## Design Rules
 
-## CSS Architecture
+Brutalist design system. No gradients, no border-radius (except Radio), no blur shadows, no opacity for styling. Use design tokens from `styles.css`.
 
-### File Structure
+| Do                                                                                         | Don't                                  |
+| ------------------------------------------------------------------------------------------ | -------------------------------------- |
+| `bg-paper`, `text-ink`, `border-chrome`                                                    | `bg-white`, `opacity-50`, `rounded-lg` |
+| `shadow-offset` / `shadow-offset-dark`                                                     | `shadow-md`, `shadow-lg` (blur)        |
+| `focus-visible:outline-2 focus-visible:outline-signal-blue focus-visible:outline-offset-2` | Inconsistent focus patterns            |
+| `disabled:border-dashed disabled:border-chrome disabled:bg-frost disabled:text-steel`      | Inconsistent disabled patterns         |
+| `before:absolute before:inset-[-14px] before:content-['']` on small controls               | Touch targets below 44px               |
 
-```
-src/
-├── css-variables.css   # Core tokens (colors, shadows) - injected by CLI
-└── styles.css          # Full design system (imports css-variables.css)
-```
-
-### Ownership Model
-
-When users run `npx @beaket/ui init`, the CLI injects `css-variables.css` content into their main CSS file.
-
-**After init, this CSS belongs to the user:**
-
-- Users are free to modify colors, shadows, and tokens
-- The library will not automatically update these values
-- When the library updates tokens, users should check the CHANGELOG and manually update if needed
-
-**Why this design:**
-
-- Users own their design tokens completely
-- No unexpected style changes from library updates
-- Clear boundary: library provides initial tokens, user maintains them
-
-### Core vs Extended Tokens
-
-| File                | Contents                                 | User Gets           |
-| ------------------- | ---------------------------------------- | ------------------- |
-| `css-variables.css` | Neutral palette, signal colors, shadows  | Yes (via init)      |
-| `styles.css`        | Functional mappings, typography, spacing | No (Storybook only) |
-
-This separation keeps the injected CSS minimal (~44 lines) while the full design system is available for reference.
-
-## Design Philosophy (Brutalist)
-
-This library follows a **brutalist design system**:
-
-- **No gradients** - Flat colors only
-- **Offset shadows only** - 2px 2px offset shadows for interactive elements (no blur/decorative shadows)
-- **No border-radius** - Sharp rectangular corners (except Radio which is circular by nature)
-- **No decorative elements** - No opacity effects for styling
-- **Use design tokens** - Always use CSS variables from `styles.css`
-
-### Design Tokens
-
-```css
-/* Neutral palette */
---graphite, --ink, --branch, --iron, --slate, --zinc   /* Dark tones */
---steel, --aluminum                                     /* Mid tones */
---chrome, --silver, --platinum, --frost, --paper        /* Light tones */
-
-/* Signal colors */
---signal-blue, --signal-red, --signal-green, --signal-amber, --signal-purple, --signal-cyan
-
-/* Shadows (offset only, no blur) */
---shadow-offset: 2px 2px 0px 0px var(--chrome);       /* Interactive elements */
---shadow-offset-dark: 2px 2px 0px 0px var(--aluminum); /* Overlays (Dialog, etc.) */
-```
-
-### Styling Rules
-
-| Do                          | Don't                                     |
-| --------------------------- | ----------------------------------------- |
-| `bg-[var(--paper)]`         | `bg-white` (except where contrast needed) |
-| `text-[var(--steel)]`       | `opacity-50`                              |
-| `border-[var(--chrome)]`    | `rounded-lg`                              |
-| `shadow-offset`             | `shadow-md`, `shadow-lg` (blur shadows)   |
-| `hover:shadow-offset-hover` | gradients, decorative effects             |
-
-### Shadow States
-
-Interactive elements use offset shadows with state transitions:
-
-| State    | Shadow                           |
-| -------- | -------------------------------- |
-| Default  | `2px 2px` (shadow-offset)        |
-| Hover    | `3px 3px` (shadow-offset-hover)  |
-| Active   | `1px 1px` (shadow-offset-active) |
-| Disabled | `none`                           |
+Shadow states: default `2px 2px`, hover `3px 3px`, active `1px 1px`, disabled `none`.
 
 ## Component Template
-
-Every component file must follow this structure:
 
 ```tsx
 import { type ClassValue, clsx } from "clsx";
@@ -112,217 +37,17 @@ export function ComponentName({ className, ...props }: React.ComponentProps<"div
 }
 ```
 
-### Compound Components
+**Compound pattern** for sub-components: `Dialog.Title`, `Dialog.Footer` — not individually exported.
 
-For complex components with sub-components, use the **compound pattern**:
+**Controlled/uncontrolled**: Support both via internal state + `open`/`onOpenChange` props. Warn in dev if `open` provided without `onOpenChange`.
 
-```tsx
-// Main component (exported)
-export function Dialog({ children }: Props) {
-  return <DialogPrimitive.Root>{children}</DialogPrimitive.Root>;
-}
+## Required Checklist
 
-// Sub-components (not exported individually)
-function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
-  return <DialogPrimitive.Title className={cn("...", className)} {...props} />;
-}
+When creating a component, you **must** create all of:
 
-function DialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
-  return <div className={cn("...", className)} {...props} />;
-}
+- [ ] `src/components/[name].tsx` — Component with `data-slot`, `cn`, design tokens
+- [ ] `src/components/[name].stories.tsx` — Storybook with `tags: ["autodocs"]` + interaction tests via `play` function
+- [ ] `registry/registry.json` — Register with dependencies and docs sections
+- [ ] `.changeset/*.md` — Package name must be `@beaket/ui` (minor for new/feature, patch for fix, major for breaking)
 
-// Attach sub-components to main component
-Dialog.Title = DialogTitle;
-Dialog.Footer = DialogFooter;
-```
-
-**Why compound-only (no individual exports)?**
-
-- **Semantic coupling**: `Dialog.Title` only makes sense inside `<Dialog>` - compound pattern signals this relationship
-- **Discoverability**: Type `Dialog.` and autocomplete shows all sub-components
-- **Encapsulation**: Not exporting sub-components signals they shouldn't be used outside their parent
-- **Namespace clarity**: `Dialog.Title` clearly shows hierarchy, avoids collision with other `Title` components
-
-### Controlled/Uncontrolled Pattern
-
-For components supporting both modes:
-
-```tsx
-export function Dialog({ open, onOpenChange, children }: Props) {
-  const [internalOpen, setInternalOpen] = useState(false);
-  const isControlled = open !== undefined;
-
-  // Dev warning for incomplete controlled usage
-  if (process.env.NODE_ENV !== "production") {
-    if (isControlled && !onOpenChange) {
-      console.warn("Dialog: `open` provided without `onOpenChange`.");
-    }
-  }
-
-  const dialogOpen = isControlled ? open : internalOpen;
-  const dialogOnOpenChange = useCallback(
-    (value: boolean) => {
-      onOpenChange?.(value);
-      if (!isControlled) setInternalOpen(value);
-    },
-    [isControlled, onOpenChange],
-  );
-
-  return (
-    <Root open={dialogOpen} onOpenChange={dialogOnOpenChange}>
-      {children}
-    </Root>
-  );
-}
-```
-
-## Required Items When Creating Components
-
-When creating a new component, you **must** create all of the following:
-
-### 1. Storybook
-
-Create at `src/components/[name].stories.tsx`.
-
-```tsx
-import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, fn, userEvent, within } from "storybook/test";
-import { ComponentName } from "./component-name";
-
-const meta: Meta<typeof ComponentName> = {
-  title: "Components/ComponentName",
-  component: ComponentName,
-  tags: ["autodocs"],
-  argTypes: {
-    // Define prop controls
-  },
-};
-
-export default meta;
-type Story = StoryObj<typeof ComponentName>;
-
-// Basic story
-export const Default: Story = {
-  args: {
-    // Default props
-  },
-};
-
-// Composition for documentation
-export const AllStates = () => <div className="flex gap-2">{/* Display all states */}</div>;
-```
-
-### 2. Component Test (Interaction Test)
-
-Implement interaction tests using Storybook's `play` function.
-
-```tsx
-export const ClickTest: Story = {
-  args: {
-    onClick: fn(),
-  },
-  play: async ({ args, canvasElement }) => {
-    const canvas = within(canvasElement);
-    const element = canvas.getByRole("button");
-
-    await userEvent.click(element);
-    await expect(args.onClick).toHaveBeenCalledTimes(1);
-  },
-};
-```
-
-#### Testing Portal-Based Components
-
-For components using portals (Dialog, Popover, etc.), content renders outside `canvasElement`. Use `screen` instead:
-
-```tsx
-import { expect, screen, userEvent, within } from "storybook/test";
-
-export const DialogTest: Story = {
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Trigger is in canvas
-    await userEvent.click(canvas.getByRole("button", { name: "Open" }));
-
-    // Dialog content is in portal - use screen
-    const dialog = await screen.findByRole("dialog");
-    await expect(dialog).toBeInTheDocument();
-
-    // Query within the dialog
-    const closeBtn = within(dialog).getByRole("button", { name: "Close" });
-    await userEvent.click(closeBtn);
-
-    // Verify closed
-    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-  },
-};
-```
-
-**Important:** Don't use mock `fn()` for `onOpenChange` props - it prevents internal state updates and the component won't actually open/close.
-
-### 3. Registry Registration
-
-Register the component in `registry/registry.json`.
-
-```json
-{
-  "name": "component-name",
-  "description": "Component description",
-  "dependencies": ["required dependency packages"],
-  "registryDependencies": [],
-  "files": ["components/component-name.tsx"],
-  "docs": {
-    "title": "ComponentName",
-    "tagline": "Brief description of the component",
-    "sections": ["AllStates"]
-  }
-}
-```
-
-### 4. Changeset
-
-Create a changeset for version tracking using `pnpm changeset` or manually create a file in `.changeset/`.
-
-**Important:** The package name must be `@beaket/ui` (not `ui`).
-
-```md
----
-"@beaket/ui": minor
----
-
-Add ComponentName component with feature X, Y, and Z
-```
-
-**Version bump guidelines:**
-
-| Change Type                       | Bump    | Example                      |
-| --------------------------------- | ------- | ---------------------------- |
-| New component                     | `minor` | Adding Dialog component      |
-| New feature to existing component | `minor` | Adding new variant to Button |
-| Bug fix                           | `patch` | Fixing focus state issue     |
-| Breaking change                   | `major` | Changing component API       |
-
-## File Structure
-
-```
-src/components/
-├── [name].tsx           # Component implementation
-└── [name].stories.tsx   # Storybook + Interaction Test
-
-registry/
-└── registry.json        # Component registration
-
-.changeset/
-└── [description].md     # Changeset for versioning
-```
-
-## Checklist
-
-Verify when creating a component:
-
-- [ ] `src/components/[name].tsx` - Component implementation
-- [ ] `src/components/[name].stories.tsx` - Storybook created
-- [ ] Interaction tests implemented (play function)
-- [ ] Registered in `registry/registry.json`
-- [ ] Changeset created with `@beaket/ui` package name
+**Testing portals**: Use `screen` (not `canvasElement`) for Dialog, Popover, etc. Don't mock `onOpenChange` with `fn()`.

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -247,7 +247,8 @@ export function DataTable<TData, TValue>({
                   onMouseEnter={() => onRowMouseEnter?.(row.original)}
                   onMouseLeave={() => onRowMouseLeave?.(row.original)}
                   className={cn(
-                    onRowClick && "cursor-pointer",
+                    onRowClick &&
+                      "focus-visible:outline-signal-blue cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-[-2px]",
                     compact && "h-10",
                     getRowClassName?.(row.original),
                   )}


### PR DESCRIPTION
## Summary
- **CLAUDE.md**: Simplified from 329 → 49 lines. Keeps only patterns that can't be inferred from code
- **.impeccable.md**: New design context file (users, brand personality, aesthetic direction, 5 design principles)
- **DataTable**: Add `focus-visible` outline to clickable rows so keyboard users can see which row is focused

## Test plan
- [ ] Verify CLAUDE.md still covers all essential patterns for component development
- [ ] Verify `.impeccable.md` is readable and accurate
- [ ] Tab through DataTable clickable rows and confirm blue outline appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)