### PR TITLE
feat: surface layer tokens for visual depth

### DIFF
--- a/.changeset/surface-layer-tokens.md
+++ b/.changeset/surface-layer-tokens.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": minor
+---
+
+Add surface layer tokens (`surface-0`, `surface-1`, `surface-2`) for visual depth between page, cards, and elevated elements. Surface containers (Card, Dialog, Sheet, Alert, Table) use `bg-surface-1`; floating overlays (DropdownMenu, Select popup) use `bg-surface-2`.

--- a/src/components/alert.tsx
+++ b/src/components/alert.tsx
@@ -10,14 +10,14 @@ const alertVariants = cva(
   {
     variants: {
       variant: {
-        note: "bg-paper text-ink border-signal-blue [&>svg]:text-signal-blue [&_[data-slot=alert-description]]:text-steel",
-        tip: "bg-paper text-ink border-signal-green [&>svg]:text-signal-green [&_[data-slot=alert-description]]:text-steel",
+        note: "bg-surface-1 text-ink border-signal-blue [&>svg]:text-signal-blue [&_[data-slot=alert-description]]:text-steel",
+        tip: "bg-surface-1 text-ink border-signal-green [&>svg]:text-signal-green [&_[data-slot=alert-description]]:text-steel",
         important:
-          "bg-paper text-ink border-signal-purple [&>svg]:text-signal-purple [&_[data-slot=alert-description]]:text-steel",
+          "bg-surface-1 text-ink border-signal-purple [&>svg]:text-signal-purple [&_[data-slot=alert-description]]:text-steel",
         warning:
-          "bg-paper text-ink border-signal-amber [&>svg]:text-signal-amber [&_[data-slot=alert-description]]:text-steel",
+          "bg-surface-1 text-ink border-signal-amber [&>svg]:text-signal-amber [&_[data-slot=alert-description]]:text-steel",
         caution:
-          "bg-paper text-ink border-signal-red [&>svg]:text-signal-red [&_[data-slot=alert-description]]:text-steel",
+          "bg-surface-1 text-ink border-signal-red [&>svg]:text-signal-red [&_[data-slot=alert-description]]:text-steel",
       },
     },
     defaultVariants: {

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -13,7 +13,7 @@ function CardRoot({ className, shadow, ...props }: CardRootProps) {
     <div
       data-slot="card"
       className={cn(
-        "border-chrome bg-paper text-ink flex flex-col gap-0 border",
+        "border-chrome bg-surface-1 text-ink flex flex-col gap-0 border",
         shadow && "shadow-offset",
         className,
       )}

--- a/src/components/colors.stories.tsx
+++ b/src/components/colors.stories.tsx
@@ -2,6 +2,11 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 const colors = {
   brand: [{ name: "Branch", variable: "--color-branch", hex: "#1c1f24", usage: "Brand identity" }],
+  surface: [
+    { name: "Surface 0", variable: "--color-surface-0", hex: "#eeeeee", usage: "Page background" },
+    { name: "Surface 1", variable: "--color-surface-1", hex: "#fafafa", usage: "Cards, panels" },
+    { name: "Surface 2", variable: "--color-surface-2", hex: "#ffffff", usage: "Nested/elevated" },
+  ],
   neutral: [
     { name: "Graphite", variable: "--color-graphite", hex: "#0d0d0d", usage: "Darkest tone" },
     { name: "Ink", variable: "--color-ink", hex: "#1a1a1a", usage: "Primary text" },
@@ -44,7 +49,16 @@ function ColorSwatch({
   hex: string;
   usage: string;
 }) {
-  const isLight = ["Paper", "Frost", "Platinum", "Silver", "Chrome"].includes(name);
+  const isLight = [
+    "Paper",
+    "Frost",
+    "Platinum",
+    "Silver",
+    "Chrome",
+    "Surface 0",
+    "Surface 1",
+    "Surface 2",
+  ].includes(name);
 
   return (
     <div className="border-chrome border">
@@ -82,6 +96,21 @@ function Colors() {
           <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">Brand</h2>
           <div className="grid grid-cols-4 gap-3">
             {colors.brand.map((color) => (
+              <ColorSwatch key={color.variable} {...color} />
+            ))}
+          </div>
+        </section>
+
+        {/* Surface Layers */}
+        <section className="mb-8">
+          <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">
+            Surface Layers
+          </h2>
+          <p className="text-muted mb-3 text-xs">
+            Visual depth: page &rarr; cards &rarr; elevated elements.
+          </p>
+          <div className="grid grid-cols-3 gap-3">
+            {colors.surface.map((color) => (
               <ColorSwatch key={color.variable} {...color} />
             ))}
           </div>
@@ -134,6 +163,25 @@ function Colors() {
                 <code className="text-signal-blue">bg-paper</code>, never raw hex
               </li>
             </ul>
+          </div>
+        </section>
+
+        {/* Surface Depth Demo */}
+        <section className="mb-8">
+          <h2 className="text-steel mb-3 text-xs font-bold tracking-wider uppercase">
+            Surface Depth Demo
+          </h2>
+          <p className="text-muted mb-3 text-xs">
+            Nested surfaces create visual hierarchy without decoration.
+          </p>
+          <div className="bg-surface-0 border-chrome border p-6">
+            <code className="text-muted text-xs">bg-surface-0 — page</code>
+            <div className="border-chrome bg-surface-1 mt-2 border p-4">
+              <code className="text-muted text-xs">bg-surface-1 — card</code>
+              <div className="border-chrome bg-surface-2 mt-2 border p-3">
+                <code className="text-muted text-xs">bg-surface-2 — dropdown / nested</code>
+              </div>
+            </div>
           </div>
         </section>
 

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -165,7 +165,7 @@ export function DataTable<TData, TValue>({
         </div>
       )}
 
-      <div className="border-chrome bg-paper overflow-x-auto border">
+      <div className="border-chrome bg-surface-1 overflow-x-auto border">
         <Table className="min-w-full">
           <Table.Header>
             {table.getHeaderGroups().map((headerGroup) => (

--- a/src/components/dialog.tsx
+++ b/src/components/dialog.tsx
@@ -102,7 +102,7 @@ export function Dialog({
         />
         <DialogPrimitive.Content
           data-slot="dialog-content"
-          className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 shadow-offset-dark border-chrome bg-paper fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 border p-6 sm:max-w-lg"
+          className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 shadow-offset-dark border-chrome bg-surface-1 fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 border p-6 sm:max-w-lg"
           onInteractOutside={preventClose ? (e) => e.preventDefault() : undefined}
           onEscapeKeyDown={preventClose ? (e) => e.preventDefault() : undefined}
         >

--- a/src/components/dropdown-menu.tsx
+++ b/src/components/dropdown-menu.tsx
@@ -35,7 +35,7 @@ function DropdownMenuContent({
         data-slot="dropdown-menu-content"
         sideOffset={sideOffset}
         className={cn(
-          "shadow-offset max-h-radix-dropdown-menu-content-available-height origin-radix-dropdown-menu-content-transform-origin border-ink bg-paper text-ink z-50 min-w-[8rem] overflow-x-hidden overflow-y-auto border p-1",
+          "shadow-offset max-h-radix-dropdown-menu-content-available-height origin-radix-dropdown-menu-content-transform-origin border-ink bg-surface-2 text-ink z-50 min-w-[8rem] overflow-x-hidden overflow-y-auto border p-1",
           "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
@@ -230,7 +230,7 @@ function DropdownMenuSubContent({
     <DropdownMenuPrimitive.SubContent
       data-slot="dropdown-menu-sub-content"
       className={cn(
-        "shadow-offset origin-radix-dropdown-menu-content-transform-origin border-ink bg-paper text-ink z-50 min-w-[8rem] overflow-hidden border p-1",
+        "shadow-offset origin-radix-dropdown-menu-content-transform-origin border-ink bg-surface-2 text-ink z-50 min-w-[8rem] overflow-hidden border p-1",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -59,7 +59,7 @@ function SelectContent({
       <SelectPrimitive.Content
         data-slot="select-content"
         className={cn(
-          "border-chrome bg-paper relative z-50 max-h-96 min-w-[8rem] overflow-hidden border",
+          "border-chrome bg-surface-2 relative z-50 max-h-96 min-w-[8rem] overflow-hidden border",
           "data-[side=bottom]:translate-y-1 data-[side=top]:-translate-y-1",
           className,
         )}

--- a/src/components/sheet.tsx
+++ b/src/components/sheet.tsx
@@ -132,7 +132,7 @@ export function Sheet({
         <DialogPrimitive.Content
           data-slot="sheet-content"
           className={cn(
-            "shadow-offset-dark border-chrome bg-paper fixed z-50 gap-4 border p-4",
+            "shadow-offset-dark border-chrome bg-surface-1 fixed z-50 gap-4 border p-4",
             fullScreen ? sidePositionsFullScreen[side] : sidePositions[side],
             sideAnimations[side],
           )}

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -60,7 +60,7 @@ function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
     <tr
       data-slot="table-row"
       className={cn(
-        "border-chrome bg-paper hover:bg-frost data-[state=selected]:bg-platinum border-b",
+        "border-chrome bg-surface-1 hover:bg-frost data-[state=selected]:bg-platinum border-b",
         className,
       )}
       {...props}

--- a/src/css-variables.css
+++ b/src/css-variables.css
@@ -40,6 +40,11 @@
   --color-signal-purple: #6f2da8;
   --color-signal-cyan: #1a6b7c;
 
+  /* Surface layers (visual depth) */
+  --color-surface-0: #eeeeee;
+  --color-surface-1: #fafafa;
+  --color-surface-2: #ffffff;
+
   /* Shadows (offset only, no blur) */
   --shadow-offset: 2px 2px 0px 0px var(--color-chrome);
   --shadow-offset-dark: 2px 2px 0px 0px var(--color-aluminum);


### PR DESCRIPTION
## Summary

Closes #246

- Add `surface-0` (`#eeeeee`), `surface-1` (`#fafafa`), `surface-2` (`#ffffff`) tokens to `css-variables.css` for page → card → floating element depth
- Migrate surface containers (Card, Dialog, Sheet, Alert, Table, DataTable) to `bg-surface-1`
- Migrate floating overlays (DropdownMenu, Select popup) to `bg-surface-2`
- Add surface layer swatches + nested depth demo to colors story
- `bg-paper` unchanged — backward compatible for form inputs and non-surface uses

**Design note:** Issue proposed `#edeef0` for `surface-0`, changed to `#eeeeee` (pure neutral gray) to maintain thermal consistency with the existing palette where every neutral is R=G=B.

## Test plan

- [ ] Storybook: verify Card, Dialog, Sheet, Alert render with `bg-surface-1`
- [ ] Storybook: verify DropdownMenu, Select popup render with `bg-surface-2`
- [ ] Colors story: surface swatches + depth demo display correctly
- [ ] Existing `bg-paper` usage (inputs, textarea, select trigger) unchanged
- [ ] Navigation links still use `bg-paper` (controls, not surfaces)

🤖 Generated with [Claude Code](https://claude.com/claude-code)