### PR TITLE
fix: add missing gap-2 to Card.Footer

### DIFF
--- a/.changeset/card-footer-gap.md
+++ b/.changeset/card-footer-gap.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+fix: add missing `gap-2` to `Card.Footer` so children are spaced correctly

--- a/src/components/card.stories.tsx
+++ b/src/components/card.stories.tsx
@@ -90,7 +90,7 @@ export const AllStates = () => (
       <Card.Content>
         <p className="text-steel text-sm">Some content here.</p>
       </Card.Content>
-      <Card.Footer className="gap-2">
+      <Card.Footer>
         <Button variant="outline">Cancel</Button>
         <Button>Save</Button>
       </Card.Footer>

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -63,7 +63,7 @@ function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-footer"
-      className={cn("flex items-center px-6 pb-6 [.border-t]:pt-6", className)}
+      className={cn("flex items-center gap-2 px-6 pb-6 [.border-t]:pt-6", className)}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
- Add `gap-2` to `Card.Footer` base className so children are spaced correctly, matching `Dialog.Footer` and `Sheet.Footer`
- Remove manual `className="gap-2"` workaround in the story

Closes #241

## Test plan
- [ ] Verify `Card.Footer` with multiple buttons renders with proper spacing
- [ ] Confirm existing Card stories render correctly in Storybook
- [ ] Check that `className` override still works on `Card.Footer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)