### PR TITLE
fix: increase default Table cell padding

### DIFF
--- a/.changeset/table-cell-padding.md
+++ b/.changeset/table-cell-padding.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+fix: increase default Table cell padding from px-1.5 py-1 to px-4 py-2/py-2.5 for better readability

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -73,7 +73,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-ink h-9 px-1.5 py-1 text-left align-middle font-semibold whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "text-ink h-10 px-4 py-2 text-left align-middle font-semibold whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}
@@ -86,7 +86,7 @@ function TableCell({ className, ...props }: React.ComponentProps<"td">) {
     <td
       data-slot="table-cell"
       className={cn(
-        "px-1.5 py-1 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "px-4 py-2.5 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className,
       )}
       {...props}
@@ -99,7 +99,7 @@ function TableSectionHeader({ className, ...props }: React.ComponentProps<"tr">)
     <tr
       data-slot="table-section-header"
       className={cn(
-        "bg-platinum [&>th]:border-chrome [&>th]:border-y [&>th]:px-1.5 [&>th]:py-1 [&>th]:font-semibold",
+        "bg-platinum [&>th]:border-chrome [&>th]:border-y [&>th]:px-4 [&>th]:py-2 [&>th]:font-semibold",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Increase `Table.Head` padding from `px-1.5 py-1` to `px-4 py-2` (and `h-9` → `h-10`)
- Increase `Table.Cell` padding from `px-1.5 py-1` to `px-4 py-2.5`
- Increase `Table.SectionHeader` child padding to match (`px-4 py-2`)

Closes #243

## Test plan
- [ ] Verify Table stories render with comfortable spacing
- [ ] Verify DataTable `compact` variant still applies tighter padding
- [ ] Visual regression check on any pages using Table directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)