### PR TITLE
fix: add missing shadow prop to Avatar (#242)

### DIFF
--- a/.changeset/avatar-shadow-prop.md
+++ b/.changeset/avatar-shadow-prop.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+fix: add missing `shadow` prop to Avatar for API consistency with Card and Table

--- a/src/components/avatar.stories.tsx
+++ b/src/components/avatar.stories.tsx
@@ -37,6 +37,15 @@ export const FallbackOnly: Story = {
   ),
 };
 
+export const WithShadow: Story = {
+  render: () => (
+    <Avatar shadow>
+      <Avatar.Image src="https://github.com/beaket.png" alt="@beaket" />
+      <Avatar.Fallback>BK</Avatar.Fallback>
+    </Avatar>
+  ),
+};
+
 // Compositions for docs
 export const AllStates = () => (
   <div className="flex items-center gap-4">
@@ -58,6 +67,12 @@ export const AllStates = () => (
         <Avatar.Fallback>A</Avatar.Fallback>
       </Avatar>
       <span className="text-steel text-xs">Single Letter</span>
+    </div>
+    <div className="flex flex-col items-center gap-2">
+      <Avatar shadow>
+        <Avatar.Fallback>SH</Avatar.Fallback>
+      </Avatar>
+      <span className="text-steel text-xs">Shadow</span>
     </div>
   </div>
 );
@@ -143,6 +158,21 @@ export const FallbackTest: Story = {
     const fallback = canvas.getByText("FB");
 
     await expect(fallback).toBeInTheDocument();
+  },
+};
+
+export const ShadowTest: Story = {
+  render: () => (
+    <Avatar shadow>
+      <Avatar.Fallback>SH</Avatar.Fallback>
+    </Avatar>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const avatar = canvas.getByText("SH").closest("[data-slot='avatar']");
+
+    await expect(avatar).toBeInTheDocument();
+    await expect(avatar).toHaveClass("shadow-offset");
   },
 };
 

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -9,14 +9,17 @@ interface Props extends React.ComponentProps<typeof AvatarPrimitive.Root> {
    * Additional CSS classes to apply to the avatar container
    */
   className?: string;
+  /** Add offset shadow to the avatar */
+  shadow?: boolean;
 }
 
-export function Avatar({ className, ...props }: Props) {
+export function Avatar({ className, shadow, ...props }: Props) {
   return (
     <AvatarPrimitive.Root
       data-slot="avatar"
       className={cn(
         "border-chrome relative flex size-10 shrink-0 overflow-hidden border",
+        shadow && "shadow-offset",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Adds `shadow?: boolean` prop to `Avatar`, matching the existing API of `Card` and `Table`
- Destructures `shadow` before `...props` to prevent DOM leak and React warning
- Applies `shadow-offset` class conditionally when `shadow` is true

Closes #242

## Test plan
- [ ] `WithShadow` story renders avatar with offset shadow
- [ ] `ShadowTest` interaction test verifies `shadow-offset` class is applied
- [ ] `AllStates` composition includes shadow variant
- [ ] TypeScript compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)