### PR TITLE
fix: increase Switch sm size for better visibility (#244)

### DIFF
--- a/.changeset/switch-sm-size.md
+++ b/.changeset/switch-sm-size.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+fix: increase Switch `sm` size from 12×28px to 16×32px for better visibility

--- a/src/components/switch.tsx
+++ b/src/components/switch.tsx
@@ -10,7 +10,7 @@ const switchVariants = cva(
   {
     variants: {
       size: {
-        sm: "h-3 w-7",
+        sm: "h-4 w-8",
         md: "h-4 w-9",
         lg: "h-5 w-11",
       },
@@ -26,7 +26,7 @@ const switchThumbVariants = cva(
   {
     variants: {
       size: {
-        sm: "size-1.5 data-[state=checked]:translate-x-4",
+        sm: "size-2 data-[state=checked]:translate-x-4",
         md: "size-2.5 data-[state=checked]:translate-x-5",
         lg: "size-3.5 data-[state=checked]:translate-x-6",
       },


### PR DESCRIPTION
## Summary
- Increases Switch `sm` track from `h-3 w-7` (12×28px) to `h-4 w-8` (16×32px)
- Increases Switch `sm` thumb from `size-1.5` (6px) to `size-2` (8px)
- Keeps touch target unchanged (`before:inset-[-14px]`)

Closes #244

## Test plan
- [ ] Visual check: `sm` switch is now visually distinct from `md` and clearly visible next to text labels
- [ ] Thumb travels correctly to the end of the track on check
- [ ] All three sizes (`sm`, `md`, `lg`) remain visually proportional

🤖 Generated with [Claude Code](https://claude.com/claude-code)