### PR TITLE
refactor: reuse Pagination component in DataTable

### DIFF
--- a/.changeset/pagination-button-mode.md
+++ b/.changeset/pagination-button-mode.md
@@ -1,0 +1,9 @@
+---
+"@beaket/ui": minor
+---
+
+Add button mode to Pagination component and refactor DataTable to use it
+
+Pagination now supports `mode="button"` with an `onPageChange` callback for client-side pagination, in addition to the existing `mode="link"` (default) with `buildPageUrl` for SSR-friendly navigation.
+
+DataTable's inline pagination has been replaced with the shared Pagination component, gaining ellipsis support for large page counts and ensuring visual consistency.

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -300,7 +300,7 @@
     },
     {
       "name": "pagination",
-      "description": "Server-side pagination component using links for SSR-friendly navigation",
+      "description": "Pagination component with link and button modes for SSR and client-side navigation",
       "dependencies": ["clsx", "lucide-react", "tailwind-merge"],
       "registryDependencies": [],
       "files": ["components/pagination.tsx"],
@@ -316,7 +316,7 @@
       "name": "data-table",
       "description": "Data table component built on TanStack Table with sorting, filtering, pagination, and row selection",
       "dependencies": ["@tanstack/react-table", "clsx", "tailwind-merge", "lucide-react"],
-      "registryDependencies": ["table", "button", "input", "checkbox"],
+      "registryDependencies": ["table", "button", "input", "checkbox", "pagination"],
       "files": ["components/data-table.tsx"],
       "docs": {
         "title": "DataTable",

--- a/src/components/data-table.stories.tsx
+++ b/src/components/data-table.stories.tsx
@@ -281,12 +281,20 @@ export const PaginationTest: Story = {
     await userEvent.click(nextButton);
 
     // Verify we're on page 2
-    const page2Info = canvas.getByText(/Page 2 of/);
+    const page2Info = canvas.getByText(/Showing 4 to 6 of/);
     await expect(page2Info).toBeInTheDocument();
 
+    // Page 2 button should be active
+    const page2Button = canvas.getByRole("button", { name: "2" });
+    await expect(page2Button).toHaveAttribute("aria-current", "page");
+
     // Go back to first page
-    const firstPageButton = canvas.getByRole("button", { name: "First page" });
-    await userEvent.click(firstPageButton);
+    const page1Button = canvas.getByRole("button", { name: "1" });
+    await userEvent.click(page1Button);
+
+    // Verify we're back on page 1
+    const page1Info = canvas.getByText(/Showing 1 to 3 of/);
+    await expect(page1Info).toBeInTheDocument();
   },
 };
 

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -12,11 +12,12 @@ import {
   type VisibilityState,
 } from "@tanstack/react-table";
 import { clsx, type ClassValue } from "clsx";
-import { ArrowDown, ArrowUp, ArrowUpDown, ChevronLeft, ChevronRight, Search } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, Search } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { twMerge } from "tailwind-merge";
 import { Checkbox } from "./checkbox";
 import { Input } from "./input";
+import { Pagination } from "./pagination";
 import { Table } from "./table";
 
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
@@ -311,52 +312,12 @@ export function DataTable<TData, TValue>({
               ` (${table.getFilteredSelectedRowModel().rows.length} selected)`}
           </div>
 
-          <nav className="flex items-center gap-1" aria-label="Table pagination">
-            <button
-              type="button"
-              onClick={() => table.previousPage()}
-              disabled={!table.getCanPreviousPage()}
-              className={cn(
-                "relative flex h-8 items-center justify-center border px-3 text-sm transition-colors before:absolute before:inset-[-8px] before:content-['']",
-                table.getCanPreviousPage()
-                  ? "border-chrome hover:bg-frost cursor-pointer"
-                  : "border-chrome text-steel cursor-not-allowed",
-              )}
-              aria-label="Previous page"
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </button>
-            {Array.from({ length: table.getPageCount() }, (_, i) => (
-              <button
-                key={i}
-                type="button"
-                onClick={() => table.setPageIndex(i)}
-                className={cn(
-                  "relative cursor-pointer border px-3 py-1 text-sm transition-colors before:absolute before:inset-[-8px] before:content-['']",
-                  table.getState().pagination.pageIndex === i
-                    ? "bg-branch text-paper border-branch"
-                    : "border-chrome hover:bg-frost",
-                )}
-                aria-current={table.getState().pagination.pageIndex === i ? "page" : undefined}
-              >
-                {i + 1}
-              </button>
-            ))}
-            <button
-              type="button"
-              onClick={() => table.nextPage()}
-              disabled={!table.getCanNextPage()}
-              className={cn(
-                "relative flex h-8 items-center justify-center border px-3 text-sm transition-colors before:absolute before:inset-[-8px] before:content-['']",
-                table.getCanNextPage()
-                  ? "border-chrome hover:bg-frost cursor-pointer"
-                  : "border-chrome text-steel cursor-not-allowed",
-              )}
-              aria-label="Next page"
-            >
-              <ChevronRight className="h-4 w-4" />
-            </button>
-          </nav>
+          <Pagination
+            mode="button"
+            page={table.getState().pagination.pageIndex + 1}
+            totalPages={table.getPageCount()}
+            onPageChange={(p) => table.setPageIndex(p - 1)}
+          />
         </div>
       )}
     </div>

--- a/src/components/pagination.stories.tsx
+++ b/src/components/pagination.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, within } from "storybook/test";
+import { useState } from "react";
+import { expect, userEvent, within } from "storybook/test";
 import { Pagination } from "./pagination";
 
 const meta: Meta<typeof Pagination> = {
@@ -24,7 +25,7 @@ const meta: Meta<typeof Pagination> = {
     docs: {
       description: {
         component:
-          "Server-side pagination component using links. Works with React Router's Link component for SSR-friendly navigation.",
+          "Pagination component supporting both link and button modes. Use link mode for SSR-friendly navigation, button mode for client-side pagination.",
       },
     },
   },
@@ -86,17 +87,17 @@ export const SinglePage: Story = {
 export const AllStates = () => (
   <div className="space-y-8">
     <div>
-      <h3 className="mb-4 text-sm font-medium">First Page</h3>
+      <h3 className="mb-4 text-sm font-medium">First Page (Link Mode)</h3>
       <Pagination page={1} totalPages={10} buildPageUrl={buildPageUrl} />
     </div>
 
     <div>
-      <h3 className="mb-4 text-sm font-medium">Middle Page</h3>
+      <h3 className="mb-4 text-sm font-medium">Middle Page (Link Mode)</h3>
       <Pagination page={5} totalPages={10} buildPageUrl={buildPageUrl} />
     </div>
 
     <div>
-      <h3 className="mb-4 text-sm font-medium">Last Page</h3>
+      <h3 className="mb-4 text-sm font-medium">Last Page (Link Mode)</h3>
       <Pagination page={10} totalPages={10} buildPageUrl={buildPageUrl} />
     </div>
 
@@ -114,6 +115,21 @@ export const AllStates = () => (
       <h3 className="mb-4 text-sm font-medium">Single Page (Hidden)</h3>
       <p className="text-steel text-sm">Pagination is hidden when totalPages = 1</p>
       <Pagination page={1} totalPages={1} buildPageUrl={buildPageUrl} />
+    </div>
+
+    <div>
+      <h3 className="mb-4 text-sm font-medium">Button Mode — First Page</h3>
+      <Pagination mode="button" page={1} totalPages={10} onPageChange={() => {}} />
+    </div>
+
+    <div>
+      <h3 className="mb-4 text-sm font-medium">Button Mode — Middle Page</h3>
+      <Pagination mode="button" page={5} totalPages={10} onPageChange={() => {}} />
+    </div>
+
+    <div>
+      <h3 className="mb-4 text-sm font-medium">Button Mode — Last Page</h3>
+      <Pagination mode="button" page={10} totalPages={10} onPageChange={() => {}} />
     </div>
   </div>
 );
@@ -188,5 +204,94 @@ export const LastPageTest: Story = {
     // Previous link should be active
     const prevLink = canvas.getByRole("link", { name: "Previous page" });
     await expect(prevLink).toHaveAttribute("href", "?page=9");
+  },
+};
+
+// --- Button mode stories ---
+
+const ButtonModeWrapper = ({ initialPage = 1, totalPages = 10 }) => {
+  const [page, setPage] = useState(initialPage);
+  return (
+    <div className="space-y-2">
+      <p className="text-steel text-sm" data-testid="page-info">
+        Page {page} of {totalPages}
+      </p>
+      <Pagination mode="button" page={page} totalPages={totalPages} onPageChange={setPage} />
+    </div>
+  );
+};
+
+export const ButtonMode = {
+  render: () => <ButtonModeWrapper initialPage={3} totalPages={10} />,
+};
+
+export const ButtonModeTest: StoryObj = {
+  render: () => <ButtonModeWrapper initialPage={1} totalPages={5} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Previous button should be disabled on first page
+    const prevButton = canvas.getByRole("button", { name: "Previous page" });
+    await expect(prevButton).toBeDisabled();
+
+    // Next button should be enabled
+    const nextButton = canvas.getByRole("button", { name: "Next page" });
+    await expect(nextButton).toBeEnabled();
+
+    // Click next page
+    await userEvent.click(nextButton);
+
+    // Verify we moved to page 2
+    const pageInfo = canvas.getByTestId("page-info");
+    await expect(pageInfo).toHaveTextContent("Page 2 of 5");
+
+    // Previous button should now be enabled
+    await expect(canvas.getByRole("button", { name: "Previous page" })).toBeEnabled();
+
+    // Click page 4 directly
+    await userEvent.click(canvas.getByRole("button", { name: "4" }));
+    await expect(pageInfo).toHaveTextContent("Page 4 of 5");
+
+    // Click previous
+    await userEvent.click(canvas.getByRole("button", { name: "Previous page" }));
+    await expect(pageInfo).toHaveTextContent("Page 3 of 5");
+  },
+};
+
+export const ButtonModeFirstPageTest: StoryObj = {
+  render: () => <ButtonModeWrapper initialPage={1} totalPages={10} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Previous button should be disabled (button, not span)
+    const prevButton = canvas.getByRole("button", { name: "Previous page" });
+    await expect(prevButton).toBeDisabled();
+
+    // Next button should be enabled
+    const nextButton = canvas.getByRole("button", { name: "Next page" });
+    await expect(nextButton).toBeEnabled();
+
+    // Page 1 should be marked as current
+    const page1 = canvas.getByRole("button", { name: "1" });
+    await expect(page1).toHaveAttribute("aria-current", "page");
+  },
+};
+
+export const ButtonModeLastPageTest: StoryObj = {
+  render: () => <ButtonModeWrapper initialPage={10} totalPages={10} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Next button should be disabled
+    const nextButton = canvas.getByRole("button", { name: "Next page" });
+    await expect(nextButton).toBeDisabled();
+
+    // Previous button should be enabled
+    const prevButton = canvas.getByRole("button", { name: "Previous page" });
+    await expect(prevButton).toBeEnabled();
+
+    // Page 10 should be marked as current
+    const page10 = canvas.getByRole("button", { name: "10" });
+    await expect(page10).toHaveAttribute("aria-current", "page");
   },
 };

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -4,7 +4,7 @@ import { twMerge } from "tailwind-merge";
 
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
-export interface PaginationProps {
+interface PaginationBaseProps {
   /**
    * Current page number (1-indexed)
    */
@@ -14,11 +14,6 @@ export interface PaginationProps {
    * Total number of pages
    */
   totalPages: number;
-
-  /**
-   * Function to build URL for a given page number
-   */
-  buildPageUrl: (page: number) => string;
 
   /**
    * Additional CSS class for the container
@@ -32,17 +27,49 @@ export interface PaginationProps {
   maxPageButtons?: number;
 }
 
+interface PaginationLinkProps extends PaginationBaseProps {
+  /**
+   * Use link-based navigation (default).
+   * Renders `<a>` tags for SSR-friendly navigation.
+   */
+  mode?: "link";
+
+  /**
+   * Function to build URL for a given page number.
+   * Required when mode is "link".
+   */
+  buildPageUrl: (page: number) => string;
+
+  onPageChange?: never;
+}
+
+interface PaginationButtonProps extends PaginationBaseProps {
+  /**
+   * Use button-based navigation for client-side pagination.
+   * Renders `<button>` tags with onClick handlers.
+   */
+  mode: "button";
+
+  /**
+   * Callback when a page is selected.
+   * Required when mode is "button".
+   */
+  onPageChange: (page: number) => void;
+
+  buildPageUrl?: never;
+}
+
+export type PaginationProps = PaginationLinkProps | PaginationButtonProps;
+
 /**
- * Server-side pagination component using links.
- * Works with React Router's Link component for SSR-friendly navigation.
+ * Pagination component supporting both link and button modes.
+ * - `mode="link"` (default): renders `<a>` tags with `buildPageUrl` for SSR-friendly navigation.
+ * - `mode="button"`: renders `<button>` tags with `onPageChange` for client-side pagination.
  */
-export function Pagination({
-  page,
-  totalPages,
-  buildPageUrl,
-  className,
-  maxPageButtons = 5,
-}: PaginationProps) {
+export function Pagination(props: PaginationProps) {
+  const { page, totalPages, className, maxPageButtons = 5 } = props;
+  const isButtonMode = props.mode === "button";
+
   if (totalPages <= 1) return null;
 
   // Calculate which page numbers to show
@@ -95,6 +122,9 @@ export function Pagination({
   const buttonInactiveClass = "border-chrome hover:bg-frost";
   const buttonDisabledClass = "border-chrome text-steel cursor-not-allowed";
 
+  const hasPrev = page > 1;
+  const hasNext = page < totalPages;
+
   return (
     <nav
       data-slot="pagination"
@@ -102,10 +132,21 @@ export function Pagination({
       aria-label="Pagination"
     >
       {/* Previous button */}
-      {page > 1 ? (
+      {isButtonMode ? (
+        <button
+          type="button"
+          data-slot="pagination-prev"
+          className={cn(buttonBaseClass, hasPrev ? buttonInactiveClass : buttonDisabledClass)}
+          disabled={!hasPrev}
+          onClick={() => hasPrev && props.onPageChange(page - 1)}
+          aria-label="Previous page"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+      ) : hasPrev ? (
         <a
           data-slot="pagination-prev"
-          href={buildPageUrl(page - 1)}
+          href={props.buildPageUrl(page - 1)}
           className={cn(buttonBaseClass, buttonInactiveClass)}
           aria-label="Previous page"
         >
@@ -138,11 +179,30 @@ export function Pagination({
         }
 
         const isCurrentPage = pageNum === page;
+
+        if (isButtonMode) {
+          return (
+            <button
+              key={pageNum}
+              type="button"
+              data-slot="pagination-page"
+              className={cn(
+                buttonBaseClass,
+                isCurrentPage ? buttonActiveClass : buttonInactiveClass,
+              )}
+              onClick={() => props.onPageChange(pageNum)}
+              aria-current={isCurrentPage ? "page" : undefined}
+            >
+              {pageNum}
+            </button>
+          );
+        }
+
         return (
           <a
             key={pageNum}
             data-slot="pagination-page"
-            href={buildPageUrl(pageNum)}
+            href={props.buildPageUrl(pageNum)}
             className={cn(buttonBaseClass, isCurrentPage ? buttonActiveClass : buttonInactiveClass)}
             aria-current={isCurrentPage ? "page" : undefined}
           >
@@ -152,10 +212,21 @@ export function Pagination({
       })}
 
       {/* Next button */}
-      {page < totalPages ? (
+      {isButtonMode ? (
+        <button
+          type="button"
+          data-slot="pagination-next"
+          className={cn(buttonBaseClass, hasNext ? buttonInactiveClass : buttonDisabledClass)}
+          disabled={!hasNext}
+          onClick={() => hasNext && props.onPageChange(page + 1)}
+          aria-label="Next page"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      ) : hasNext ? (
         <a
           data-slot="pagination-next"
-          href={buildPageUrl(page + 1)}
+          href={props.buildPageUrl(page + 1)}
           className={cn(buttonBaseClass, buttonInactiveClass)}
           aria-label="Next page"
         >


### PR DESCRIPTION
## Summary

Closes #254

- Extended `Pagination` to support `mode="button"` with `onPageChange` callback alongside existing `mode="link"` (default) with `buildPageUrl`
- Replaced DataTable's ~45-line inline pagination with `<Pagination mode="button" />`, gaining ellipsis support for large page counts
- Added button mode stories and interaction tests for Pagination

## Test plan

- [ ] Verify Pagination link mode stories still render correctly (Default, MiddlePage, LastPage, etc.)
- [ ] Verify new button mode stories render and navigate correctly (ButtonMode, ButtonModeTest)
- [ ] Verify DataTable WithPagination and FullFeatured stories work with the shared Pagination component
- [ ] Run interaction tests: PaginationTest, ButtonModeTest, ButtonModeFirstPageTest, ButtonModeLastPageTest
- [ ] Confirm keyboard navigation works in both link and button modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)