### PR TITLE
chore: remove "Thanks" prefix from changelog entries

### DIFF
--- a/.changeset/changelog-config.cjs
+++ b/.changeset/changelog-config.cjs
@@ -1,0 +1,11 @@
+const github = require("@changesets/changelog-github");
+
+const base = github.default || github;
+
+module.exports = {
+  ...base,
+  getReleaseLine: async (...args) => {
+    const line = await base.getReleaseLine(...args);
+    return line.replace(/ Thanks (@[^!]+)!/, " $1");
+  },
+};

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.2/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "beaket/ui" }],
+  "changelog": ["./changelog-config.cjs", { "repo": "beaket/ui" }],
   "commit": false,
   "fixed": [],
   "linked": [],


### PR DESCRIPTION
## Summary
- Wrap `@changesets/changelog-github` with custom config to output `@user` instead of `Thanks @user!` in release PR changelogs
- Before: `#251 5d86371 Thanks @jihnma! - fix: ...`
- After: `#251 5d86371 @jihnma - fix: ...`

## Test plan
- [ ] Merge a changeset and verify the release PR body uses the new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)