### PR TITLE
fix: React 19 ref collision and unstable effect dependencies

### DIFF
--- a/.changeset/react-perf-fixes.md
+++ b/.changeset/react-perf-fixes.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+fix: resolve React 19 ref collision in Textarea and stabilize effect dependencies in DataTable, Dialog, Sheet

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -129,14 +129,17 @@ export function DataTable<TData, TValue>({
   const tableRef = useRef(table);
   tableRef.current = table;
 
+  const onSelectionChangeRef = useRef(onSelectionChange);
+  onSelectionChangeRef.current = onSelectionChange;
+
   useEffect(() => {
-    if (selectable && onSelectionChange) {
+    if (selectable && onSelectionChangeRef.current) {
       const selectedRows = tableRef.current
         .getFilteredSelectedRowModel()
         .rows.map((row) => row.original);
-      onSelectionChange(selectedRows);
+      onSelectionChangeRef.current(selectedRows);
     }
-  }, [rowSelection, selectable, onSelectionChange]);
+  }, [rowSelection, selectable]);
 
   return (
     <div className={className}>

--- a/src/components/dialog.tsx
+++ b/src/components/dialog.tsx
@@ -1,7 +1,7 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { type ClassValue, clsx } from "clsx";
 import { X } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { twMerge } from "tailwind-merge";
 
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
@@ -60,40 +60,43 @@ export function Dialog({
   closeWhen,
 }: Props) {
   const [internalOpen, setInternalOpen] = useState(false);
-
   const isControlled = open !== undefined;
-
-  // Warn in dev mode if controlled without onOpenChange
-  if (process.env.NODE_ENV !== "production") {
-    if (isControlled && !onOpenChange) {
-      console.warn(
-        "Dialog: `open` prop provided without `onOpenChange`. The dialog will be read-only.",
-      );
-    }
-  }
-
   const dialogOpen = isControlled ? open : internalOpen;
-  const dialogOnOpenChange = useCallback(
-    (value: boolean) => {
-      if (onOpenChange) {
-        onOpenChange(value);
+
+  const onOpenChangeRef = useRef(onOpenChange);
+  onOpenChangeRef.current = onOpenChange;
+
+  const hasWarnedRef = useRef(false);
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      if (isControlled && !onOpenChange && !hasWarnedRef.current) {
+        console.warn(
+          "Dialog: `open` prop provided without `onOpenChange`. The dialog will be read-only.",
+        );
+        hasWarnedRef.current = true;
       }
-      if (!isControlled) {
-        setInternalOpen(value);
-      }
-    },
-    [isControlled, onOpenChange],
-  );
+    }
+  }, [isControlled, onOpenChange]);
 
   // Auto-close when closeWhen becomes truthy
   useEffect(() => {
     if (closeWhen) {
-      dialogOnOpenChange(false);
+      if (isControlled) {
+        onOpenChangeRef.current?.(false);
+      } else {
+        setInternalOpen(false);
+        onOpenChangeRef.current?.(false);
+      }
     }
-  }, [closeWhen, dialogOnOpenChange]);
+  }, [closeWhen, isControlled]);
+
+  const handleOpenChange = (value: boolean) => {
+    onOpenChangeRef.current?.(value);
+    if (!isControlled) setInternalOpen(value);
+  };
 
   return (
-    <DialogPrimitive.Root open={dialogOpen} onOpenChange={dialogOnOpenChange}>
+    <DialogPrimitive.Root open={dialogOpen} onOpenChange={handleOpenChange}>
       {trigger && <DialogPrimitive.Trigger asChild>{trigger}</DialogPrimitive.Trigger>}
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay

--- a/src/components/sheet.tsx
+++ b/src/components/sheet.tsx
@@ -1,7 +1,7 @@
 import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { type ClassValue, clsx } from "clsx";
 import { X } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { twMerge } from "tailwind-merge";
 
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
@@ -91,38 +91,43 @@ export function Sheet({
   fullScreen = false,
 }: Props) {
   const [internalOpen, setInternalOpen] = useState(false);
-
   const isControlled = open !== undefined;
-
-  if (process.env.NODE_ENV !== "production") {
-    if (isControlled && !onOpenChange) {
-      console.warn(
-        "Sheet: `open` prop provided without `onOpenChange`. The sheet will be read-only.",
-      );
-    }
-  }
-
   const sheetOpen = isControlled ? open : internalOpen;
-  const sheetOnOpenChange = useCallback(
-    (value: boolean) => {
-      if (onOpenChange) {
-        onOpenChange(value);
-      }
-      if (!isControlled) {
-        setInternalOpen(value);
-      }
-    },
-    [isControlled, onOpenChange],
-  );
 
+  const onOpenChangeRef = useRef(onOpenChange);
+  onOpenChangeRef.current = onOpenChange;
+
+  const hasWarnedRef = useRef(false);
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") {
+      if (isControlled && !onOpenChange && !hasWarnedRef.current) {
+        console.warn(
+          "Sheet: `open` prop provided without `onOpenChange`. The sheet will be read-only.",
+        );
+        hasWarnedRef.current = true;
+      }
+    }
+  }, [isControlled, onOpenChange]);
+
+  // Auto-close when closeWhen becomes truthy
   useEffect(() => {
     if (closeWhen) {
-      sheetOnOpenChange(false);
+      if (isControlled) {
+        onOpenChangeRef.current?.(false);
+      } else {
+        setInternalOpen(false);
+        onOpenChangeRef.current?.(false);
+      }
     }
-  }, [closeWhen, sheetOnOpenChange]);
+  }, [closeWhen, isControlled]);
+
+  const handleOpenChange = (value: boolean) => {
+    onOpenChangeRef.current?.(value);
+    if (!isControlled) setInternalOpen(value);
+  };
 
   return (
-    <DialogPrimitive.Root open={sheetOpen} onOpenChange={sheetOnOpenChange}>
+    <DialogPrimitive.Root open={sheetOpen} onOpenChange={handleOpenChange}>
       {trigger && <DialogPrimitive.Trigger asChild>{trigger}</DialogPrimitive.Trigger>}
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay

--- a/src/components/textarea.tsx
+++ b/src/components/textarea.tsx
@@ -16,11 +16,20 @@ interface Props extends React.ComponentProps<"textarea"> {
   autoResize?: boolean;
 }
 
-export function Textarea({ className, autoResize = true, onInput, ...props }: Props) {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
+export function Textarea({ className, autoResize = true, onInput, ref, ...props }: Props) {
+  const internalRef = useRef<HTMLTextAreaElement>(null);
+  const externalRef = useRef(ref);
+  externalRef.current = ref;
+
+  const mergedRef = useCallback((node: HTMLTextAreaElement | null) => {
+    internalRef.current = node;
+    const extRef = externalRef.current;
+    if (typeof extRef === "function") extRef(node);
+    else if (extRef) extRef.current = node;
+  }, []);
 
   const adjustHeight = useCallback(() => {
-    const textarea = textareaRef.current;
+    const textarea = internalRef.current;
     if (!textarea || !autoResize) return;
 
     textarea.style.height = "auto";
@@ -33,7 +42,7 @@ export function Textarea({ className, autoResize = true, onInput, ...props }: Pr
 
   return (
     <textarea
-      ref={textareaRef}
+      ref={mergedRef}
       data-slot="textarea"
       className={cn(
         "border-graphite bg-paper text-ink w-full border px-3 py-2 text-sm",


### PR DESCRIPTION
## Summary

- **Textarea**: Fix React 19 `ref` collision — `ref` was not destructured, so `{...props}` overwrote the internal `textareaRef`, breaking `autoResize` when consumers passed a ref
- **DataTable**: Store `onSelectionChange` in a ref to prevent `useEffect` from re-firing when consumers pass unstable (inline) callbacks
- **Dialog/Sheet**: Remove `useCallback` wrapper, stabilize `closeWhen` effect with ref-based `onOpenChange`, move dev warnings into `useEffect` to fire only once (not every render / Strict Mode double-invoke)

## Verified against official docs (context7)

| Fix | Source |
|-----|--------|
| Textarea ref as prop | [React 19 blog](https://react.dev/blog/2024/12/05/react-19) — `ref` is a regular prop, destructure before spreading |
| DataTable callback ref | [React docs](https://react.dev/learn/removing-effect-dependencies) — `useEffectEvent` pattern (ref workaround for stable React) |
| Dialog/Sheet warning | [React Strict Mode](https://react.dev/reference/react/StrictMode) — render functions called twice in dev |

## Test plan

- [ ] `pnpm typecheck` passes (confirmed)
- [ ] Textarea: pass external `ref` and verify `autoResize` still works
- [ ] DataTable: pass inline `onSelectionChange` callback and verify no infinite re-render
- [ ] Dialog/Sheet: open/close in controlled, uncontrolled, and `closeWhen` modes
- [ ] Dialog/Sheet: verify dev warning appears only once in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)