### PR TITLE
fix(docs): improve mobile UX for docs site

### DIFF
--- a/docs/src/components/props-table.astro
+++ b/docs/src/components/props-table.astro
@@ -17,7 +17,7 @@ const { props } = Astro.props;
 {props.length === 0 ? (
   <p class="text-sm text-[var(--steel)]">—</p>
 ) : (
-  <div class="overflow-x-auto">
+  <div class="props-table-scroll overflow-x-auto">
   <table class="w-full min-w-[500px] font-mono text-xs">
     <thead>
       <tr class="border-b border-[var(--chrome)] text-left tracking-wide text-[var(--steel)] uppercase">

--- a/docs/src/components/theme-switcher.tsx
+++ b/docs/src/components/theme-switcher.tsx
@@ -147,7 +147,8 @@ export function ThemeSwitcher({ layout = "sidebar" }: { layout?: "sidebar" | "in
   if (layout === "inline") {
     return (
       <nav aria-label="Theme" className="flex items-center gap-2">
-        <ul className="m-0 flex list-none gap-2 p-0">
+        {/* Desktop: button row */}
+        <ul className="m-0 hidden list-none gap-2 p-0 sm:flex">
           {baseThemes.map((name) => (
             <li key={name}>
               <button
@@ -162,6 +163,18 @@ export function ThemeSwitcher({ layout = "sidebar" }: { layout?: "sidebar" | "in
             </li>
           ))}
         </ul>
+        {/* Mobile: select */}
+        <select
+          value={active}
+          onChange={(e) => handleClick(e.target.value)}
+          className="border-graphite text-ink border bg-transparent px-2 py-1 text-xs sm:hidden"
+        >
+          {baseThemes.map((name) => (
+            <option key={name} value={name}>
+              {themeLabels[name]}
+            </option>
+          ))}
+        </select>
         <button
           type="button"
           onClick={toggleDark}

--- a/docs/src/layouts/doc.astro
+++ b/docs/src/layouts/doc.astro
@@ -29,7 +29,7 @@ const currentYear = new Date().getFullYear();
           <a href="/ui/" class="sidebar-title">Beaket UI</a>
           <span class="sidebar-version">v{pkg.version}</span>
           <button class="sidebar-toggle" aria-label="Toggle menu" aria-expanded="false">
-            <span class="sidebar-toggle-icon"></span>
+            {title} ▼
           </button>
         </div>
 
@@ -82,10 +82,12 @@ const currentYear = new Date().getFullYear();
     <script>
       const toggle = document.querySelector('.sidebar-toggle');
       const nav = document.querySelector('.sidebar-nav');
+      const pageTitle = toggle?.textContent?.replace(/[▼▲]/, '').trim() || '';
       toggle?.addEventListener('click', () => {
         const expanded = toggle.getAttribute('aria-expanded') === 'true';
         toggle.setAttribute('aria-expanded', String(!expanded));
         nav?.classList.toggle('open');
+        if (toggle) toggle.textContent = `${pageTitle} ${expanded ? '▼' : '▲'}`;
       });
 
       // Add copy buttons to all code blocks

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -19,7 +19,7 @@ const currentYear = new Date().getFullYear();
   </head>
   <body class="min-h-screen bg-paper">
     <main class="mx-auto max-w-4xl p-4">
-      <div style="display: flex; justify-content: flex-end; margin-bottom: 12px;">
+      <div class="home-theme-bar">
         <ThemeSwitcher client:load layout="inline" />
       </div>
       <ComponentShowcase client:load components={registry.components} version={pkg.version} />

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -380,10 +380,14 @@ a:not([data-slot]) {
 
   .sidebar-link {
     display: block;
-    padding: 0.5rem 0;
-    min-height: 44px;
-    display: flex;
-    align-items: center;
+    padding: 0.25rem 0;
+    position: relative;
+  }
+
+  .sidebar-link::before {
+    content: '';
+    position: absolute;
+    inset: -8px -12px;
   }
 
   .main {

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -312,35 +312,12 @@ a:not([data-slot]) {
   display: none;
   background: none;
   border: 1px solid var(--chrome);
-  padding: 0.25rem;
   cursor: pointer;
   margin-left: auto;
-}
-
-.sidebar-toggle-icon {
-  display: block;
-  width: 14px;
-  height: 2px;
-  background: var(--ink);
-  position: relative;
-}
-
-.sidebar-toggle-icon::before,
-.sidebar-toggle-icon::after {
-  content: "";
-  position: absolute;
-  width: 14px;
-  height: 2px;
-  background: var(--ink);
-  left: 0;
-}
-
-.sidebar-toggle-icon::before {
-  top: -5px;
-}
-
-.sidebar-toggle-icon::after {
-  top: 5px;
+  font-size: 0.75rem;
+  font-family: inherit;
+  color: var(--ink);
+  font-weight: 600;
 }
 
 /* Responsive: Mobile (<768px) */
@@ -350,13 +327,16 @@ a:not([data-slot]) {
   }
 
   .sidebar {
-    position: static;
+    position: sticky;
+    top: 0;
+    z-index: 50;
     width: 100%;
     height: auto;
     border-right: none;
     border-bottom: 1px solid var(--chrome);
     padding: 0.75rem 1rem;
     overflow-y: visible;
+    background: var(--paper);
   }
 
   .sidebar-header {
@@ -373,7 +353,10 @@ a:not([data-slot]) {
   }
 
   .sidebar-toggle {
-    display: block;
+    display: flex;
+    align-items: center;
+    min-height: 44px;
+    padding: 0.25rem 0.5rem;
   }
 
   .sidebar-nav {
@@ -397,7 +380,10 @@ a:not([data-slot]) {
 
   .sidebar-link {
     display: block;
-    padding: 0.25rem 0;
+    padding: 0.5rem 0;
+    min-height: 44px;
+    display: flex;
+    align-items: center;
   }
 
   .main {
@@ -412,6 +398,24 @@ a:not([data-slot]) {
 
   table {
     font-size: 0.75rem;
+  }
+
+  /* Smooth scroll for props table on touch */
+  .props-table-scroll {
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* Copy button always visible on touch devices */
+  .copy-button {
+    visibility: visible;
+  }
+
+  /* Prev/next nav touch targets */
+  .component-nav-link {
+    padding: 0.5rem 0;
+    min-height: 44px;
+    display: inline-flex;
+    align-items: center;
   }
 
   /* Responsive preview boxes */

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -367,7 +367,7 @@ a:not([data-slot]) {
   }
 
   .sidebar-toggle::before {
-    content: '';
+    content: "";
     position: absolute;
     inset: -12px -8px;
   }
@@ -398,7 +398,7 @@ a:not([data-slot]) {
   }
 
   .sidebar-link::before {
-    content: '';
+    content: "";
     position: absolute;
     inset: -8px -12px;
   }
@@ -437,7 +437,7 @@ a:not([data-slot]) {
   }
 
   .component-nav-link::before {
-    content: '';
+    content: "";
     position: absolute;
     inset: -12px -8px;
   }

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -301,6 +301,12 @@ a:not([data-slot]) {
   margin: 0 0.5rem;
 }
 
+.home-theme-bar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
+}
+
 /* Sidebar toggle (hidden on desktop) */
 .sidebar-header {
   display: flex;
@@ -311,13 +317,15 @@ a:not([data-slot]) {
 .sidebar-toggle {
   display: none;
   background: none;
-  border: 1px solid var(--chrome);
+  border: none;
   cursor: pointer;
   margin-left: auto;
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
   font-family: inherit;
-  color: var(--ink);
+  color: var(--steel);
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
 }
 
 /* Responsive: Mobile (<768px) */
@@ -334,7 +342,7 @@ a:not([data-slot]) {
     height: auto;
     border-right: none;
     border-bottom: 1px solid var(--chrome);
-    padding: 0.75rem 1rem;
+    padding: 0.5rem 1rem;
     overflow-y: visible;
     background: var(--paper);
   }
@@ -353,10 +361,15 @@ a:not([data-slot]) {
   }
 
   .sidebar-toggle {
-    display: flex;
-    align-items: center;
-    min-height: 44px;
-    padding: 0.25rem 0.5rem;
+    display: block;
+    position: relative;
+    padding: 0;
+  }
+
+  .sidebar-toggle::before {
+    content: '';
+    position: absolute;
+    inset: -12px -8px;
   }
 
   .sidebar-nav {
@@ -396,6 +409,10 @@ a:not([data-slot]) {
     max-width: 100%;
   }
 
+  body {
+    font-size: 16px;
+  }
+
   pre {
     font-size: 0.75rem;
   }
@@ -416,10 +433,25 @@ a:not([data-slot]) {
 
   /* Prev/next nav touch targets */
   .component-nav-link {
-    padding: 0.5rem 0;
-    min-height: 44px;
-    display: inline-flex;
-    align-items: center;
+    position: relative;
+  }
+
+  .component-nav-link::before {
+    content: '';
+    position: absolute;
+    inset: -12px -8px;
+  }
+
+  /* Home page theme bar sticky on mobile */
+  .home-theme-bar {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: var(--paper);
+    margin: 0 -1rem;
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid var(--chrome);
+    margin-bottom: 0.75rem;
   }
 
   /* Responsive preview boxes */


### PR DESCRIPTION
## Summary
- Replace hamburger icon with page title + ▼/▲ toggle — brutalist, shows current context
- Make mobile header sticky so navigation is always reachable while scrolling
- Expand all touch targets to 44px minimum (sidebar links, nav toggle, prev/next links)
- Show code copy buttons on mobile (previously hidden behind hover)
- Add smooth scroll for props table on touch devices

## Test plan
- [ ] Open docs on mobile (375px viewport) — header shows page name + ▼
- [ ] Scroll down — header stays sticky at top
- [ ] Tap ▼ — nav expands with ▲, links have adequate tap spacing
- [ ] Tap ▲ — nav collapses
- [ ] Code blocks show Copy button without hover
- [ ] Prev/next links at page bottom are easy to tap
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)