### PR TITLE
docs: improve component prop documentation

### DIFF
--- a/.changeset/improve-prop-documentation.md
+++ b/.changeset/improve-prop-documentation.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+Improve component prop documentation: extract compound component props (Card, Navigation, Tabs, Select, DropdownMenu), show enum literal values instead of "enum", filter className noise, fix ReactNode types showing as "any", and add inline option listings to JSDoc comments

--- a/docs/scripts/generate-props.ts
+++ b/docs/scripts/generate-props.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import { withCompilerOptions } from "react-docgen-typescript";
+import * as ts from "typescript";
 import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -17,51 +18,265 @@ interface ComponentProps {
   [componentName: string]: PropInfo[];
 }
 
+const EXCLUDED_PROPS = new Set(["className"]);
+const QUOTED_UNION_RE = /^("[^"]*"(\s*\|\s*"[^"]*")*)$/;
+
+function isSourceFile(fileName: string): boolean {
+  return !fileName.includes("node_modules") && fileName.includes("/src/components/");
+}
+
+function simplifyTypeName(raw: string): string {
+  if (raw === "React.ReactNode" || raw === "ReactNode") return "ReactNode";
+  if (QUOTED_UNION_RE.test(raw)) return raw.replace(/"/g, "");
+  return raw;
+}
+
 // Read registry
 const registryPath = path.resolve(__dirname, "../../registry/registry.json");
 const registry = JSON.parse(fs.readFileSync(registryPath, "utf-8"));
 
-// Parser options
 const parser = withCompilerOptions(
   { esModuleInterop: true, jsx: 1 }, // 1 = React
   {
     savePropValueAsString: true,
     shouldExtractLiteralValuesFromEnum: true,
     propFilter: (prop) => {
-      // Only keep props defined in our source files (not from node_modules)
+      if (EXCLUDED_PROPS.has(prop.name)) return false;
       if (prop.declarations && prop.declarations.length > 0) {
-        return prop.declarations.some(
-          (d) => !d.fileName.includes("node_modules") && d.fileName.includes("/src/components/"),
-        );
+        return prop.declarations.some((d) => isSourceFile(d.fileName));
       }
       return false;
     },
   },
 );
 
+// TS program for compound component extraction — only load component files
+const tsconfigPath = path.resolve(__dirname, "../../tsconfig.json");
+const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+const parsedConfig = ts.parseJsonConfigFileContent(
+  configFile.config,
+  ts.sys,
+  path.resolve(__dirname, "../.."),
+);
+const componentFilePaths = registry.components.map((c: { files: string[] }) =>
+  path.resolve(__dirname, "../../src", c.files[0]),
+);
+const program = ts.createProgram(componentFilePaths, parsedConfig.options);
+const checker = program.getTypeChecker();
+
+/**
+ * When react-docgen-typescript reports type as "enum", extract the actual
+ * literal values from the type.value array.
+ */
+function resolveEnumType(typeName: string, typeValue: unknown): string {
+  if (typeName === "enum" && Array.isArray(typeValue)) {
+    return typeValue.map((v: { value: string }) => v.value.replace(/"/g, "")).join(" | ");
+  }
+  return typeName;
+}
+
+/**
+ * Parse compound component patterns and return the root function name
+ * plus a map of functionName → subComponentName (e.g. "CardHeader" → "Header").
+ */
+function getCompoundMappings(source: string): { root: string | null; subs: Map<string, string> } {
+  const subs = new Map<string, string>();
+  let root: string | null = null;
+
+  // Pattern 1: Object.assign(RootFunc, { Sub: SubFunc, ... })
+  const assignMatch = source.match(/Object\.assign\((\w+),\s*\{([^}]+)\}/s);
+  if (assignMatch) {
+    root = assignMatch[1];
+    const body = assignMatch[2];
+    const pairRegex = /(\w+):\s*(\w+)/g;
+    let m;
+    while ((m = pairRegex.exec(body)) !== null) {
+      subs.set(m[2], m[1]); // funcName → subName
+    }
+  }
+
+  // Pattern 2: ExportedName.SubName = SubFunc;
+  const propAssignRegex = /^\w+\.(\w+)\s*=\s*(\w+);/gm;
+  let m;
+  while ((m = propAssignRegex.exec(source)) !== null) {
+    subs.set(m[2], m[1]); // funcName → subName
+  }
+
+  return { root, subs };
+}
+
+/**
+ * Get the declared type annotation text for a symbol, falling back to
+ * the checker's typeToString.
+ */
+function getTypeString(sym: ts.Symbol, contextNode: ts.Node, sourceFile: ts.SourceFile): string {
+  const decl = sym.getDeclarations()?.[0];
+  if (decl && (ts.isPropertySignature(decl) || ts.isPropertyDeclaration(decl)) && decl.type) {
+    return simplifyTypeName(decl.type.getText(sourceFile));
+  }
+  const propType = checker.getTypeOfSymbolAtLocation(sym, contextNode);
+  let str = checker.typeToString(propType);
+  if (str === "true | false") str = "boolean";
+  return str;
+}
+
+/**
+ * Extract props from a function declaration using the TypeScript type checker.
+ */
+function extractFunctionProps(node: ts.FunctionDeclaration, sourceFile: ts.SourceFile): PropInfo[] {
+  if (!node.parameters.length) return [];
+
+  const propsParam = node.parameters[0];
+  const paramType = checker.getTypeAtLocation(propsParam);
+  const props: PropInfo[] = [];
+
+  for (const sym of paramType.getProperties()) {
+    if (EXCLUDED_PROPS.has(sym.name)) continue;
+
+    const decls = sym.getDeclarations();
+    if (!decls?.length) continue;
+    if (!decls.some((d) => isSourceFile(d.getSourceFile().fileName))) continue;
+
+    const typeString = getTypeString(sym, propsParam, sourceFile);
+    const jsDoc = ts.displayPartsToString(sym.getDocumentationComment(checker)).trim();
+
+    const isOptional = decls.some(
+      (d) => (ts.isPropertySignature(d) || ts.isPropertyDeclaration(d)) && !!d.questionToken,
+    );
+
+    let defaultValue: string | null = null;
+    if (ts.isObjectBindingPattern(propsParam.name)) {
+      for (const element of propsParam.name.elements) {
+        if (
+          ts.isBindingElement(element) &&
+          ts.isIdentifier(element.name) &&
+          element.name.text === sym.name &&
+          element.initializer
+        ) {
+          defaultValue = element.initializer.getText(sourceFile);
+          if (defaultValue.startsWith('"') && defaultValue.endsWith('"')) {
+            defaultValue = defaultValue.slice(1, -1);
+          }
+        }
+      }
+    }
+
+    props.push({
+      name: sym.name,
+      type: typeString,
+      required: !isOptional,
+      defaultValue,
+      description: jsDoc,
+    });
+  }
+
+  return props;
+}
+
+/**
+ * Single AST walk to resolve all "any"-typed props to their declared type
+ * annotations (e.g. React.ReactNode → "ReactNode").
+ */
+function resolveAnyTypes(sourceFile: ts.SourceFile, propNames: Set<string>): Map<string, string> {
+  const resolved = new Map<string, string>();
+
+  function visit(node: ts.Node) {
+    if (resolved.size === propNames.size) return;
+    if (
+      (ts.isPropertySignature(node) || ts.isPropertyDeclaration(node)) &&
+      node.name &&
+      ts.isIdentifier(node.name) &&
+      propNames.has(node.name.text) &&
+      node.type
+    ) {
+      const simplified = simplifyTypeName(node.type.getText(sourceFile));
+      if (simplified !== node.type.getText(sourceFile)) {
+        resolved.set(node.name.text, simplified);
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  ts.forEachChild(sourceFile, visit);
+  return resolved;
+}
+
 function generateProps() {
   const result: ComponentProps = {};
 
   for (const component of registry.components) {
     const filePath = path.resolve(__dirname, "../../src", component.files[0]);
-
-    if (!fs.existsSync(filePath)) {
+    const sourceFile = program.getSourceFile(filePath);
+    if (!sourceFile) {
       console.warn(`File not found: ${filePath}`);
       continue;
     }
 
+    const source = sourceFile.text;
+
+    // Step 1: Use react-docgen-typescript for directly exported components
     const docs = parser.parse(filePath);
+    const props: PropInfo[] = [];
+    const foundSubNames = new Set<string>();
 
     if (docs.length > 0) {
-      const componentDoc = docs[0];
-      result[component.name] = Object.entries(componentDoc.props).map(([name, prop]) => ({
-        name,
-        type: prop.type.name,
-        required: prop.required,
-        defaultValue: prop.defaultValue?.value ?? null,
-        description: prop.description,
-      }));
+      for (const doc of docs) {
+        const dotIndex = doc.displayName.indexOf(".");
+        let prefix = "";
+        if (dotIndex !== -1) {
+          const subName = doc.displayName.slice(dotIndex + 1);
+          prefix = `${subName}.`;
+          foundSubNames.add(subName);
+        }
+
+        for (const [name, prop] of Object.entries(doc.props)) {
+          props.push({
+            name: prefix + name,
+            type: resolveEnumType(prop.type.name, prop.type.value),
+            required: prop.required,
+            defaultValue: prop.defaultValue?.value ?? null,
+            description: prop.description,
+          });
+        }
+      }
     }
+
+    // Step 2: Use TS compiler API for compound components not found by react-docgen
+    const { root: rootFuncName, subs } = getCompoundMappings(source);
+
+    if (subs.size > 0) {
+      ts.forEachChild(sourceFile, (node) => {
+        if (!ts.isFunctionDeclaration(node) || !node.name) return;
+        const funcName = node.name.text;
+
+        if (funcName === rootFuncName && props.length === 0) {
+          props.push(...extractFunctionProps(node, sourceFile));
+        }
+
+        const subName = subs.get(funcName);
+        if (subName && !foundSubNames.has(subName)) {
+          const subProps = extractFunctionProps(node, sourceFile);
+          for (const prop of subProps) {
+            props.push({ ...prop, name: `${subName}.${prop.name}` });
+          }
+        }
+      });
+    }
+
+    // Step 3: Batch-resolve "any" types via single AST walk
+    const anyPropNames = new Set(
+      props.filter((p) => p.type === "any").map((p) => p.name.split(".").pop()!),
+    );
+    if (anyPropNames.size > 0) {
+      const resolved = resolveAnyTypes(sourceFile, anyPropNames);
+      for (const prop of props) {
+        const baseName = prop.name.split(".").pop()!;
+        const better = resolved.get(baseName);
+        if (prop.type === "any" && better) prop.type = better;
+      }
+    }
+
+    result[component.name] = props;
   }
 
   // Output

--- a/src/components/alert.tsx
+++ b/src/components/alert.tsx
@@ -44,6 +44,8 @@ const variantTitles = {
 
 interface AlertProps
   extends Omit<React.ComponentProps<"div">, "title">, VariantProps<typeof alertVariants> {
+  /** note | tip | important | warning | caution. Semantic variant that controls color and icon */
+  variant?: "note" | "tip" | "important" | "warning" | "caution";
   /**
    * Title text for the alert. If not provided, displays the variant name capitalized.
    */

--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -5,7 +5,7 @@ import { twMerge } from "tailwind-merge";
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
 export interface Props extends React.HTMLAttributes<HTMLSpanElement> {
-  /** Badge style variant */
+  /** default | secondary | success | error | info | outline | warning | code. Badge style variant */
   variant?: "default" | "secondary" | "success" | "error" | "info" | "outline" | "warning" | "code";
 }
 

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -6,7 +6,7 @@ import { twMerge } from "tailwind-merge";
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
 export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  /** Button style variant */
+  /** primary | secondary | destructive | outline | ghost | link | success | stark | warning. Button style variant */
   variant?:
     | "primary"
     | "destructive"
@@ -17,7 +17,7 @@ export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
     | "success"
     | "stark"
     | "warning";
-  /** Button size */
+  /** sm | md | lg | icon. Button size */
   size?: "sm" | "md" | "lg" | "icon";
   /** Shows a loading spinner and disables the button */
   loading?: boolean;

--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -23,7 +23,7 @@ import { Table } from "./table";
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
 export interface DataTableProps<TData, TValue> {
-  /** Column definitions using TanStack Table's ColumnDef */
+  /** Column definitions using TanStack Table's ColumnDef — see https://tanstack.com/table/latest/docs/guide/column-defs */
   columns: ColumnDef<TData, TValue>[];
   /** Array of data to display */
   data: TData[];

--- a/src/components/dropdown-menu.tsx
+++ b/src/components/dropdown-menu.tsx
@@ -63,7 +63,7 @@ function DropdownMenuItem({
    */
   inset?: boolean;
   /**
-   * Visual style variant of the menu item
+   * default | destructive. Visual style variant of the menu item
    */
   variant?: "default" | "destructive";
 }) {

--- a/src/components/select.tsx
+++ b/src/components/select.tsx
@@ -19,7 +19,7 @@ function SelectValue(props: React.ComponentProps<typeof SelectPrimitive.Value>) 
 
 interface SelectTriggerProps extends React.ComponentProps<typeof SelectPrimitive.Trigger> {
   /**
-   * Size variant of the select trigger
+   * sm | default. Size variant of the select trigger
    */
   size?: "sm" | "default";
 }

--- a/src/components/sheet.tsx
+++ b/src/components/sheet.tsx
@@ -45,7 +45,7 @@ interface Props {
   closeWhen?: unknown;
 
   /**
-   * Side from which the sheet slides in
+   * left | right | top | bottom. Side from which the sheet slides in
    */
   side?: "left" | "right" | "top" | "bottom";
 

--- a/src/components/switch.tsx
+++ b/src/components/switch.tsx
@@ -47,7 +47,7 @@ interface SwitchProps
   className?: string;
 
   /**
-   * Size of the switch
+   * sm | md | lg. Size of the switch
    */
   size?: "sm" | "md" | "lg";
 


### PR DESCRIPTION
## Summary
- Rewrite `docs/scripts/generate-props.ts` to extract compound component props (Card, Navigation, Tabs, Select, DropdownMenu) using the TypeScript compiler API as fallback for `Object.assign` / property-assignment patterns
- Show enum literal values instead of `"enum"` (e.g. `primary | secondary | destructive` for button variant)
- Filter `className` from all component prop tables
- Fix `ReactNode` types showing as `"any"` (input prefix/suffix, dialog trigger, etc.)
- Add inline option listings to JSDoc comments with consistent `"options. Description"` format
- Add TanStack Table docs link to DataTable columns JSDoc

Closes #259

## Test plan
- [x] `npx tsx scripts/generate-props.ts` runs without errors
- [x] Generated `props.json` includes previously missing components (card, navigation, tabs, select)
- [x] Sub-component props properly prefixed (e.g. `Link.active`, `Trigger.size`, `Item.variant`)
- [x] No `className` props in output
- [x] No duplicate entries in dropdown-menu
- [x] Enum types resolved to literal values
- [x] `ReactNode` shown instead of `any`
- [x] TypeScript compilation passes (`tsc --noEmit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)