### PR TITLE
fix(docs): redesign 404 page

### DIFF
--- a/docs/src/pages/404.astro
+++ b/docs/src/pages/404.astro
@@ -1,9 +1,56 @@
 ---
-import Layout from '../layouts/doc.astro';
+import '../styles/global.css';
 ---
 
-<Layout title="404">
-  <h1>404</h1>
-  <p>Page not found.</p>
-  <p><a href="#" onclick="history.back(); return false;">Go back</a></p>
-</Layout>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/svg+xml" href="/ui/favicon.svg" />
+    <title>404 - Beaket UI</title>
+    <script is:inline src="/ui/theme-init.js"></script>
+  </head>
+  <body>
+    <main class="error-page">
+      <h1 class="error-code">404</h1>
+      <p class="error-message">Page not found.</p>
+      <a href="/ui/" class="error-action">← Home</a>
+    </main>
+  </body>
+</html>
+
+<style>
+  .error-page {
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+  }
+  .error-code {
+    font-size: 4.5rem;
+    font-weight: 300;
+    letter-spacing: -0.02em;
+    margin: 0;
+  }
+  .error-message {
+    margin-top: 0.5rem;
+    color: var(--steel);
+  }
+  .error-action {
+    margin-top: 2rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--ink);
+    text-decoration: none;
+    border: 1px solid var(--ink);
+    padding: 0.5rem 1.5rem;
+  }
+  .error-action:hover {
+    background: var(--frost);
+  }
+</style>


### PR DESCRIPTION
## Summary
- Redesign 404 page as standalone centered layout (no sidebar)
- Large lightweight status code + message + home link
- Follows main app's ErrorPage pattern in brutalist style

## Test plan
- [ ] Visit a non-existent docs URL (e.g. `/ui/nonexistent`)
- [ ] Verify centered layout with 404 code, message, and home link
- [ ] Verify theming works (design tokens applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)