### PR TITLE
chore: block major version bumps by default

### DIFF
--- a/.changeset/remove-composed-components.md
+++ b/.changeset/remove-composed-components.md
@@ -1,5 +1,5 @@
 ---
-"@beaket/ui": major
+"@beaket/ui": minor
 ---
 
 Remove 5 composed components in favor of primitive-first philosophy

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,22 @@
+# Block major changesets unless explicitly allowed
+if [ "$ALLOW_MAJOR" != "1" ]; then
+  MAJOR_FILES=$(git diff --cached --name-only --diff-filter=ACMR -- '.changeset/*.md' | while read f; do
+    grep -l '"@beaket/ui": major' "$f" 2>/dev/null
+  done)
+  if [ -n "$MAJOR_FILES" ]; then
+    echo ""
+    echo "BLOCKED: major version bump detected in changeset."
+    echo ""
+    echo "  $MAJOR_FILES"
+    echo ""
+    echo "Major bumps require explicit approval. See docs/git-rules.md."
+    echo "To override: ALLOW_MAJOR=1 git commit ..."
+    echo ""
+    exit 1
+  fi
+fi
+
 # Format staged files and re-add them to include the formatting changes in the commit
 FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
 [ -z "$FILES" ] && exit 0
-prettier $FILES --write --ignore-unknown && git add $FILES
+npx prettier $FILES --write --ignore-unknown && git add $FILES

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,6 @@ When creating a component, you **must** create all of:
 - [ ] `src/components/[name].tsx` — Component with `data-slot`, `cn`, design tokens
 - [ ] `src/components/[name].stories.tsx` — Storybook with `tags: ["autodocs"]` + interaction tests via `play` function
 - [ ] `registry/registry.json` — Register with dependencies and docs sections
-- [ ] `.changeset/*.md` — Package name must be `@beaket/ui` (minor for new/feature, patch for fix, major for breaking)
+- [ ] `.changeset/*.md` — Package name must be `@beaket/ui` (minor for new/feature, patch for fix). **NEVER use `major` — see `docs/git-rules.md`**
 
 **Testing portals**: Use `screen` (not `canvasElement`) for Dialog, Popover, etc. Don't mock `onOpenChange` with `fn()`.

--- a/docs/git-rules.md
+++ b/docs/git-rules.md
@@ -1,0 +1,41 @@
+# Git Rules
+
+## Versioning Policy
+
+### NEVER use `major` in changesets without explicit approval
+
+This project uses [Changesets](https://github.com/changesets/changesets) for versioning. **Major version bumps are restricted** and must be explicitly approved by a maintainer.
+
+- **`patch`** — Bug fixes, typos, minor adjustments. Use freely.
+- **`minor`** — New features, new components, non-breaking enhancements. Use freely.
+- **`major`** — **BLOCKED by default.** Breaking changes, removed APIs, renamed exports.
+
+### Why?
+
+A major version bump signals breaking changes to every consumer of this library. Premature or accidental major bumps erode trust and force unnecessary migration work on users. We release major versions deliberately, not accidentally.
+
+### How to release a major version
+
+1. Discuss with maintainers first
+2. Create the changeset with `minor` initially
+3. A maintainer will change it to `major` and add `ALLOW_MAJOR=1` to the commit message to bypass the pre-commit hook
+4. The release PR will then bump the major version
+
+### Pre-commit hook
+
+The `pre-commit` hook automatically blocks commits that contain `major` changesets unless `ALLOW_MAJOR=1` is set as an environment variable:
+
+```bash
+# Normal commit — major changesets are blocked
+git commit -m "feat: add something"
+
+# Explicitly allow major — maintainer override
+ALLOW_MAJOR=1 git commit -m "feat!: remove deprecated API"
+```
+
+## Changeset Guidelines
+
+- Package name must always be `@beaket/ui`
+- One changeset per logical change
+- Write clear, user-facing descriptions (these appear in the changelog)
+- Include migration instructions for any breaking change


### PR DESCRIPTION
## Summary
- Add pre-commit hook that blocks `major` changesets unless `ALLOW_MAJOR=1` is set
- Add `docs/git-rules.md` documenting versioning policy and override process
- Update `CLAUDE.md` to instruct AI to never use `major` in changesets
- Downgrade `remove-composed-components` changeset from `major` to `minor`
- Fix prettier PATH issue in pre-commit hook (use `npx`)

## How it works
```bash
# This will be blocked:
git commit -m "feat: something"  # if staged changeset has "major"

# This will pass:
ALLOW_MAJOR=1 git commit -m "feat!: breaking change"
```

## Test plan
- [ ] Create a changeset with `major`, try to commit — should be blocked
- [ ] Same commit with `ALLOW_MAJOR=1` — should pass
- [ ] PR #237 should now show 2.x.x instead of 3.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)