### PR TITLE
fix(ci): rename Chromatic job to avoid misleading "test" skip status

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -23,7 +23,7 @@ on:
       - "tsconfig.json"
 
 jobs:
-  test:
+  chromatic:
     if: github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Rename Chromatic workflow job from `test` to `chromatic`
- Fixes misleading "test — SKIPPED" status on Renovate bot PRs that made CI look like it failed

## Test plan
- [ ] Verify the job appears as `chromatic` in PR checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)