### PR TITLE
fix(docs): improve home page layout and card visibility

### DIFF
--- a/docs/src/components/component-showcase.tsx
+++ b/docs/src/components/component-showcase.tsx
@@ -6,6 +6,7 @@ interface ComponentData {
     title: string;
     previewStory: string;
     span?: number;
+    rowSpan?: number;
   };
 }
 
@@ -16,36 +17,43 @@ interface ComponentShowcaseProps {
 
 export function ComponentShowcase({ components, version }: ComponentShowcaseProps) {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div
+      className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+      style={{ gridAutoRows: "190px", gridAutoFlow: "dense" }}
+    >
       {/* Branding Card */}
       <a
         href="/ui/installation"
         data-slot="branding-card"
-        className="shadow-offset hover:shadow-offset-hover active:shadow-offset-active border-ink bg-paper flex flex-col justify-between border-2 p-4 no-underline transition-shadow outline-none"
+        className="shadow-offset hover:shadow-offset-hover active:shadow-offset-active border-ink bg-branch flex flex-col justify-between border-2 p-4 no-underline transition-shadow outline-none"
       >
         <div>
           <div>
-            <span className="text-ink text-sm font-bold tracking-wide uppercase">Beaket UI</span>
-            <span className="text-steel ml-1.5 text-[10px]">v{version}</span>
+            <span className="text-paper text-sm font-bold tracking-wide uppercase">Beaket UI</span>
+            <span className="text-paper/60 ml-1.5 text-[10px]">v{version}</span>
           </div>
-          <p className="text-steel m-0 mt-3 text-sm leading-relaxed">
+          <p className="text-paper/80 m-0 mt-3 text-sm leading-relaxed">
             Brutalist React components.
             <br />
             Copy-paste into your project.
           </p>
         </div>
-        <div className="bg-branch text-paper mt-4 inline-block px-3 py-1.5 text-xs font-bold">
+        <div className="bg-paper text-ink mt-4 inline-block px-3 py-1.5 text-xs font-bold">
           → Get Started
         </div>
       </a>
 
       {/* Component Cards */}
       {components.map((component, index) => {
-        const span = component.docs.span ?? 1;
-        const spanClass = span === 3 ? "col-span-full" : span === 2 ? "sm:col-span-2" : "";
-        const previewHeight = span >= 2 ? "h-[260px]" : "h-[120px]";
+        const colSpan = component.docs.span ?? 1;
+        const rowSpan = component.docs.rowSpan ?? 1;
+        const colClass = colSpan === 3 ? "col-span-full" : colSpan === 2 ? "sm:col-span-2" : "";
         return (
-          <div key={component.name} className={`bg-paper p-4 ${spanClass}`}>
+          <div
+            key={component.name}
+            className={`border-chrome bg-surface-1 flex flex-col border p-4 ${colClass}`}
+            style={rowSpan > 1 ? { gridRow: `span ${rowSpan}` } : undefined}
+          >
             <a
               data-slot="component-link"
               href={`/ui/components/${component.name}`}
@@ -53,9 +61,7 @@ export function ComponentShowcase({ components, version }: ComponentShowcaseProp
             >
               {component.docs.title} →
             </a>
-            <div
-              className={`mt-3 ${previewHeight} overflow-hidden [&_[data-slot=input-wrapper]]:w-full [&_[data-slot=input]]:w-full [&_[data-slot=select]]:w-full [&_ul]:justify-start [&>*]:m-0`}
-            >
+            <div className="mt-3 min-h-0 flex-1 overflow-hidden [&_[data-slot=input-wrapper]]:w-full [&_[data-slot=input]]:w-full [&_[data-slot=select]]:w-full [&_ul]:justify-start [&>*]:m-0">
               <StoryPreview
                 componentName={component.name}
                 storyName={component.docs.previewStory}

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -93,7 +93,8 @@
         "title": "Button",
         "tagline": "Clickable button with multiple variants and sizes.",
         "sections": ["AllVariants", "AllSizes", "AllStates"],
-        "previewStory": "AllVariants"
+        "previewStory": "AllVariants",
+        "rowSpan": 2
       }
     },
     {
@@ -106,7 +107,8 @@
         "title": "Checkbox",
         "tagline": "A control for boolean input with checked and unchecked states.",
         "sections": ["AllStates"],
-        "previewStory": "AllStates"
+        "previewStory": "AllStates",
+        "rowSpan": 2
       }
     },
     {
@@ -119,7 +121,8 @@
         "title": "Input",
         "tagline": "A text input field for capturing user data.",
         "sections": ["AllStates", "AllTypes"],
-        "previewStory": "AllStates"
+        "previewStory": "AllStates",
+        "rowSpan": 2
       }
     },
     {
@@ -132,7 +135,8 @@
         "title": "Label",
         "tagline": "A semantic label for form controls with proper accessibility.",
         "sections": ["AllStates"],
-        "previewStory": "AllStates"
+        "previewStory": "AllStates",
+        "rowSpan": 2
       }
     },
     {
@@ -145,7 +149,8 @@
         "title": "Radio",
         "tagline": "A control for selecting one option from a set of choices.",
         "sections": ["AllStates"],
-        "previewStory": "AllStates"
+        "previewStory": "AllStates",
+        "rowSpan": 2
       }
     },
     {
@@ -229,7 +234,8 @@
         "title": "Tabs",
         "tagline": "A set of layered sections of content that display one panel at a time.",
         "sections": ["AllStates"],
-        "previewStory": "Default"
+        "previewStory": "Default",
+        "rowSpan": 2
       }
     },
     {
@@ -323,7 +329,8 @@
         "tagline": "A powerful data table with sorting, filtering, pagination, and selection.",
         "sections": ["AllFeatures"],
         "previewStory": "FullFeatured",
-        "span": 3
+        "span": 3,
+        "rowSpan": 2
       }
     },
     {


### PR DESCRIPTION
## Summary
- **Card visibility**: Added `border-chrome` borders and `bg-surface-1` background to component cards — previously invisible against `bg-paper` page background, especially in dark mode
- **Dynamic grid layout**: Switched to `gridAutoFlow: dense` with `gridAutoRows: 190px` and added `rowSpan` support — tall components (Button, Input, Radio, etc.) now span 2 rows instead of being clipped
- **Branding card hierarchy**: Inverted branding card to `bg-branch text-paper` so it stands out as the primary CTA across all themes

## Test plan
- [ ] Verify all 4 themes (Porcelain, Tobacco, Marigold, Eucalyptus) in both light and dark mode
- [ ] Check that component previews are not clipped (Button, Checkbox, Input, Label, Radio)
- [ ] Verify dense grid packing fills gaps correctly
- [ ] Test mobile viewport (grid-cols-1) layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)