### PR TITLE
fix(avatar): add hydration guard to prevent React 19 SSR mismatch

### DIFF
--- a/.changeset/fix-avatar-hydration.md
+++ b/.changeset/fix-avatar-hydration.md
@@ -1,0 +1,7 @@
+---
+"@beaket/ui": patch
+---
+
+fix: Avatar.Image hydration mismatch in React 19 SSR
+
+Added hydration guard to `Avatar.Image` that defers rendering until after mount. This prevents React hydration error #418 caused by `@radix-ui/react-use-is-hydrated` returning `true` during client hydration in React 19, which made cached images render `<img>` while the server rendered `<span>` (fallback).

--- a/src/components/avatar.stories.tsx
+++ b/src/components/avatar.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { expect, within } from "storybook/test";
+import { expect, waitFor, within } from "storybook/test";
 import { Avatar } from "./avatar";
 
 const meta: Meta<typeof Avatar> = {
@@ -128,6 +128,31 @@ export const AvatarGroup = () => (
     </Avatar>
   </div>
 );
+
+export const HydrationGuardTest: Story = {
+  render: () => (
+    <Avatar>
+      <Avatar.Image src="https://github.com/beaket.png" alt="@beaket" />
+      <Avatar.Fallback>HG</Avatar.Fallback>
+    </Avatar>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Avatar.Image defers rendering until after mount (hydration guard),
+    // so fallback should be visible initially, then image loads.
+    const fallback = canvas.getByText("HG");
+    await expect(fallback).toBeInTheDocument();
+
+    // Verify the image eventually renders after the hydration guard clears
+    await waitFor(
+      () => {
+        const img = canvasElement.querySelector("[data-slot='avatar-image']");
+        expect(img).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+  },
+};
 
 // Interaction Tests
 export const RenderTest: Story = {

--- a/src/components/avatar.tsx
+++ b/src/components/avatar.tsx
@@ -1,8 +1,11 @@
 import * as AvatarPrimitive from "@radix-ui/react-avatar";
 import { type ClassValue, clsx } from "clsx";
+import { useEffect, useState } from "react";
 import { twMerge } from "tailwind-merge";
 
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
+
+let hydrated = false;
 
 interface Props extends React.ComponentProps<typeof AvatarPrimitive.Root> {
   /**
@@ -32,6 +35,16 @@ function AvatarImage({
   alt,
   ...props
 }: React.ComponentProps<typeof AvatarPrimitive.Image>) {
+  // Hydration guard: delay rendering until after mount to prevent React 19 SSR
+  // hydration mismatch. Radix's useIsHydrated (via useSyncExternalStore) returns
+  // true during client hydration in React 19, causing cached images to render
+  // <img> while the server rendered <span> (fallback). See #291.
+  const [mounted, setMounted] = useState(hydrated);
+  useEffect(() => {
+    if (!mounted) setMounted(true);
+    hydrated = true;
+  }, []);
+
   if (process.env.NODE_ENV !== "production") {
     if (!alt) {
       console.warn(
@@ -39,6 +52,8 @@ function AvatarImage({
       );
     }
   }
+
+  if (!mounted) return null;
 
   return (
     <AvatarPrimitive.Image


### PR DESCRIPTION
## Summary
- Adds hydration guard to `Avatar.Image` that defers rendering until after mount, preventing React hydration error #418 in React 19 SSR
- Uses a module-level `hydrated` flag so only the first `Avatar.Image` on the page pays the double-render cost; subsequent avatars skip the extra cycle
- Adds `HydrationGuardTest` story with `waitFor` assertion to verify the image renders after the guard clears

## Root cause
`@radix-ui/react-use-is-hydrated` (v0.1.0) uses `useSyncExternalStore` where `getSnapshot` (`() => true`) is called during React 19 client hydration instead of `getServerSnapshot` (`() => false`). This causes cached images to render `<img>` on the client while the server rendered `<span>` (fallback) → structural hydration mismatch.

## Trade-off
One-frame fallback flash on cached images (sub-frame on fast devices). Acceptable compared to hydration errors.

## Test plan
- [ ] Storybook: `HydrationGuardTest` passes — fallback appears, then image loads
- [ ] Storybook: existing `Default`, `WithFallback`, `FallbackOnly` stories unaffected
- [ ] SSR: avatar-heavy page no longer produces React error #418 with cached images

Closes #291

🤖 Generated with [Claude Code](https://claude.com/claude-code)