### PR TITLE
feat(input): add ref prop support

### DIFF
--- a/.changeset/input-ref-support.md
+++ b/.changeset/input-ref-support.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": minor
+---
+
+Add ref prop support to Input component for direct DOM access (e.g. focus management)

--- a/src/components/input.stories.tsx
+++ b/src/components/input.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Eye, EyeOff, Mail, Search, X } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { expect, fn, userEvent, within } from "storybook/test";
 import { Input } from "./input";
 
@@ -222,5 +222,61 @@ export const ClearTest: Story = {
     await expect(input).toHaveValue("Clear me");
     await userEvent.clear(input);
     await expect(input).toHaveValue("");
+  },
+};
+
+export const RefTest: Story = {
+  render: () => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    return (
+      <div className="flex flex-col gap-2">
+        <Input ref={inputRef} placeholder="Ref input" />
+        <button
+          type="button"
+          data-testid="focus-btn"
+          onClick={() => inputRef.current?.focus()}
+          className="border-graphite border px-3 py-1 text-sm"
+        >
+          Focus via ref
+        </button>
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("textbox");
+    const button = canvas.getByTestId("focus-btn");
+
+    await expect(input).not.toHaveFocus();
+    await userEvent.click(button);
+    await expect(input).toHaveFocus();
+  },
+};
+
+export const RefWithPrefixTest: Story = {
+  render: () => {
+    const inputRef = useRef<HTMLInputElement>(null);
+    return (
+      <div className="flex flex-col gap-2">
+        <Input ref={inputRef} placeholder="Search..." prefix={<Search />} />
+        <button
+          type="button"
+          data-testid="focus-btn"
+          onClick={() => inputRef.current?.focus()}
+          className="border-graphite border px-3 py-1 text-sm"
+        >
+          Focus via ref
+        </button>
+      </div>
+    );
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole("textbox");
+    const button = canvas.getByTestId("focus-btn");
+
+    await expect(input).not.toHaveFocus();
+    await userEvent.click(button);
+    await expect(input).toHaveFocus();
   },
 };

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -10,6 +10,8 @@ export interface Props extends Omit<React.InputHTMLAttributes<HTMLInputElement>,
   prefix?: React.ReactNode;
   /** Element to render after the input (e.g., icon or button) */
   suffix?: React.ReactNode;
+  /** Ref forwarded to the underlying input element */
+  ref?: React.Ref<HTMLInputElement>;
 }
 
 const inputBaseStyles = [
@@ -23,10 +25,16 @@ const inputBaseStyles = [
   "read-only:bg-frost read-only:text-steel",
 ].join(" ");
 
-export function Input({ className, type = "text", prefix, suffix, ...props }: Props) {
+export function Input({ className, type = "text", prefix, suffix, ref, ...props }: Props) {
   if (!prefix && !suffix) {
     return (
-      <input type={type} data-slot="input" className={cn(inputBaseStyles, className)} {...props} />
+      <input
+        ref={ref}
+        type={type}
+        data-slot="input"
+        className={cn(inputBaseStyles, className)}
+        {...props}
+      />
     );
   }
 
@@ -41,6 +49,7 @@ export function Input({ className, type = "text", prefix, suffix, ...props }: Pr
         </span>
       )}
       <input
+        ref={ref}
         type={type}
         data-slot="input"
         className={cn(inputBaseStyles, prefix && "pl-9", suffix && "pr-9", className)}


### PR DESCRIPTION
## Summary
- Add `ref` prop to `Input` component's `Props` interface
- Forward `ref` to the underlying `<input>` element in both the simple and prefix/suffix branches
- Uses React 19 ref-as-prop pattern (no `forwardRef` needed)

Closes #306

## Test plan
- [x] `RefTest` story: verifies `ref.current.focus()` works on plain input
- [x] `RefWithPrefixTest` story: verifies ref works with prefix/suffix wrapper
- [x] TypeScript type-check passes
- [ ] Storybook interaction tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)