### PR TITLE
feat(cli): sync theme tokens on add and new theme command

### DIFF
--- a/.changeset/theme-sync-cli.md
+++ b/.changeset/theme-sync-cli.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": minor
+---
+
+Add theme token sync to CLI. Running `npx @beaket/ui add -o` now also updates outdated CSS design tokens. New `npx @beaket/ui theme` command for standalone theme sync and switching.

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -3,6 +3,8 @@ import pc from "picocolors";
 import { getConfig } from "../utils/config.ts";
 import { installDependencies, writeComponentFiles } from "../utils/files.ts";
 import { fetchComponent, fetchRegistry } from "../utils/registry.ts";
+import { syncTheme } from "../utils/theme.ts";
+import { THEME_CSS } from "../utils/themes.ts";
 
 interface AddOptions {
   overwrite?: boolean;
@@ -87,5 +89,12 @@ export async function add(componentNames: string[], options: AddOptions) {
   console.log();
   console.log("Added:");
   allWritten.forEach((f) => console.log(pc.cyan(`  ${f}`)));
+
+  // Sync theme tokens
+  if (config.css) {
+    console.log();
+    await syncTheme(config, THEME_CSS, { overwrite: options.overwrite });
+  }
+
   console.log();
 }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -2,22 +2,9 @@ import fs from "fs-extra";
 import path from "path";
 import pc from "picocolors";
 import prompts from "prompts";
-import CSS_DEFAULT from "../../../../src/css-variables.css";
-import CSS_EUCALYPTUS from "../../../../src/themes/eucalyptus.css";
-import CSS_MARIGOLD from "../../../../src/themes/marigold.css";
-import CSS_PORCELAIN from "../../../../src/themes/porcelain.css";
-import CSS_TOBACCO from "../../../../src/themes/tobacco.css";
 import { writeConfig, type BeaketConfig } from "../utils/config.ts";
-
-const THEME_CSS: Record<string, string> = {
-  porcelain: CSS_PORCELAIN,
-  tobacco: CSS_TOBACCO,
-  marigold: CSS_MARIGOLD,
-  eucalyptus: CSS_EUCALYPTUS,
-  default: CSS_DEFAULT,
-};
-
-const VALID_THEMES = Object.keys(THEME_CSS);
+import { replaceThemeInCss } from "../utils/theme.ts";
+import { THEME_CSS, VALID_THEMES } from "../utils/themes.ts";
 
 interface TsConfig {
   compilerOptions?: {
@@ -162,6 +149,7 @@ export async function init(options: InitOptions) {
   const config: BeaketConfig = {
     $schema: "https://beaket.dev/schema.json",
     components: response.components,
+    css: response.css || undefined,
     theme: response.theme,
   };
 
@@ -170,12 +158,20 @@ export async function init(options: InitOptions) {
 
   // Inject CSS variables into Tailwind CSS file
   const selectedCss = THEME_CSS[response.theme];
+  if (!selectedCss) {
+    console.log(pc.red("Error:"), `Unknown theme "${response.theme}".`);
+    process.exit(1);
+  }
   if (response.css) {
     const cssPath = path.join(process.cwd(), response.css);
     if (await fs.pathExists(cssPath)) {
       const cssContent = await fs.readFile(cssPath, "utf-8");
-      if (!cssContent.includes("Beaket UI Design System")) {
-        await fs.writeFile(cssPath, cssContent + selectedCss);
+      if (
+        !cssContent.includes("Beaket UI Design System") &&
+        !cssContent.includes("beaket:theme:start")
+      ) {
+        const { css } = replaceThemeInCss(cssContent, selectedCss);
+        await fs.writeFile(cssPath, css);
         console.log(pc.green("✔"), `Added CSS variables to ${response.css}`);
         console.log(pc.green("✔"), `Using ${response.theme} theme`);
       } else {

--- a/packages/cli/src/commands/theme.ts
+++ b/packages/cli/src/commands/theme.ts
@@ -1,0 +1,41 @@
+import pc from "picocolors";
+import { getConfig, writeConfig } from "../utils/config.ts";
+import { syncTheme } from "../utils/theme.ts";
+import { THEME_CSS, VALID_THEMES } from "../utils/themes.ts";
+
+interface ThemeOptions {
+  theme?: string;
+}
+
+export async function theme(options: ThemeOptions) {
+  console.log();
+
+  const config = await getConfig();
+  if (!config) {
+    console.log(pc.red("Error:"), "beaket.ui.json not found.");
+    console.log("Run", pc.cyan("npx @beaket/ui init"), "first.");
+    process.exit(1);
+  }
+
+  // Switch theme if --theme flag provided
+  if (options.theme) {
+    if (!VALID_THEMES.includes(options.theme)) {
+      console.log(
+        pc.red("Error:"),
+        `Invalid theme "${options.theme}". Choose from: ${VALID_THEMES.join(", ")}`,
+      );
+      process.exit(1);
+    }
+    config.theme = options.theme;
+  }
+
+  await syncTheme(config, THEME_CSS, { overwrite: true });
+
+  // Persist theme change to config only after successful sync
+  if (options.theme) {
+    await writeConfig(config);
+    console.log(pc.green("✔"), `Switched to ${options.theme} theme.`);
+  }
+
+  console.log();
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,6 +1,7 @@
 import { Command } from "commander";
 import { add } from "./commands/add.ts";
 import { init } from "./commands/init.ts";
+import { theme } from "./commands/theme.ts";
 
 declare const __VERSION__: string;
 const version = __VERSION__;
@@ -25,5 +26,11 @@ program
   .argument("<components...>", "Component names to add")
   .option("-o, --overwrite", "Overwrite existing files")
   .action(add);
+
+program
+  .command("theme")
+  .description("Sync theme CSS tokens to your project")
+  .option("--theme <preset>", "Switch theme: porcelain, tobacco, marigold, or eucalyptus")
+  .action(theme);
 
 program.parse();

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -4,6 +4,7 @@ import path from "path";
 export interface BeaketConfig {
   $schema?: string;
   components: string;
+  css?: string;
   theme?: string;
 }
 

--- a/packages/cli/src/utils/theme.test.ts
+++ b/packages/cli/src/utils/theme.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from "vitest";
+import { extractThemeBlock, replaceThemeInCss, wrapThemeCss } from "./theme.ts";
+
+const THEME_START = "/* beaket:theme:start */";
+const THEME_END = "/* beaket:theme:end */";
+
+// Realistic theme sample with @keyframes (legacy end detection depends on this)
+const sampleTheme = `/*
+ * Beaket UI Design System - Porcelain Theme
+ */
+
+@theme {
+  --color-ink: #080b10;
+  --color-paper: #ffffff;
+}
+
+@keyframes navigation-progress {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
+}
+`;
+
+const updatedTheme = `/*
+ * Beaket UI Design System - Porcelain Theme
+ */
+
+@theme {
+  --color-ink: #0a0d12;
+  --color-paper: #fefefe;
+}
+
+@keyframes navigation-progress {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
+}
+`;
+
+// Realistic multi-block theme matching actual file structure:
+// @theme with navigation-progress property, @media dark mode, @keyframes
+const realisticTheme = `/*
+ * Beaket UI Design System - Porcelain Theme
+ */
+
+@theme {
+  --color-ink: #080b10;
+  --color-paper: #ffffff;
+  --animate-navigation-progress: navigation-progress 1s ease-in-out infinite;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-ink: #dce0e6;
+    --color-paper: #06080c;
+  }
+}
+
+@keyframes navigation-progress {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
+}
+`;
+
+const realisticUpdated = `/*
+ * Beaket UI Design System - Porcelain Theme
+ */
+
+@theme {
+  --color-ink: #0a0d12;
+  --color-paper: #fefefe;
+  --animate-navigation-progress: navigation-progress 1s ease-in-out infinite;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color-ink: #e0e4ea;
+    --color-paper: #080a10;
+  }
+}
+
+@keyframes navigation-progress {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
+}
+`;
+
+describe("wrapThemeCss", () => {
+  it("wraps CSS with start/end markers", () => {
+    const result = wrapThemeCss(sampleTheme);
+    expect(result).toContain(THEME_START);
+    expect(result).toContain(THEME_END);
+    expect(result.indexOf(THEME_START)).toBeLessThan(result.indexOf("@theme"));
+    expect(result.indexOf("@theme")).toBeLessThan(result.indexOf(THEME_END));
+  });
+});
+
+describe("replaceThemeInCss", () => {
+  it("replaces marker-wrapped theme block", () => {
+    const existing = `@import "tailwindcss";\n\n${THEME_START}\n${sampleTheme}${THEME_END}\n`;
+
+    const { css, replaced } = replaceThemeInCss(existing, updatedTheme);
+
+    expect(replaced).toBe(true);
+    expect(css).toContain("--color-ink: #0a0d12");
+    expect(css).not.toContain("--color-ink: #080b10");
+    expect(css).toContain('@import "tailwindcss"');
+    expect(css).toContain(THEME_START);
+    expect(css).toContain(THEME_END);
+  });
+
+  it("replaces legacy theme (no markers)", () => {
+    const existing = `@import "tailwindcss";\n\n${sampleTheme}`;
+
+    const { css, replaced } = replaceThemeInCss(existing, updatedTheme);
+
+    expect(replaced).toBe(true);
+    expect(css).toContain("--color-ink: #0a0d12");
+    expect(css).not.toContain("--color-ink: #080b10");
+    expect(css).toContain('@import "tailwindcss"');
+    expect(css).toContain(THEME_START);
+    expect(css).toContain(THEME_END);
+  });
+
+  it("preserves content after legacy theme block", () => {
+    const existing = `@import "tailwindcss";\n\n${sampleTheme}\n.custom { color: red; }\n`;
+
+    const { css, replaced } = replaceThemeInCss(existing, updatedTheme);
+
+    expect(replaced).toBe(true);
+    expect(css).toContain("--color-ink: #0a0d12");
+    expect(css).not.toContain("--color-ink: #080b10");
+    expect(css).toContain(".custom { color: red; }");
+  });
+
+  it("appends theme when none exists", () => {
+    const existing = '@import "tailwindcss";\n\nbody { margin: 0; }\n';
+
+    const { css, replaced } = replaceThemeInCss(existing, sampleTheme);
+
+    expect(replaced).toBe(false);
+    expect(css).toContain("body { margin: 0; }");
+    expect(css).toContain("--color-ink: #080b10");
+    expect(css).toContain(THEME_START);
+    expect(css).toContain(THEME_END);
+  });
+
+  it("preserves content after marker-wrapped block", () => {
+    const existing = `@import "tailwindcss";\n\n${THEME_START}\n${sampleTheme}${THEME_END}\n\n.custom { color: red; }\n`;
+
+    const { css, replaced } = replaceThemeInCss(existing, updatedTheme);
+
+    expect(replaced).toBe(true);
+    expect(css).toContain(".custom { color: red; }");
+    expect(css).toContain("--color-ink: #0a0d12");
+  });
+
+  it("preserves content before theme block", () => {
+    const existing = `@import "tailwindcss";\n\n@layer base {\n  html { font-size: 16px; }\n}\n\n${THEME_START}\n${sampleTheme}${THEME_END}\n`;
+
+    const { css, replaced } = replaceThemeInCss(existing, updatedTheme);
+
+    expect(replaced).toBe(true);
+    expect(css).toContain("font-size: 16px");
+    expect(css).toContain("--color-ink: #0a0d12");
+  });
+
+  it("handles reversed markers gracefully (treats as no markers)", () => {
+    const existing = `@import "tailwindcss";\n\n${THEME_END}\nstuff\n${THEME_START}\n`;
+
+    const { css, replaced } = replaceThemeInCss(existing, sampleTheme);
+
+    // Should treat as no existing theme and append
+    expect(replaced).toBe(false);
+    expect(css).toContain("--color-ink: #080b10");
+  });
+
+  it("replaces realistic legacy theme with @theme, @media, and @keyframes", () => {
+    const existing = `@import "tailwindcss";\n\n${realisticTheme}`;
+
+    const { css, replaced } = replaceThemeInCss(existing, realisticUpdated);
+
+    expect(replaced).toBe(true);
+    expect(css).toContain("--color-ink: #0a0d12");
+    expect(css).not.toContain("--color-ink: #080b10");
+    expect(css).toContain(THEME_START);
+    expect(css).toContain(THEME_END);
+  });
+
+  it("preserves user CSS after realistic legacy theme", () => {
+    const existing = `@import "tailwindcss";\n\n${realisticTheme}\n.my-app { padding: 1rem; }\n`;
+
+    const { css, replaced } = replaceThemeInCss(existing, realisticUpdated);
+
+    expect(replaced).toBe(true);
+    expect(css).toContain("--color-ink: #0a0d12");
+    expect(css).not.toContain("--color-ink: #080b10");
+    expect(css).toContain(".my-app { padding: 1rem; }");
+    // @keyframes should be inside markers, not orphaned
+    expect(css).toContain("@keyframes navigation-progress");
+  });
+});
+
+describe("extractThemeBlock", () => {
+  it("extracts from marker-wrapped block", () => {
+    const cssContent = `@import "tailwindcss";\n\n${THEME_START}\n${sampleTheme}${THEME_END}\n`;
+
+    const result = extractThemeBlock(cssContent);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain("--color-ink: #080b10");
+  });
+
+  it("extracts from legacy block without trailing content", () => {
+    const cssContent = `@import "tailwindcss";\n\n${sampleTheme}`;
+
+    const result = extractThemeBlock(cssContent);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain("Beaket UI Design System");
+    expect(result).toContain("--color-ink: #080b10");
+  });
+
+  it("extracts from legacy block and excludes trailing content", () => {
+    const cssContent = `@import "tailwindcss";\n\n${sampleTheme}\n.custom { color: red; }\n`;
+
+    const result = extractThemeBlock(cssContent);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain("--color-ink: #080b10");
+    expect(result).not.toContain(".custom");
+  });
+
+  it("returns null when no theme exists", () => {
+    const cssContent = '@import "tailwindcss";\n\nbody { margin: 0; }\n';
+
+    const result = extractThemeBlock(cssContent);
+
+    expect(result).toBeNull();
+  });
+
+  it("handles reversed markers gracefully", () => {
+    const cssContent = `${THEME_END}\nstuff\n${THEME_START}\n`;
+
+    const result = extractThemeBlock(cssContent);
+
+    expect(result).toBeNull();
+  });
+
+  it("extracts realistic legacy block and excludes trailing content", () => {
+    const cssContent = `@import "tailwindcss";\n\n${realisticTheme}\n.my-app { padding: 1rem; }\n`;
+
+    const result = extractThemeBlock(cssContent);
+
+    expect(result).not.toBeNull();
+    expect(result).toContain("--color-ink: #080b10");
+    expect(result).toContain("@keyframes navigation-progress");
+    expect(result).not.toContain(".my-app");
+  });
+});

--- a/packages/cli/src/utils/theme.ts
+++ b/packages/cli/src/utils/theme.ts
@@ -1,0 +1,178 @@
+import fs from "fs-extra";
+import path from "path";
+import pc from "picocolors";
+import prompts from "prompts";
+import type { BeaketConfig } from "./config.ts";
+
+const THEME_START = "/* beaket:theme:start */";
+const THEME_END = "/* beaket:theme:end */";
+const LEGACY_MARKER = "Beaket UI Design System";
+// All theme files end with the navigation-progress keyframe declaration
+const LEGACY_END_MARKER = "@keyframes navigation-progress";
+
+export function wrapThemeCss(css: string): string {
+  return `${THEME_START}\n${css}${THEME_END}\n`;
+}
+
+/**
+ * Find the end of a legacy theme block (no markers).
+ * Themes end with `@keyframes navigation-progress { ... }`.
+ * Returns the index just past the closing `}\n`, or -1 if not found.
+ */
+function findLegacyBlockEnd(css: string, searchFrom: number): number {
+  const keyframeIdx = css.indexOf(LEGACY_END_MARKER, searchFrom);
+  if (keyframeIdx === -1) {
+    // No keyframe found — fall back to end of file
+    return css.length;
+  }
+  // Find the closing `}` of the @keyframes block after the marker
+  let depth = 0;
+  let inBlock = false;
+  for (let i = keyframeIdx; i < css.length; i++) {
+    if (css[i] === "{") {
+      depth++;
+      inBlock = true;
+    } else if (css[i] === "}") {
+      depth--;
+      if (inBlock && depth === 0) {
+        // Skip trailing newline if present
+        const end = css[i + 1] === "\n" ? i + 2 : i + 1;
+        return end;
+      }
+    }
+  }
+  return css.length;
+}
+
+export function replaceThemeInCss(
+  existingCss: string,
+  newThemeCss: string,
+): { css: string; replaced: boolean } {
+  const wrapped = wrapThemeCss(newThemeCss);
+
+  // Try marker-based replacement first
+  const startIdx = existingCss.indexOf(THEME_START);
+  const endIdx = existingCss.indexOf(THEME_END);
+
+  if (startIdx !== -1 && endIdx !== -1 && startIdx < endIdx) {
+    const before = existingCss.substring(0, startIdx);
+    const afterEnd = endIdx + THEME_END.length;
+    // Skip trailing newline after end marker
+    const after =
+      existingCss[afterEnd] === "\n"
+        ? existingCss.substring(afterEnd + 1)
+        : existingCss.substring(afterEnd);
+    return { css: before + wrapped + after, replaced: true };
+  }
+
+  // Try legacy marker (comment containing "Beaket UI Design System")
+  const legacyIdx = existingCss.indexOf(LEGACY_MARKER);
+  if (legacyIdx !== -1) {
+    const commentStart = existingCss.lastIndexOf("/*", legacyIdx);
+    if (commentStart !== -1) {
+      const blockEnd = findLegacyBlockEnd(existingCss, commentStart);
+      // Find preceding newline to avoid leaving a trailing blank line
+      let cutPoint = commentStart;
+      if (commentStart > 0 && existingCss[commentStart - 1] === "\n") {
+        cutPoint = commentStart - 1;
+      }
+      const before = existingCss.substring(0, cutPoint);
+      const after = existingCss.substring(blockEnd);
+      return { css: before + "\n" + wrapped + after, replaced: true };
+    }
+  }
+
+  // No existing theme — append
+  const separator = existingCss.endsWith("\n") ? "\n" : "\n\n";
+  return { css: existingCss + separator + wrapped, replaced: false };
+}
+
+export function extractThemeBlock(cssContent: string): string | null {
+  const startIdx = cssContent.indexOf(THEME_START);
+  const endIdx = cssContent.indexOf(THEME_END);
+
+  if (startIdx !== -1 && endIdx !== -1 && startIdx < endIdx) {
+    const contentStart = startIdx + THEME_START.length;
+    // Skip leading newline after start marker
+    const adjustedStart = cssContent[contentStart] === "\n" ? contentStart + 1 : contentStart;
+    return cssContent.substring(adjustedStart, endIdx);
+  }
+
+  const legacyIdx = cssContent.indexOf(LEGACY_MARKER);
+  if (legacyIdx !== -1) {
+    const commentStart = cssContent.lastIndexOf("/*", legacyIdx);
+    if (commentStart !== -1) {
+      const blockEnd = findLegacyBlockEnd(cssContent, commentStart);
+      return cssContent.substring(commentStart, blockEnd);
+    }
+  }
+
+  return null;
+}
+
+interface SyncThemeOptions {
+  overwrite?: boolean;
+}
+
+export async function syncTheme(
+  config: BeaketConfig,
+  themeCssMap: Record<string, string>,
+  options: SyncThemeOptions = {},
+): Promise<boolean> {
+  const themeName = config.theme || "porcelain";
+  const themeCss = themeCssMap[themeName];
+
+  if (!themeCss) {
+    console.log(pc.yellow("!"), `Unknown theme "${themeName}". Skipping theme sync.`);
+    return false;
+  }
+
+  if (!config.css) {
+    console.log(pc.yellow("!"), "No CSS path in config. Skipping theme sync.");
+    console.log("  Run", pc.cyan("npx @beaket/ui init"), "to set CSS path.");
+    return false;
+  }
+
+  const cssPath = path.join(process.cwd(), config.css);
+
+  if (!(await fs.pathExists(cssPath))) {
+    console.log(pc.yellow("!"), `CSS file not found: ${config.css}. Skipping theme sync.`);
+    return false;
+  }
+
+  const existingCss = await fs.readFile(cssPath, "utf-8");
+  const existingTheme = extractThemeBlock(existingCss);
+
+  // Check if theme is already up to date
+  if (existingTheme !== null && existingTheme.trim() === themeCss.trim()) {
+    console.log(pc.green("✔"), "Theme tokens are up to date.");
+    return false;
+  }
+
+  if (existingTheme === null) {
+    // No theme block found — always inject
+    const { css } = replaceThemeInCss(existingCss, themeCss);
+    await fs.writeFile(cssPath, css);
+    console.log(pc.green("✔"), `Added ${themeName} theme tokens to ${config.css}`);
+    return true;
+  }
+
+  // Theme exists but is outdated
+  if (!options.overwrite) {
+    const { confirm } = await prompts({
+      type: "confirm",
+      name: "confirm",
+      message: `Theme tokens in ${config.css} are outdated. Update to latest ${themeName}?`,
+      initial: true,
+    });
+    if (!confirm) {
+      console.log(pc.yellow("ℹ"), "Skipped theme update.");
+      return false;
+    }
+  }
+
+  const { css } = replaceThemeInCss(existingCss, themeCss);
+  await fs.writeFile(cssPath, css);
+  console.log(pc.green("✔"), `Updated ${themeName} theme tokens in ${config.css}`);
+  return true;
+}

--- a/packages/cli/src/utils/themes.ts
+++ b/packages/cli/src/utils/themes.ts
@@ -1,0 +1,13 @@
+import CSS_EUCALYPTUS from "../../../../src/themes/eucalyptus.css";
+import CSS_MARIGOLD from "../../../../src/themes/marigold.css";
+import CSS_PORCELAIN from "../../../../src/themes/porcelain.css";
+import CSS_TOBACCO from "../../../../src/themes/tobacco.css";
+
+export const THEME_CSS: Record<string, string> = {
+  porcelain: CSS_PORCELAIN,
+  tobacco: CSS_TOBACCO,
+  marigold: CSS_MARIGOLD,
+  eucalyptus: CSS_EUCALYPTUS,
+};
+
+export const VALID_THEMES = Object.keys(THEME_CSS);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,13 @@ export default defineConfig({
           setupFiles: [".storybook/vitest.setup.ts"],
         },
       },
+      {
+        test: {
+          name: "cli",
+          include: ["packages/cli/src/**/*.test.ts"],
+          environment: "node",
+        },
+      },
     ],
   },
 });


### PR DESCRIPTION
## Summary
- `add` command now syncs theme CSS tokens after component install (auto with `-o`, prompts otherwise)
- New `npx @beaket/ui theme` command for standalone theme sync and `--theme` switching
- `init` now persists `css` path to `beaket.ui.json` and wraps injected CSS with `beaket:theme:start/end` markers
- Legacy (pre-marker) consumer CSS files are detected and migrated without data loss

Closes #301

## Test plan
- [x] 16 unit tests covering marker replacement, legacy migration, trailing content preservation, reversed markers, realistic multi-block themes
- [x] E2E verified: init → stale tokens → theme sync → restored values
- [x] E2E verified: legacy project (no markers) with user CSS after theme → content preserved
- [x] E2E verified: theme switching (`--theme tobacco`)
- [x] E2E verified: idempotent ("up to date" on re-run)
- [x] typecheck + build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)