### PR TITLE
Add resizable prop to Textarea for manual height control

### DIFF
--- a/.changeset/textarea-resizable.md
+++ b/.changeset/textarea-resizable.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": minor
+---
+
+Add `resizable` prop to `Textarea` so it can auto-grow with content while also letting the user drag the handle to make it taller. The manually dragged height becomes a floor — content can still push it larger but won't shrink it below the user's chosen size. Closes #332.

--- a/src/components/textarea.stories.tsx
+++ b/src/components/textarea.stories.tsx
@@ -77,6 +77,15 @@ export const AutoResize: Story = {
         />
       </div>
       <div className="space-y-1.5">
+        <Label htmlFor="textarea-resizable">Auto Resize + Manual (resizable)</Label>
+        <Textarea
+          id="textarea-resizable"
+          resizable
+          placeholder="Grows with content — drag the handle to make it taller."
+          defaultValue={"Line 1\nLine 2"}
+        />
+      </div>
+      <div className="space-y-1.5">
         <Label htmlFor="textarea-fixed">Fixed Height (autoResize=false)</Label>
         <Textarea
           id="textarea-fixed"
@@ -108,6 +117,17 @@ export const InteractionTest: Story = {
           data-testid="basic-textarea"
         />
       </div>
+      <div>
+        <Label htmlFor="test-resizable-textarea" className="sr-only">
+          Resizable textarea
+        </Label>
+        <Textarea
+          id="test-resizable-textarea"
+          resizable
+          placeholder="Resizable"
+          data-testid="resizable-textarea"
+        />
+      </div>
     </div>
   ),
   play: async ({ args, canvasElement }) => {
@@ -117,5 +137,10 @@ export const InteractionTest: Story = {
     await userEvent.type(basicTextarea, "Hello\nWorld");
     await expect(args.onChange).toHaveBeenCalled();
     await expect(basicTextarea).toHaveValue("Hello\nWorld");
+
+    const resizableTextarea = canvas.getByTestId("resizable-textarea") as HTMLTextAreaElement;
+    await expect(resizableTextarea).toHaveClass("resize-y");
+    await userEvent.type(resizableTextarea, "A\nB\nC");
+    await expect(resizableTextarea).toHaveValue("A\nB\nC");
   },
 };

--- a/src/components/textarea.tsx
+++ b/src/components/textarea.tsx
@@ -14,9 +14,24 @@ interface Props extends React.ComponentProps<"textarea"> {
    * @default true
    */
   autoResize?: boolean;
+  /**
+   * Allow the user to manually resize the textarea vertically. When combined with
+   * `autoResize`, the textarea still grows with content but the user can drag it
+   * taller — the manual height becomes a floor that content can only exceed.
+   * @default false
+   */
+  resizable?: boolean;
 }
 
-export function Textarea({ className, autoResize = true, onInput, ref, ...props }: Props) {
+export function Textarea({
+  className,
+  autoResize = true,
+  resizable = false,
+  onInput,
+  onPointerUp,
+  ref,
+  ...props
+}: Props) {
   const internalRef = useRef<HTMLTextAreaElement>(null);
   const externalRef = useRef(ref);
   externalRef.current = ref;
@@ -28,17 +43,39 @@ export function Textarea({ className, autoResize = true, onInput, ref, ...props 
     else if (extRef) extRef.current = node;
   }, []);
 
+  const userHeightRef = useRef<number | null>(null);
+  const lastAppliedHeightRef = useRef<number | null>(null);
+
   const adjustHeight = useCallback(() => {
     const textarea = internalRef.current;
     if (!textarea || !autoResize) return;
 
     textarea.style.height = "auto";
-    textarea.style.height = `${textarea.scrollHeight}px`;
+    const contentHeight = textarea.scrollHeight;
+    const floor = userHeightRef.current ?? 0;
+    const next = Math.max(contentHeight, floor);
+    textarea.style.height = `${next}px`;
+    lastAppliedHeightRef.current = next;
   }, [autoResize]);
 
   useEffect(() => {
     adjustHeight();
   }, [adjustHeight, props.value, props.defaultValue]);
+
+  const handlePointerUp = useCallback(
+    (e: React.PointerEvent<HTMLTextAreaElement>) => {
+      onPointerUp?.(e);
+      if (!autoResize || !resizable) return;
+      const textarea = internalRef.current;
+      if (!textarea) return;
+      const current = textarea.offsetHeight;
+      if (lastAppliedHeightRef.current !== null && current !== lastAppliedHeightRef.current) {
+        userHeightRef.current = current;
+        adjustHeight();
+      }
+    },
+    [autoResize, resizable, onPointerUp, adjustHeight],
+  );
 
   return (
     <textarea
@@ -51,13 +88,16 @@ export function Textarea({ className, autoResize = true, onInput, ref, ...props 
         "disabled:border-chrome disabled:bg-frost disabled:text-steel disabled:cursor-not-allowed disabled:border-dashed",
         "read-only:bg-frost read-only:cursor-default",
         "aria-[invalid=true]:border-signal-red aria-[invalid=true]:focus-visible:outline-signal-red",
-        autoResize && "resize-none overflow-hidden",
+        autoResize && !resizable && "resize-none overflow-hidden",
+        autoResize && resizable && "resize-y overflow-hidden",
+        !autoResize && resizable && "resize-y",
         className,
       )}
       onInput={(e) => {
         adjustHeight();
         onInput?.(e);
       }}
+      onPointerUp={handlePointerUp}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary
Adds a new `resizable` prop to the `Textarea` component that allows users to manually resize the textarea vertically while maintaining auto-resize functionality. When combined with `autoResize`, the textarea grows with content but users can drag the handle to set a minimum height that content can exceed.

## Key Changes
- Added `resizable` prop (default: `false`) to the Textarea component interface
- Implemented height tracking with `userHeightRef` to store manually set heights and `lastAppliedHeightRef` to track the last auto-applied height
- Updated `adjustHeight()` logic to respect user-set heights as a floor — content can push the textarea taller but won't shrink below the user's chosen size
- Added `handlePointerUp` callback to detect when the user finishes dragging the resize handle and update the height floor accordingly
- Updated Tailwind class logic to conditionally apply `resize-none`, `resize-y`, or allow default resizing based on `autoResize` and `resizable` prop combinations
- Added story examples demonstrating the new resizable behavior
- Added interaction tests to verify the resizable textarea functionality

## Implementation Details
- The solution uses `onPointerUp` to detect resize completion by comparing `offsetHeight` against the last applied height
- When `autoResize` and `resizable` are both true, the textarea applies `resize-y overflow-hidden` classes
- The height floor mechanism ensures that manually dragged heights persist and act as a minimum, while content-driven growth still works normally

https://claude.ai/code/session_01LpHcWzpQ6zPWr4u4qZZfux