### PR TITLE
fix(deps): bump fast-uri to >=3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,19 +55,6 @@
     "vite": "8.0.14",
     "vitest": "4.1.7"
   },
-  "pnpm": {
-    "overrides": {
-      "rollup": ">=4.59.0",
-      "minimatch": ">=10.2.3",
-      "svgo": ">=4.0.1",
-      "lodash": ">=4.17.23",
-      "ajv": ">=8.18.0",
-      "h3": ">=1.15.6",
-      "devalue": ">=5.6.4",
-      "brace-expansion": ">=5.0.5",
-      "yaml": ">=2.8.3"
-    }
-  },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   devalue: '>=5.6.4'
   brace-expansion: '>=5.0.5'
   yaml: '>=2.8.3'
+  fast-uri: '>=3.1.2'
 
 importers:
 
@@ -3291,8 +3292,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -7489,7 +7490,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -8021,7 +8022,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,15 @@ packages:
 onlyBuiltDependencies:
   - esbuild
   - sharp
+
+overrides:
+  rollup: ">=4.59.0"
+  minimatch: ">=10.2.3"
+  svgo: ">=4.0.1"
+  lodash: ">=4.17.23"
+  ajv: ">=8.18.0"
+  h3: ">=1.15.6"
+  devalue: ">=5.6.4"
+  brace-expansion: ">=5.0.5"
+  yaml: ">=2.8.3"
+  fast-uri: ">=3.1.2"


### PR DESCRIPTION
## Summary
- Adds `fast-uri: ">=3.1.2"` to pnpm overrides, resolving Dependabot alerts [#25](https://github.com/beaket/ui/security/dependabot/25) and [#26](https://github.com/beaket/ui/security/dependabot/26) (path traversal + host confusion, both high severity).
- Moves the existing `pnpm.overrides` block from `package.json` to `pnpm-workspace.yaml`. pnpm 10 ignores the old location and was warning on every install, meaning the prior security pins (rollup, ajv, h3, etc.) weren't actually being re-applied on fresh installs.

## Test plan
- [ ] CI install + typecheck green
- [ ] `grep fast-uri pnpm-lock.yaml` shows 3.1.2 only

🤖 Generated with [Claude Code](https://claude.com/claude-code)