### PR TITLE
chore(deps): update pnpm to v11 (+ workspace migration)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "author": "",
   "license": "MIT",
-  "packageManager": "pnpm@10.34.1",
+  "packageManager": "pnpm@11.4.0",
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.30.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,9 +2,7 @@ packages:
   - packages/*
   - docs
 
-onlyBuiltDependencies:
-  - esbuild
-  - sharp
+minimumReleaseAge: 0
 
 overrides:
   rollup: ">=4.59.0"
@@ -17,3 +15,7 @@ overrides:
   brace-expansion: ">=5.0.5"
   yaml: ">=2.8.3"
   fast-uri: ">=3.1.2"
+
+allowBuilds:
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
## Summary
- Bumps `packageManager` from `pnpm@10.34.1` to `pnpm@11.4.0` (supersedes #366, which was opened by Renovate before pnpm 11 config migrations were needed).
- Migrates `pnpm-workspace.yaml` for pnpm 11: replaces deprecated `onlyBuiltDependencies` with `allowBuilds` (esbuild, sharp).
- Sets `minimumReleaseAge: 0` to opt out of pnpm 11's new 24h supply-chain default, which otherwise blocks CI on any lockfile entry resolved within 24h of an upstream publish — a constant blocker for Renovate PRs.
- Regenerates `pnpm-lock.yaml` under pnpm 11.

## Why not just merge #366
Renovate's PR only bumped `packageManager` and left `pnpm.overrides` in `package.json` (since moved to `pnpm-workspace.yaml` on main) plus the now-deprecated `onlyBuiltDependencies`. CI failed on both the config drift and the new release-age policy.

## Test plan
- [x] `pnpm install` exits 0 locally on pnpm 11.4.0
- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (256/256)
- [ ] Confirm CI green
- [ ] Close #366 once this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)