### PR TITLE
fix(input): align Props type with ComponentProps<"input">

### DIFF
--- a/.changeset/input-component-props.md
+++ b/.changeset/input-component-props.md
@@ -1,0 +1,5 @@
+---
+"@beaket/ui": patch
+---
+
+Align `Input` props type with the rest of the library: extends `React.ComponentProps<"input">` instead of `React.InputHTMLAttributes<HTMLInputElement>`, matching `Textarea`. Removes redundant `className` and `ref` declarations (already inherited). No runtime behavior change. Closes #333.

--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -3,15 +3,11 @@ import { twMerge } from "tailwind-merge";
 
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
-export interface Props extends Omit<React.InputHTMLAttributes<HTMLInputElement>, "prefix"> {
-  /** Additional CSS classes to apply to the input */
-  className?: string;
+export interface Props extends Omit<React.ComponentProps<"input">, "prefix"> {
   /** Element to render before the input (e.g., icon) */
   prefix?: React.ReactNode;
   /** Element to render after the input (e.g., icon or button) */
   suffix?: React.ReactNode;
-  /** Ref forwarded to the underlying input element */
-  ref?: React.Ref<HTMLInputElement>;
 }
 
 const inputBaseStyles = [


### PR DESCRIPTION
## Summary
- Switches `Input` props from `React.InputHTMLAttributes<HTMLInputElement>` to `React.ComponentProps<"input">`, matching `Textarea`'s convention.
- Removes redundant `className` and `ref` declarations (already inherited from `ComponentProps`).
- No runtime change.

Closes #333.

## Test plan
- [x] `pnpm typecheck` passes
- [ ] Storybook still renders Input stories without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)