### PR TITLE
fix(docs): migrate from @tailwindcss/vite to @tailwindcss/postcss

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,6 +1,5 @@
 // @ts-check
 import react from "@astrojs/react";
-import tailwindcss from "@tailwindcss/vite";
 import { defineConfig } from "astro/config";
 import path from "path";
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
@@ -36,8 +35,6 @@ export default defineConfig({
     ],
   },
   vite: {
-    // @ts-expect-error - Vite version mismatch between root (7.x) and Astro (6.x)
-    plugins: [tailwindcss()],
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "../src"),

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@astrojs/react": "^5.0.1",
     "@radix-ui/react-slot": "^1.2.4",
-    "@tailwindcss/vite": "4.3.0",
+    "@tailwindcss/postcss": "4.3.0",
     "astro": "^6.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "2.1.1",

--- a/docs/postcss.config.mjs
+++ b/docs/postcss.config.mjs
@@ -1,0 +1,5 @@
+export default {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,9 +159,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.2.15)(react@19.2.6)
-      '@tailwindcss/vite':
+      '@tailwindcss/postcss':
         specifier: 4.3.0
-        version: 4.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.8.3))
+        version: 4.3.0
       astro:
         specifier: ^6.0.0
         version: 6.4.2(@types/node@25.9.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.8.3)
@@ -238,6 +238,10 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
 
   '@astrojs/check@0.9.9':
     resolution: {integrity: sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==}
@@ -2592,6 +2596,9 @@ packages:
   '@tailwindcss/oxide@4.3.0':
     resolution: {integrity: sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==}
     engines: {node: '>= 20'}
+
+  '@tailwindcss/postcss@4.3.0':
+    resolution: {integrity: sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==}
 
   '@tailwindcss/vite@4.3.0':
     resolution: {integrity: sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==}
@@ -5146,6 +5153,8 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
+  '@alloc/quick-lru@5.2.0': {}
+
   '@astrojs/check@0.9.9(prettier@3.8.3)(typescript@6.0.3)':
     dependencies:
       '@astrojs/language-server': 2.16.7(prettier@3.8.3)(typescript@6.0.3)
@@ -7166,6 +7175,14 @@ snapshots:
       '@tailwindcss/oxide-wasm32-wasi': 4.3.0
       '@tailwindcss/oxide-win32-arm64-msvc': 4.3.0
       '@tailwindcss/oxide-win32-x64-msvc': 4.3.0
+
+  '@tailwindcss/postcss@4.3.0':
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      '@tailwindcss/node': 4.3.0
+      '@tailwindcss/oxide': 4.3.0
+      postcss: 8.5.15
+      tailwindcss: 4.3.0
 
   '@tailwindcss/vite@4.3.0(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.8.3))':
     dependencies:


### PR DESCRIPTION
## Summary

- Docs build was failing in CI ([run 26612371754](https://github.com/beaket/ui/actions/runs/26612371754/job/78422665115)) with:
  ```
  [@tailwindcss/vite:generate:build] Missing field `tsconfigPaths` on BindingViteResolvePluginConfig.resolveOptions
  ```
- `@tailwindcss/vite` calls Vite's internal resolver via `createIdResolver` without passing `tsconfigPaths`. Astro 6's bundled rolldown-vite binding requires that field and aborts the build. Tracked upstream in [withastro/astro#16542](https://github.com/withastro/astro/issues/16542); the recommended workaround is to switch the docs over to `@tailwindcss/postcss` until `@tailwindcss/vite` supports rolldown-vite.
- This is scoped to the Astro docs site. Storybook (regular Vite) was unaffected and still uses `@tailwindcss/vite`.

### Changes

- `docs/package.json`: replace `@tailwindcss/vite` with `@tailwindcss/postcss`
- `docs/astro.config.mjs`: drop the `tailwindcss()` Vite plugin (and the obsolete `@ts-expect-error`)
- `docs/postcss.config.mjs`: new — registers `@tailwindcss/postcss`

No changeset: only affects the docs site build, not the published `@beaket/ui` package — consistent with prior `chore(deps)` commits (#406, #408).

## Test plan

- [x] `cd docs && pnpm build` — Astro build completes, 34 pages emitted
- [x] Compiled CSS contains theme utilities (`bg-paper`, `text-ink`, `border-chrome`, `bg-branch`)
- [x] `cd docs && pnpm dev` — dev server returns 200 with Tailwind utilities present
- [x] Root `pnpm build` (Storybook) still succeeds
- [x] `pnpm typecheck` clean across workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)