### PR TITLE
feat(paper): OS-driven dark mode (+ provenance fix)

### DIFF
--- a/.changeset/paper-dark-mode.md
+++ b/.changeset/paper-dark-mode.md
@@ -1,0 +1,9 @@
+---
+"@beaket/paper": minor
+---
+
+Add dark mode to `@beaket/paper`. The editor now follows the OS `prefers-color-scheme` automatically.
+
+- Previously, dark mode only flipped the porcelain-bridged tokens, but the editor pinned `--color-ink` and its editor-owned tokens (canvas, surface, code-syntax ramp, overlay shadow) to light values — so body text rendered dark on a dark surface and was unreadable.
+- Every token now carries a dark-aware default while keeping its `var()` chain intact, so `--beaket-paper-*` overrides and the porcelain `--color-*` bridge still win in both modes. Dark defaults mirror porcelain's dark block, with a GitHub Dark Default code-syntax ramp.
+- The dark tokens ship as a scoped stylesheet (CodeMirror's theme builder can't emit `@media` for the root selector); the task-list checkbox also gets a dark checkmark so it stays visible on the light checked fill.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true" # generate npm provenance attestations on publish
+          # Provenance is enabled via `provenance=true` in the repo-root .npmrc —
+          # pnpm ignores NPM_CONFIG_PROVENANCE, so do NOT re-add it here.
 
       - name: Create check run for Release PR
         if: steps.changesets.outputs.pullRequestNumber

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ dist
 
 # Environment
 .npmrc
+# but track the repo-root .npmrc (provenance=true); package/home ones stay ignored
+!/.npmrc
 .env
 
 # Astro

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,12 @@
+# Attach npm provenance attestations when publishing (OIDC trusted publishing).
+#
+# pnpm does NOT read the NPM_CONFIG_PROVENANCE env var — its publish config
+# (@pnpm/config.reader) only ingests URL-scoped `npm_config_//…` env vars, so a
+# bare scalar like NPM_CONFIG_PROVENANCE is dropped. The flag must come from this
+# rc file. This is why @beaket/paper@0.1.0 published over OIDC with no attestation.
+#
+# With `provenance=true`, pnpm's OIDC flow short-circuits the registry visibility
+# lookup (`if (options.provenance != null) …`) and always emits the sigstore
+# bundle. Applies repo-wide to every changeset-published package (@beaket/ui,
+# @beaket/paper) — both are public, both run with `id-token: write`.
+provenance=true

--- a/packages/paper/README.md
+++ b/packages/paper/README.md
@@ -106,8 +106,15 @@ fights:
 
 When rendered within `@beaket/ui`'s porcelain theme, the editor's tokens bridge to porcelain's
 `--color-*` variables automatically (the second tier of `var(--beaket-paper-X, var(--color-Y,
-default))`), so it matches the design system — including dark mode for the bridged tokens — with no
-setup.
+default))`), so it matches the design system — including dark mode — with no setup.
+
+### Dark mode
+
+Dark mode is built in and follows the OS `prefers-color-scheme` automatically — no class to toggle,
+no config. It works standalone (the package ships dark-aware defaults for every token, including the
+editor-owned canvas/surface and the code-syntax ramp) and inside porcelain (the `--color-*` bridge
+flows porcelain's dark block through). Your `--beaket-paper-*` overrides win in both modes; set them
+inside your own `@media (prefers-color-scheme: dark)` block to customize the dark palette.
 
 ### 3. Escape hatches (power users)
 

--- a/packages/paper/src/editor/createEditor.ts
+++ b/packages/paper/src/editor/createEditor.ts
@@ -23,7 +23,7 @@ import type { SlashItemsConfig } from "./extensions/slashCommand";
 import { slashCommand } from "./extensions/slashCommand";
 import { tableAutoConvert } from "./extensions/tableAutoConvert";
 import { tableWidget } from "./extensions/tableWidget";
-import { baseTheme } from "./theme";
+import { baseTheme, darkThemeStyle } from "./theme";
 export { defaultSlashItems } from "./extensions/slashCommand";
 export type { SlashItemsConfig, SlashItemSpec } from "./extensions/slashCommand";
 
@@ -70,6 +70,7 @@ export function editorExtensions(opts: EditorOptions = {}): Extension[] {
     keymap.of([...defaultKeymap, ...historyKeymap]),
     EditorView.lineWrapping,
     baseTheme,
+    darkThemeStyle(),
     markdownExtension(),
     inlineSyntaxHiding(),
     blockSyntaxHiding(),

--- a/packages/paper/src/editor/extensions/listRendering.ts
+++ b/packages/paper/src/editor/extensions/listRendering.ts
@@ -130,6 +130,9 @@ function computeDecorations(view: EditorView): DecorationSet {
 // A native input can't draw ::after, so appearance:none + SVG background stamps the check.
 const CHECK_MARK =
   "url(\"data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2016%2016'%20fill='none'%20stroke='%23ffffff'%20stroke-width='2.25'%3E%3Cpath%20d='M3.5%208.5l3%203%206-6'/%3E%3C/svg%3E\")";
+// Dark mode stamps onto a light --ink fill, so the white checkmark above would vanish; use a dark stroke instead.
+const CHECK_MARK_DARK =
+  "url(\"data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2016%2016'%20fill='none'%20stroke='%230d1117'%20stroke-width='2.25'%3E%3Cpath%20d='M3.5%208.5l3%203%206-6'/%3E%3C/svg%3E\")";
 
 export function listRendering(): Extension {
   return [
@@ -157,6 +160,12 @@ export function listRendering(): Extension {
       ".cm-task-checkbox:focus-visible": {
         outline: "2px solid var(--accent)",
         outlineOffset: "2px",
+      },
+      // Dark mode: --ink fills light, so the white checkmark would disappear — stamp a dark one instead.
+      "@media (prefers-color-scheme: dark)": {
+        ".cm-task-checkbox:checked": {
+          background: `var(--ink) ${CHECK_MARK_DARK} center / 11px no-repeat`,
+        },
       },
     }),
   ];

--- a/packages/paper/src/editor/theme.test.ts
+++ b/packages/paper/src/editor/theme.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { tokens } from "./theme";
+import { darkThemeCss, darkTokens, tokens } from "./theme";
 
 // Token reconciliation + public theming contract (ADR-0013 decision 6).
 //
@@ -69,5 +69,79 @@ describe("theme typography is variabilized (CJK-first defaults)", () => {
     expect(tokens["--font-size"]).toBe("var(--beaket-paper-font-size, 17px)");
     expect(tokens["--line-height"]).toBe("var(--beaket-paper-line-height, 1.75)");
     expect(tokens["--measure"]).toBe("var(--beaket-paper-measure, none)");
+  });
+});
+
+// Dark mode wiring (jsdom-safe: locks the var() chains, not rendered color — the rendered dark colors
+// are a browser/manual check, same carve-out as the light tokens above).
+describe("dark theme keeps the override + bridge chains, swapping only the built-in default", () => {
+  // Every color/shadow token a consumer can override stays publicly overridable in dark mode too.
+  const NON_PUBLIC = new Set(["--color-ink"]);
+  it("every dark token still reads a --beaket-paper-* override first", () => {
+    for (const [name, value] of Object.entries(darkTokens)) {
+      if (NON_PUBLIC.has(name)) continue;
+      expect(value, `${name} should read a --beaket-paper-* override first`).toMatch(
+        /^var\(--beaket-paper-[a-z-]+,/,
+      );
+    }
+  });
+
+  it("flips the locally-pinned ink to a dark-aware light value (no longer shadows the host with #232a35)", () => {
+    expect(tokens["--color-ink"]).toBe("#232a35");
+    expect(darkTokens["--color-ink"]).toBe("#e6eaee");
+    expect(darkTokens["--ink"]).toBe("var(--beaket-paper-ink, var(--color-ink, #e6eaee))");
+  });
+
+  it("preserves the porcelain bridge while swapping defaults to porcelain's dark block", () => {
+    expect(darkTokens["--paper"]).toBe("var(--beaket-paper-paper, var(--color-paper, #0d1117))");
+    expect(darkTokens["--frost"]).toBe("var(--beaket-paper-frost, var(--color-frost, #0e1016))");
+    expect(darkTokens["--chrome"]).toBe("var(--beaket-paper-chrome, var(--color-chrome, #2a303e))");
+    expect(darkTokens["--accent"]).toBe(
+      "var(--beaket-paper-accent, var(--color-signal-blue, #1a8ed8))",
+    );
+  });
+
+  it("swaps editor-owned canvas/surface and syntax to dark-aware defaults", () => {
+    expect(darkTokens["--canvas"]).toBe("var(--beaket-paper-canvas, #14171c)");
+    expect(darkTokens["--surface"]).toBe("var(--beaket-paper-surface, #1c1f27)");
+    expect(darkTokens["--syn-kw"]).toBe("var(--beaket-paper-syntax-keyword, #ff7b72)");
+  });
+
+  it("covers exactly the light tokens that don't bridge to porcelain's dark block", () => {
+    // Typography/measure carry no color, so they need no dark variant; everything else must.
+    const LIGHT_ONLY = new Set([
+      "--font",
+      "--font-size",
+      "--line-height",
+      "--measure",
+      // Derived at use time from --accent (which is dark here), so they follow without re-declaration.
+      "--accent-sel",
+      "--accent-weak",
+    ]);
+    const expected = Object.keys(tokens).filter((k) => !LIGHT_ONLY.has(k));
+    expect(Object.keys(darkTokens).sort()).toEqual(expected.sort());
+  });
+});
+
+// The dark block can't go through baseTheme (style-mod can't emit `@media { & { … } }` for the root —
+// nested `&` produces bare declarations under the at-rule), so it ships as a scoped stylesheet. This
+// locks the structure that makes it apply: an @media wrapper + a two-class root selector that outranks
+// baseTheme's single generated class without disturbing the var() override/bridge chains.
+describe("darkThemeCss emits a scoped prefers-color-scheme block", () => {
+  const css = darkThemeCss();
+
+  it("wraps the tokens in a prefers-color-scheme: dark media query", () => {
+    expect(css).toMatch(/^@media \(prefers-color-scheme: dark\)\{/);
+  });
+
+  it("scopes to .cm-editor + the beaket class (specificity 0,2,0 > baseTheme's 0,1,0)", () => {
+    expect(css).toContain(".cm-editor.cm-beaket-paper{");
+  });
+
+  it("contains every dark token declaration (including the readable light ink fix)", () => {
+    for (const [name, value] of Object.entries(darkTokens)) {
+      expect(css).toContain(`${name}: ${value};`);
+    }
+    expect(css).toContain("--ink: var(--beaket-paper-ink, var(--color-ink, #e6eaee));");
   });
 });

--- a/packages/paper/src/editor/theme.ts
+++ b/packages/paper/src/editor/theme.ts
@@ -1,4 +1,5 @@
-import { EditorView } from "@codemirror/view";
+import type { Extension } from "@codemirror/state";
+import { EditorView, ViewPlugin } from "@codemirror/view";
 
 // CJK tier-1 typography default. Japanese fonts are placed BEFORE Korean fonts (key): Apple SD
 // Gothic Neo includes kana/kanji glyphs, so if a Korean font came first, Japanese would render in
@@ -40,14 +41,14 @@ const DEFAULT_FONT_STACK = [
 //       (and inherits porcelain's dark-mode block)
 //    3) built-in default — keeps the package self-sufficient standalone.
 // ② Editor-owned → 2-tier: `var(--beaket-paper-X, default)` (no porcelain equivalent). These do
-//    NOT inherit porcelain's dark block — each needs a dark value when dark mode (deferred) lands.
+//    NOT inherit porcelain's dark block, so they carry their own dark default in `darkTokens` below.
 // ③ `--color-ink` is a deliberate local override of porcelain's harsh ink — documented divergence.
 //    accent-sel/weak are derived from `--accent`, so a consumer accent override flows into them.
 //    letter-spacing is intentionally NOT exposed (negative spacing breaks mixed CJK; CJK-first guard).
 // Exported for the token-wiring contract test (not part of the package's JS public surface).
 export const tokens = {
   // ③ Local override: porcelain --color-ink is #0a0d14 (≈18:1), too harsh on the near-white canvas
-  //    (ADR-0009). Pin it softer, locally to the editor. Needs a dark-aware value for dark mode.
+  //    (ADR-0009). Pin it softer, locally to the editor. Dark-aware counterpart in `darkTokens`.
   "--color-ink": "#232a35",
   // ① Porcelain-bridged colors (3-tier)
   "--ink": "var(--beaket-paper-ink, var(--color-ink, #232a35))",
@@ -85,6 +86,50 @@ export const tokens = {
   "--line-height": "var(--beaket-paper-line-height, 1.75)",
   // Opt-in readable measure (max line width). Default `none` = full width, unchanged behavior.
   "--measure": "var(--beaket-paper-measure, none)",
+};
+
+// Dark mode (ADR-0009 dark canvas). Same architecture as `tokens`: each entry keeps its var() chain
+// so the public `--beaket-paper-*` override and the porcelain `--color-*` bridge still win — ONLY the
+// built-in fallback default is swapped to a dark-aware value. That makes the package self-sufficient in
+// dark mode standalone, while still inheriting porcelain's dark block (or a host's dark `--color-*`)
+// when present. These values are emitted into the scoped `@media` stylesheet by `darkThemeStyle()`
+// below (it can't live in baseTheme — see that comment for why).
+//
+// `--color-ink`: in LIGHT we pin it softer than porcelain's harsh #0a0d14 (ADR-0009). In DARK porcelain's
+// ink (#e6eaee) is already soft, so the pin just carries a dark-aware value of its own — same role,
+// dark-aware. The PUBLIC `--beaket-paper-ink` still overrides first.
+//
+// Neutral scale + accent defaults mirror porcelain's dark block (so standalone == porcelain dark).
+// Code syntax swaps GitHub Light → GitHub Dark Default. Derived `--accent-sel`/`--accent-weak` are NOT
+// re-declared: they read `var(--accent)` at use time, which is the dark accent here, so they follow.
+export const darkTokens = {
+  // ③ Local override, dark-aware (no longer shadows the host with a light value in dark mode).
+  "--color-ink": "#e6eaee",
+  // ① Porcelain-bridged colors (3-tier), dark defaults mirror porcelain's dark block
+  "--ink": "var(--beaket-paper-ink, var(--color-ink, #e6eaee))",
+  "--paper": "var(--beaket-paper-paper, var(--color-paper, #0d1117))",
+  "--frost": "var(--beaket-paper-frost, var(--color-frost, #0e1016))",
+  "--accent": "var(--beaket-paper-accent, var(--color-signal-blue, #1a8ed8))",
+  "--shadow-overlay": "var(--beaket-paper-shadow, var(--shadow-offset, 1px 1px 0 0 #000000))",
+  // ① Porcelain-bridged neutral scale (dark, inverted ramp — values verified identical to porcelain.css)
+  "--platinum": "var(--beaket-paper-platinum, var(--color-platinum, #161a22))",
+  "--silver": "var(--beaket-paper-silver, var(--color-silver, #1e242e))",
+  "--chrome": "var(--beaket-paper-chrome, var(--color-chrome, #2a303e))",
+  "--aluminum": "var(--beaket-paper-aluminum, var(--color-aluminum, #3e4454))",
+  "--muted": "var(--beaket-paper-muted, var(--color-muted, #586070))",
+  "--steel": "var(--beaket-paper-steel, var(--color-steel, #6c7486))",
+  "--slate": "var(--beaket-paper-slate, var(--color-slate, #9ca4b2))",
+  // ② Editor-owned colors (2-tier; no porcelain equivalent). Cool near-black writing canvas + raised fill.
+  "--canvas": "var(--beaket-paper-canvas, #14171c)",
+  "--surface": "var(--beaket-paper-surface, #1c1f27)",
+  // ② Editor-owned code syntax — GitHub Dark Default (mirrors the GitHub Light ramp above)
+  "--syn-kw": "var(--beaket-paper-syntax-keyword, #ff7b72)",
+  "--syn-str": "var(--beaket-paper-syntax-string, #a5d6ff)",
+  "--syn-num": "var(--beaket-paper-syntax-number, #79c0ff)",
+  "--syn-fn": "var(--beaket-paper-syntax-function, #d2a8ff)",
+  "--syn-type": "var(--beaket-paper-syntax-type, #ffa657)",
+  "--syn-cmt": "var(--beaket-paper-syntax-comment, #8b949e)",
+  "--syn-tag": "var(--beaket-paper-syntax-tag, #7ee787)",
 };
 
 export const baseTheme = EditorView.theme({
@@ -125,3 +170,46 @@ export const baseTheme = EditorView.theme({
     backgroundColor: "var(--accent-sel)",
   },
 });
+
+// Dark mode can't be expressed through baseTheme: CodeMirror's theme builder (style-mod) maps the
+// editor root to `&`, but a nested `&` inside an `@media` block hits style-mod's selector-replacement
+// path and emits bare declarations directly under the at-rule (invalid CSS the browser discards). So
+// the dark token block is shipped as a separate, scoped stylesheet injected by `darkThemeStyle()`.
+//
+// Scoping: `EditorView.editorAttributes` stamps DARK_SCOPE_CLASS on the editor root, and the stylesheet
+// targets `.cm-editor.<scope>`. Two classes = specificity (0,2,0), which outranks baseTheme's single
+// generated class (0,1,0) — so in dark mode these tokens win regardless of source order, while the
+// `--beaket-paper-*` override and `--color-*` porcelain bridge inside each var() chain still apply.
+const DARK_SCOPE_CLASS = "cm-beaket-paper";
+const DARK_STYLE_ID = "beaket-paper-dark-tokens";
+
+/** Serializes `darkTokens` into the scoped dark-mode stylesheet text. Exported for the wiring test. */
+export function darkThemeCss(): string {
+  const decls = Object.entries(darkTokens)
+    .map(([name, value]) => `${name}: ${value};`)
+    .join(" ");
+  return `@media (prefers-color-scheme: dark){.cm-editor.${DARK_SCOPE_CLASS}{${decls}}}`;
+}
+
+/**
+ * Dark mode. Stamps the scope class on the editor and injects the dark token stylesheet once per
+ * document/shadow root (idempotent by id). Self-contained — the consumer flips automatically with the
+ * OS color scheme; `--beaket-paper-*` overrides and the porcelain bridge keep working in both modes.
+ */
+export function darkThemeStyle(): Extension {
+  return [
+    EditorView.editorAttributes.of({ class: DARK_SCOPE_CLASS }),
+    ViewPlugin.define((view) => {
+      const root = view.dom.getRootNode() as Document | ShadowRoot;
+      const host: ParentNode & Node =
+        root instanceof ShadowRoot ? root : ((root as Document).head ?? document.head);
+      if (!host.querySelector(`#${DARK_STYLE_ID}`)) {
+        const style = (root.ownerDocument ?? document).createElement("style");
+        style.id = DARK_STYLE_ID;
+        style.textContent = darkThemeCss();
+        host.appendChild(style);
+      }
+      return {};
+    }),
+  ];
+}


### PR DESCRIPTION
## Summary

`@beaket/paper` now follows the OS `prefers-color-scheme` automatically. Previously the editor was unreadable in dark mode: it pinned `--color-ink` and its editor-owned tokens (canvas, surface, code-syntax ramp, overlay shadow) to **light** values directly on `.cm-editor`, so when the host bridged `--paper` dark, body text rendered dark-on-dark.

This PR also carries the pending npm **provenance** fix so the next release (0.2.0) ships with both.

## Dark mode

- **`darkTokens`** mirrors `tokens` but swaps each `var()` chain's final fallback to a dark-aware default (porcelain-dark neutrals + GitHub Dark Default syntax). The `--beaket-paper-*` override and `--color-*` porcelain bridge still win in both modes.
- Shipped as a **scoped stylesheet** via `darkThemeStyle()`. It can't live in `baseTheme`: CodeMirror's theme builder (style-mod) maps the editor root to `&`, and a nested `&` inside `@media` hits style-mod's selector-replace path → emits bare declarations under the at-rule → the browser discards them. The sheet targets `.cm-editor.cm-beaket-paper` (specificity `0,2,0` beats baseTheme's `0,1,0`, so it's order-independent).
- Task-list checkbox gets a dark checkmark so it stays visible on the light checked fill.

## Provenance fix (`.npmrc` `provenance=true`)

pnpm ignores the `NPM_CONFIG_PROVENANCE` env, and auto-detect is skipped on a first-ever publish — so `0.1.0` published without an attestation. Setting `provenance=true` in the repo-root `.npmrc` is pnpm's recognized rcOption and makes the sigstore bundle always emit. Attestation will attach on the next release.

## Verification

Browser-tested in **real OS dark mode** (not simulated):
- Body text contrast **14.7:1** (WCAG AAA is 7:1)
- Table, slash menu (overlay), checkbox, inline code, and CJK (한국어/日本語/English) all legible
- Porcelain bridge confirmed: `--paper` resolved to the host's `#16181c`, not the standalone default
- 216 tests pass, `tsc --noEmit` clean, build succeeds

Light mode is byte-identical to before: every addition is gated behind `@media (prefers-color-scheme: dark)` or referenced only by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)