### PR TITLE
Rename Paper React component from BeaketPaper to Paper

### DIFF
--- a/.changeset/paper-rename-component.md
+++ b/.changeset/paper-rename-component.md
@@ -1,0 +1,14 @@
+---
+"@beaket/paper": minor
+---
+
+Rename the React component from `BeaketPaper` to `Paper` (and its types `BeaketPaperHandle` → `PaperHandle`, `BeaketPaperProps` → `PaperProps`). The package scope (`@beaket/paper`) already namespaces the export, so the prefix was redundant.
+
+**Breaking:** update imports from `@beaket/paper/react`:
+
+```diff
+-import { BeaketPaper, type BeaketPaperHandle } from "@beaket/paper/react";
++import { Paper, type PaperHandle } from "@beaket/paper/react";
+```
+
+If `Paper` collides with another import in your code, alias it: `import { Paper as BeaketPaper } from "@beaket/paper/react"`.

--- a/packages/paper/README.md
+++ b/packages/paper/README.md
@@ -24,13 +24,13 @@ npm install react react-dom
 ### React
 
 ```tsx
-import { BeaketPaper, type BeaketPaperHandle } from "@beaket/paper/react";
+import { Paper, type PaperHandle } from "@beaket/paper/react";
 import { useRef } from "react";
 
 function Editor() {
-  const ref = useRef<BeaketPaperHandle>(null);
+  const ref = useRef<PaperHandle>(null);
   return (
-    <BeaketPaper
+    <Paper
       ref={ref}
       defaultValue="# Hello\n\nStart writing…"
       onChange={(markdown) => console.log(markdown)}
@@ -44,6 +44,8 @@ The editor is uncontrolled: pass `defaultValue` for the initial document and cal
 on user edits only (it is IME-guarded, and `setValue` does not echo back through it). For anything
 the curated handle does not expose, `ref.current.getView()` returns the underlying CodeMirror
 `EditorView`.
+
+If `Paper` collides with another import in your code, alias it: `import { Paper as BeaketPaper } from "@beaket/paper/react"`.
 
 ### Framework-agnostic core
 

--- a/packages/paper/docs/DECISIONS.md
+++ b/packages/paper/docs/DECISIONS.md
@@ -42,7 +42,7 @@ migration (2026-06-17); only the decisions that constrain future work are kept h
   _ingestion_ is delegated to the consumer (`onInsertImage`). Slash items are a declarative consumer
   contract with a transformer override; privileged built-ins are kept separate.
 - **Package shape.** Two layers: a framework-agnostic **core** (`createEditor`, zero React) plus a
-  thin **React wrapper** (`<BeaketPaper>`). Uncontrolled (`defaultValue` + `ref.setValue()`);
+  thin **React wrapper** (`<Paper>`). Uncontrolled (`defaultValue` + `ref.setValue()`);
   `onChange` emits full markdown on user edits only (IME-guarded; `setValue` does not echo). A
   curated `ref` handle with a `getView()` escape hatch. Shipped as a **standalone npm package**, not
   a copy-paste registry component — so it is exempt from the monorepo's component checklist (no

--- a/packages/paper/src/react/Paper.tsx
+++ b/packages/paper/src/react/Paper.tsx
@@ -14,7 +14,7 @@ import { createValueController } from "../editor/valueController";
 // Uncontrolled: defaultValue is only the initial value; full replacement is commanded via ref.setValue().
 
 /** Curated handle exposed via ref + getView() escape hatch (unsafe). ADR-0013 decision 3. */
-export interface BeaketPaperHandle {
+export interface PaperHandle {
   getValue(): string;
   /** Replace the whole document. While an IME composition is active, deferred and applied on settle (ADR-0004). */
   setValue(md: string): void;
@@ -25,7 +25,7 @@ export interface BeaketPaperHandle {
   getView(): EditorView;
 }
 
-export interface BeaketPaperProps {
+export interface PaperProps {
   /** Initial document body. Not a live prop (uncontrolled) — changes do not trigger recreation. */
   defaultValue?: string;
   /** Full markdown on every user edit. Once after IME settle; setValue produces no echo. */
@@ -45,7 +45,7 @@ export interface BeaketPaperProps {
   className?: string;
 }
 
-export const BeaketPaper = forwardRef<BeaketPaperHandle, BeaketPaperProps>(function BeaketPaper(
+export const Paper = forwardRef<PaperHandle, PaperProps>(function Paper(
   {
     defaultValue,
     onChange,
@@ -114,7 +114,7 @@ export const BeaketPaper = forwardRef<BeaketPaperHandle, BeaketPaperProps>(funct
 
   useImperativeHandle(
     ref,
-    (): BeaketPaperHandle => ({
+    (): PaperHandle => ({
       getValue: () => viewRef.current?.state.doc.toString() ?? "",
       setValue: (md) => controllerRef.current?.setValue(md),
       focus: () => viewRef.current?.focus(),
@@ -127,7 +127,7 @@ export const BeaketPaper = forwardRef<BeaketPaperHandle, BeaketPaperProps>(funct
       },
       getView: () => {
         const view = viewRef.current;
-        if (!view) throw new Error("BeaketPaper: view is not mounted yet");
+        if (!view) throw new Error("Paper: view is not mounted yet");
         return view;
       },
     }),

--- a/packages/paper/src/react/index.ts
+++ b/packages/paper/src/react/index.ts
@@ -1,6 +1,6 @@
 // `@beaket/paper/react` entry — thin wrapper only (ADR-0013 exports map). React = optional peerDep.
-export { BeaketPaper } from "./BeaketPaper";
-export type { BeaketPaperHandle, BeaketPaperProps } from "./BeaketPaper";
+export { Paper } from "./Paper";
+export type { PaperHandle, PaperProps } from "./Paper";
 // Re-export the highlight input type (core-owned, ADR-0014).
 export type { Anchor, AnchorStatus } from "../editor/anchor";
 export type { HighlightInput } from "../editor/extensions/highlightLayer";

--- a/sites/paper/src/components/editor-playground.tsx
+++ b/sites/paper/src/components/editor-playground.tsx
@@ -1,4 +1,4 @@
-import { BeaketPaper, type BeaketPaperHandle } from "@beaket/paper/react";
+import { Paper, type PaperHandle } from "@beaket/paper/react";
 import { useRef, useState } from "react";
 
 const INITIAL = `# Paper
@@ -32,7 +32,7 @@ const FONTS = [
 ];
 
 export function EditorPlayground() {
-  const ref = useRef<BeaketPaperHandle>(null);
+  const ref = useRef<PaperHandle>(null);
   const [markdown, setMarkdown] = useState(INITIAL);
   const [accent, setAccent] = useState(ACCENTS[0].value);
   const [font, setFont] = useState(FONTS[0].value);
@@ -84,7 +84,7 @@ export function EditorPlayground() {
 
       {/* The editor ships no container chrome — the host supplies the paper card. */}
       <div className="pg-paper">
-        <BeaketPaper ref={ref} defaultValue={INITIAL} onChange={setMarkdown} />
+        <Paper ref={ref} defaultValue={INITIAL} onChange={setMarkdown} />
       </div>
 
       <div className="pg-footer">

--- a/sites/paper/src/pages/api.astro
+++ b/sites/paper/src/pages/api.astro
@@ -7,7 +7,7 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
 <Base title="API Reference — Paper">
   <h1>API Reference</h1>
 
-  <h2 id="props"><code>&lt;BeaketPaper&gt;</code> props</h2>
+  <h2 id="props"><code>&lt;Paper&gt;</code> props</h2>
   <p>Import from <code>@beaket/paper/react</code>. All props are optional.</p>
   <table>
     <thead><tr><th>Prop</th><th>Type</th><th>Notes</th></tr></thead>
@@ -26,7 +26,7 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
   </table>
 
   <h2 id="handle">Imperative handle (<code>ref</code>)</h2>
-  <p>The <code>ref</code> exposes a <code>BeaketPaperHandle</code>:</p>
+  <p>The <code>ref</code> exposes a <code>PaperHandle</code>:</p>
   <table>
     <thead><tr><th>Method</th><th>Returns</th><th>Notes</th></tr></thead>
     <tbody>

--- a/sites/paper/src/pages/usage.astro
+++ b/sites/paper/src/pages/usage.astro
@@ -3,13 +3,13 @@ import Base from '../layouts/base.astro';
 const base = import.meta.env.BASE_URL;
 const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p);
 
-const reactCode = `import { BeaketPaper, type BeaketPaperHandle } from "@beaket/paper/react";
+const reactCode = `import { Paper, type PaperHandle } from "@beaket/paper/react";
 import { useRef } from "react";
 
 function Editor() {
-  const ref = useRef<BeaketPaperHandle>(null);
+  const ref = useRef<PaperHandle>(null);
   return (
-    <BeaketPaper
+    <Paper
       ref={ref}
       defaultValue={"# Hello\\n\\nStart writing…"}
       onChange={(markdown) => console.log(markdown)}


### PR DESCRIPTION
## What

Clean rename of the `@beaket/paper` React component from `BeaketPaper` to `Paper`, including its types:

- `BeaketPaper` → `Paper`
- `BeaketPaperHandle` → `PaperHandle`
- `BeaketPaperProps` → `PaperProps`

The file `src/react/BeaketPaper.tsx` is renamed to `src/react/Paper.tsx`.

## Why

The package scope (`@beaket/paper`) already namespaces the export, so `import { BeaketPaper } from "@beaket/paper/react"` repeated "beaket". `import { Paper } from "@beaket/paper/react"` reads cleaner and matches the convention of scoped-package exports (Radix, shadcn, etc.).

## Breaking change

Consumers must update imports:

```diff
-import { BeaketPaper, type BeaketPaperHandle } from "@beaket/paper/react";
+import { Paper, type PaperHandle } from "@beaket/paper/react";
```

`Paper` is a generic name and can collide with other libraries (e.g. MUI's `Paper`); the README and changeset note the `import { Paper as BeaketPaper }` alias escape hatch. Released as a **minor** bump (pre-1.0, and `major` is disallowed by repo rules).

## Scope of changes

- `packages/paper/src/react/Paper.tsx` (renamed) + `index.ts` re-exports
- `packages/paper/README.md`, `docs/DECISIONS.md`
- `sites/paper/` playground component + `usage.astro` / `api.astro` examples
- Changeset added

`CHANGELOG.md` left untouched as a historical record.

## Verification

- `pnpm typecheck` ✅
- `pnpm test` ✅ (216 tests pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135ZkfibR8H67r5DfuvRM68

---
_Generated by [Claude Code](https://claude.ai/code/session_0135ZkfibR8H67r5DfuvRM68)_