### PR TITLE
docs(paper): wider editor playground, better mobile, no header border

### DIFF
--- a/sites/paper/src/components/editor-playground.tsx
+++ b/sites/paper/src/components/editor-playground.tsx
@@ -112,11 +112,19 @@ export function EditorPlayground() {
           color: var(--steel, #686b6f);
         }
         .pg-swatch {
+          position: relative;
           width: 22px;
           height: 22px;
           border: 1px solid var(--chrome);
           cursor: pointer;
           padding: 0;
+        }
+        /* Transparent hit area extends the tap target past 44px without
+           changing the visible swatch (the design-system touch-target trick). */
+        .pg-swatch::before {
+          content: "";
+          position: absolute;
+          inset: -12px;
         }
         .pg-btn {
           font: inherit;

--- a/sites/paper/src/components/editor-playground.tsx
+++ b/sites/paper/src/components/editor-playground.tsx
@@ -132,8 +132,8 @@ export function EditorPlayground() {
           background: var(--beaket-paper-paper, var(--paper, #fff));
           border: 1px solid var(--chrome);
           box-shadow: var(--shadow-offset, 2px 2px 0 0 var(--chrome));
-          padding: 1.25rem;
-          min-height: 340px;
+          padding: 1.25rem 1.5rem;
+          min-height: min(60vh, 520px);
         }
         .pg-footer {
           display: flex;
@@ -153,6 +153,21 @@ export function EditorPlayground() {
           word-break: break-word;
           max-height: 320px;
           overflow: auto;
+        }
+        @media (max-width: 540px) {
+          .pg-toolbar {
+            gap: 0.85rem 1rem;
+            padding: 0.5rem 0;
+          }
+          .pg-paper {
+            padding: 0.9rem 1rem;
+            min-height: min(58vh, 460px);
+          }
+          /* Bigger tap targets for the swatches on touch screens. */
+          .pg-swatch {
+            width: 26px;
+            height: 26px;
+          }
         }
       `}</style>
     </div>

--- a/sites/paper/src/layouts/base.astro
+++ b/sites/paper/src/layouts/base.astro
@@ -4,10 +4,12 @@ import '../styles/global.css';
 interface Props {
   title?: string;
   description?: string;
+  bodyClass?: string;
 }
 const {
   title = 'Paper — markdown-first editor',
   description = 'A markdown-first, CJK-first Live Preview editor built on CodeMirror 6. Standalone npm package.',
+  bodyClass,
 } = Astro.props;
 
 const base = import.meta.env.BASE_URL;
@@ -35,7 +37,7 @@ const year = new Date().getFullYear();
     <meta name="description" content={description} />
     <meta name="color-scheme" content="light dark" />
   </head>
-  <body>
+  <body class={bodyClass}>
     <header class="masthead">
       <div class="masthead-inner">
         <a href={withBase('')} class="brand">Paper</a>

--- a/sites/paper/src/pages/index.astro
+++ b/sites/paper/src/pages/index.astro
@@ -5,7 +5,7 @@ const base = import.meta.env.BASE_URL;
 const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p);
 ---
 
-<Base title="Paper — markdown-first editor">
+<Base title="Paper — markdown-first editor" bodyClass="home">
   <section class="hero">
     <h1>Write markdown<br />the way it reads.</h1>
     <p>
@@ -53,6 +53,13 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
     font-size: 13px;
     color: var(--steel);
     margin-top: 0.75rem;
+  }
+  @media (max-width: 540px) {
+    .playground-frame {
+      /* Full-bleed on phones so the editor gets every pixel of width. */
+      margin: 0 -1.1rem;
+      padding: 0.75rem 0.85rem 0.85rem;
+    }
   }
   .next {
     margin-top: 2.5rem;

--- a/sites/paper/src/styles/global.css
+++ b/sites/paper/src/styles/global.css
@@ -94,6 +94,9 @@ pre code {
 /* Header */
 .masthead {
   background: var(--paper);
+  /* A quiet chrome hairline — the heavy black rule is gone, but the brutalist
+     system still wants the edge shown (matches the sidebar/footer separators). */
+  border-bottom: 1px solid var(--chrome);
 }
 .masthead-inner {
   display: flex;

--- a/sites/paper/src/styles/global.css
+++ b/sites/paper/src/styles/global.css
@@ -91,9 +91,10 @@ pre code {
   padding: 0 1.5rem;
 }
 
-/* Header — borderless. The bold wordmark + whitespace carry it; no rule needed. */
+/* Header — borderless and seamless. Matches the page (--canvas) so there's no
+   panel edge; the bold wordmark + whitespace carry it on their own. */
 .masthead {
-  background: var(--paper);
+  background: var(--canvas);
 }
 .masthead-inner {
   display: flex;

--- a/sites/paper/src/styles/global.css
+++ b/sites/paper/src/styles/global.css
@@ -93,7 +93,6 @@ pre code {
 
 /* Header */
 .masthead {
-  border-bottom: 2px solid var(--ink);
   background: var(--paper);
 }
 .masthead-inner {
@@ -101,14 +100,14 @@ pre code {
   align-items: baseline;
   gap: 1rem;
   padding: 1.1rem 1.5rem;
-  max-width: 1080px;
+  max-width: 1120px;
   margin: 0 auto;
 }
 
 /* Layout: sidebar + content */
 .layout {
   display: flex;
-  max-width: 1080px;
+  max-width: 1120px;
   margin: 0 auto;
   align-items: flex-start;
 }
@@ -159,15 +158,24 @@ pre code {
   max-width: 760px;
   padding: 2.25rem 2.5rem 4rem;
 }
+/* The home page leads with the playground — let it use the full width
+   beside the sidebar instead of the narrow reading column. */
+.home .content {
+  max-width: none;
+}
 
 @media (max-width: 820px) {
+  .masthead-inner {
+    padding: 0.85rem 1.1rem;
+    gap: 0.6rem;
+  }
   .layout {
     flex-direction: column;
   }
   .sidebar {
     position: static;
     width: 100%;
-    padding: 1rem 1.5rem;
+    padding: 1rem 1.1rem;
     border-bottom: 1px solid var(--chrome);
   }
   .sidebar-toggle {
@@ -181,8 +189,15 @@ pre code {
     display: flex;
   }
   .content {
-    padding: 1.5rem 1.5rem 3rem;
+    padding: 1.5rem 1.1rem 3rem;
     max-width: none;
+  }
+}
+
+@media (max-width: 540px) {
+  /* The package name crowds the brand on phones — the heading carries it. */
+  .brand-sub {
+    display: none;
   }
 }
 .brand {

--- a/sites/paper/src/styles/global.css
+++ b/sites/paper/src/styles/global.css
@@ -91,12 +91,9 @@ pre code {
   padding: 0 1.5rem;
 }
 
-/* Header */
+/* Header — borderless. The bold wordmark + whitespace carry it; no rule needed. */
 .masthead {
   background: var(--paper);
-  /* A quiet chrome hairline — the heavy black rule is gone, but the brutalist
-     system still wants the edge shown (matches the sidebar/footer separators). */
-  border-bottom: 1px solid var(--chrome);
 }
 .masthead-inner {
   display: flex;


### PR DESCRIPTION
## Summary

Two improvements to the **@beaket/paper** docs site (`sites/paper/`) based on feedback:

### 1. Editor is wider and easier to try
- On the home page, the playground now fills the full width beside the sidebar instead of being trapped in the narrow 760px reading column (`.home .content` max-width unset). The shared layout/masthead grew `1080px → 1120px` to match.
- The editor surface is taller — `min-height: min(60vh, 520px)` — so there's real room to type and try things, with a bit more horizontal padding.

### 2. Mobile optimization + header cleanup
- **Removed the black 2px header border.** The `--paper`/`--canvas` tonal difference carries the separation, leaving a cleaner masthead.
- Phones get a **full-bleed playground** (negative margin) so the editor uses every pixel of width.
- Tighter masthead/content padding on small screens, larger accent-swatch tap targets, and the `@beaket/paper` sub-label is hidden under 540px where it crowds the brand.

## Changes
- `sites/paper/src/styles/global.css` — header border, layout widths, home content width, mobile chrome
- `sites/paper/src/layouts/base.astro` — new `bodyClass` prop
- `sites/paper/src/pages/index.astro` — `bodyClass="home"`, mobile full-bleed frame
- `sites/paper/src/components/editor-playground.tsx` — taller editor, mobile media query

## Testing
- `astro build` passes; all 5 pages generated.
- Verified built output: `<body class="home">` on the home page only, and `.masthead{background:var(--paper)}` with no `--ink` border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SfoYyHi87bPuydTzm6D3iL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfoYyHi87bPuydTzm6D3iL)_