### PR TITLE
Refresh Paper docs: match the new landing + document dark mode

### DIFF
--- a/sites/paper/src/pages/api.astro
+++ b/sites/paper/src/pages/api.astro
@@ -54,7 +54,3 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
 
   <p class="next"><a href={withBase('styling')}>Styling →</a></p>
 </Base>
-
-<style>
-  .next { margin-top: 2.5rem; font-weight: 600; }
-</style>

--- a/sites/paper/src/pages/installation.astro
+++ b/sites/paper/src/pages/installation.astro
@@ -40,7 +40,3 @@ npm install react react-dom`;
 
   <p class="next"><a href={withBase('usage')}>Usage →</a></p>
 </Base>
-
-<style>
-  .next { margin-top: 2.5rem; font-weight: 600; }
-</style>

--- a/sites/paper/src/pages/styling.astro
+++ b/sites/paper/src/pages/styling.astro
@@ -1,5 +1,7 @@
 ---
 import Base from '../layouts/base.astro';
+const base = import.meta.env.BASE_URL;
+const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p);
 
 const cssCode = `.my-editor-wrapper {
   --beaket-paper-accent: #0c6bae;     /* links, focus, selection tint */
@@ -39,10 +41,25 @@ const cssCode = `.my-editor-wrapper {
     explicit override first, then the host palette, then a built-in default.
   </p>
 
+  <h2 id="dark">Dark mode</h2>
+  <p>
+    The editor follows the OS <code>prefers-color-scheme</code> automatically — no setup, no class to
+    toggle. Every token carries a dark-aware default, so body text, surfaces, and the code-syntax ramp
+    all flip together (the dark ramp mirrors GitHub Dark Default).
+  </p>
+  <p>
+    Theming still wins in both modes: a token you set on <code>:root</code> or an ancestor —
+    <code>--beaket-paper-*</code> directly, or the host's <code>--color-*</code> palette through the
+    bridge — applies to light and dark alike. To diverge per scheme, set your overrides inside your own
+    <code>@media (prefers-color-scheme: dark)</code> block.
+  </p>
+
   <h2 id="escape">Escape hatches</h2>
   <p>For anything the variables don't cover:</p>
   <ul>
     <li>Style the stable <code>.cm-*</code> class hooks directly — e.g. <code>.cm-table-widget</code>, <code>.cm-slash-menu</code>, <code>.cm-md-copy</code>.</li>
     <li>Reach the underlying CodeMirror <code>EditorView</code> via <code>ref.current.getView()</code> to add your own extensions or theme.</li>
   </ul>
+
+  <p class="next"><a href={withBase('')}>← Back to overview</a></p>
 </Base>

--- a/sites/paper/src/pages/usage.astro
+++ b/sites/paper/src/pages/usage.astro
@@ -65,7 +65,3 @@ const editor = createEditor(document.querySelector("#editor")!, {
 
   <p class="next"><a href={withBase('api')}>API Reference →</a></p>
 </Base>
-
-<style>
-  .next { margin-top: 2.5rem; font-weight: 600; }
-</style>

--- a/sites/paper/src/styles/global.css
+++ b/sites/paper/src/styles/global.css
@@ -169,7 +169,31 @@ pre code {
   flex: 1;
   min-width: 0;
   max-width: 760px;
-  padding: 2.25rem 2.5rem 4rem;
+  padding: 3.25rem 2.5rem 5rem;
+}
+/* Docs lead: the headline + first paragraph get the same spacious, tight-tracked
+   treatment as the landing so the pages read as one family. */
+.content > h1 {
+  font-size: clamp(2rem, 3.6vw, 2.6rem);
+  line-height: 1.1;
+  letter-spacing: -0.03em;
+  margin: 0 0 1rem;
+}
+.content > h1 + p {
+  font-size: 17px;
+  line-height: 1.6;
+  color: var(--slate);
+  margin-top: 0;
+}
+/* "Next page" footer link — a divider + breathing room closes each doc page. */
+.next {
+  margin-top: 3.5rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--chrome);
+  font-weight: 600;
+}
+.next a {
+  font-size: 1.05rem;
 }
 /* The home page leads with the playground — let it use the full width
    beside the sidebar instead of the narrow reading column. */


### PR DESCRIPTION
## Why

Follow-up to the landing redesign (#459). The docs pages still used the old, denser styling and didn't reflect the 0.3.0 package — most notably dark mode (shipped in 0.2.0) was only mentioned in one clause.

## What changed

**Visual — match the new landing**
- `global.css`: refined doc `<h1>` (clamp size, tight tracking), a slate **lead paragraph** treatment for the first line, more top breathing room, and a unified **divider-separated "next page" link**
- Removed the now-redundant per-page `.next` style blocks (installation / usage / api)

**Content — sync to the 0.3.0 implementation**
- `styling.astro`: added a proper **Dark mode** section — the editor follows the OS `prefers-color-scheme` automatically, and `--beaket-paper-*` / `--color-*` overrides still win in both modes
- Audited the rest against the package: props table, imperative handle, and core `EditorOptions` already match 0.3.0 (`Paper`/`PaperHandle` naming, peer-dep ranges, ESM-only note) — no other drift found

## Verification

- `pnpm --filter paper-site build` ✓
- Screenshotted Installation + Styling pages (refined headings, lead paragraph, dark-mode section, divider footer link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KHQNUP9JyXPyPnvcvNdjpf

---
_Generated by [Claude Code](https://claude.ai/code/session_01KHQNUP9JyXPyPnvcvNdjpf)_