### PR TITLE
docs(paper): restore sidebar landing + honest "Why Paper" copy

### DIFF
--- a/sites/paper/src/layouts/base.astro
+++ b/sites/paper/src/layouts/base.astro
@@ -26,9 +26,6 @@ const nav = [
 ];
 const isActive = (seg: string) => (seg === '' ? path === homePath : path.endsWith('/' + seg));
 const year = new Date().getFullYear();
-// The landing page leads with the hero + playground, so it drops the docs
-// sidebar and runs full-width. Docs pages keep the sidebar.
-const isHome = bodyClass === 'home';
 ---
 
 <!doctype html>
@@ -46,24 +43,21 @@ const isHome = bodyClass === 'home';
         <a href={withBase('')} class="brand">Paper</a>
         <span class="brand-sub">@beaket/paper</span>
         <nav class="masthead-links">
-          <a href={withBase('installation')}>Docs</a>
           <a href="https://www.npmjs.com/package/@beaket/paper">npm</a>
           <a href="https://github.com/beaket/ui/tree/main/packages/paper">GitHub</a>
         </nav>
       </div>
     </header>
 
-    <div class:list={['layout', { 'is-home': isHome }]}>
-      {!isHome && (
-        <aside class="sidebar">
-          <button class="sidebar-toggle" aria-label="Toggle navigation" aria-expanded="false">Menu ▾</button>
-          <nav class="sidebar-nav">
-            {nav.map((item) => (
-              <a href={item.href} class:list={['sidebar-link', { active: isActive(item.seg) }]}>{item.label}</a>
-            ))}
-          </nav>
-        </aside>
-      )}
+    <div class="layout">
+      <aside class="sidebar">
+        <button class="sidebar-toggle" aria-label="Toggle navigation" aria-expanded="false">Menu ▾</button>
+        <nav class="sidebar-nav">
+          {nav.map((item) => (
+            <a href={item.href} class:list={['sidebar-link', { active: isActive(item.seg) }]}>{item.label}</a>
+          ))}
+        </nav>
+      </aside>
 
       <main class="content">
         <slot />

--- a/sites/paper/src/pages/index.astro
+++ b/sites/paper/src/pages/index.astro
@@ -10,82 +10,52 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
     <h1>Write markdown<br />the way it reads.</h1>
     <p>
       <strong>Paper</strong> is a markdown-first, CJK-first <strong>Live Preview</strong> editor built
-      on CodeMirror 6. The text is the single source of truth — only the line under your cursor shows
-      raw syntax, everything else renders. The Obsidian model, as a standalone npm package.
+      on CodeMirror 6.<br />
+      Drop it into your app as a dependency.
     </p>
-    <div class="badges">
-      <span class="badge">CodeMirror 6</span>
-      <span class="badge">CJK-first</span>
-      <span class="badge">Framework-agnostic core + React</span>
-      <span class="badge">Uncontrolled by design</span>
-    </div>
   </section>
 
-  <section class="showcase">
+  <section>
     <div class="playground-frame">
       <EditorPlayground client:only="react" />
     </div>
     <p class="hint">Type <code>/</code> for the slash menu · drop an image · paste a table · change the accent &amp; font.</p>
   </section>
 
-  <section class="cta">
-    <a class="cta-link" href={withBase('installation')}>Get started — Installation →</a>
-    <a class="cta-alt" href={withBase('usage')}>Read the usage guide</a>
-  </section>
+  <h2>Why Paper</h2>
+  <p>
+    Live preview rewrites the DOM as you type — hiding and revealing syntax around your cursor. Do that
+    mid-IME-composition and Japanese or Korean input drops or duplicates characters. It's a stubborn,
+    still-open problem even in mature, widely-used editors.
+  </p>
+  <p>
+    Paper makes one promise its central invariant: <strong>never break composition</strong> — no
+    decoration recompute, no widget rebuild while you're mid-character. That's the editor I wanted,
+    small enough to drop into any app.
+  </p>
+
+  <p class="next"><a href={withBase('installation')}>Installation →</a></p>
 </Base>
 
 <style>
-  .showcase {
-    margin-top: 1rem;
-  }
   .playground-frame {
     background: var(--frost);
-    padding: 1.25rem 1.5rem 1.5rem;
-    border: 1px solid var(--chrome);
-    box-shadow: var(--shadow-offset);
+    padding: 1rem 1.25rem 1.25rem;
   }
   .hint {
     font-size: 13px;
     color: var(--steel);
-    margin-top: 1rem;
+    margin-top: 0.75rem;
   }
-
-  .cta {
-    margin-top: 3.5rem;
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-    flex-wrap: wrap;
-  }
-  .cta-link {
-    display: inline-block;
-    font-weight: 600;
-    padding: 0.7rem 1.2rem;
-    background: var(--ink);
-    color: var(--paper);
-    border: 1px solid var(--ink);
-    box-shadow: var(--shadow-offset);
-  }
-  .cta-link:hover {
-    text-decoration: none;
-  }
-  .cta-alt {
-    font-weight: 600;
-  }
-
-  @media (max-width: 720px) {
-    .cta {
-      margin-top: 2.5rem;
-    }
-  }
-
   @media (max-width: 540px) {
     .playground-frame {
       /* Full-bleed on phones so the editor gets every pixel of width. */
       margin: 0 -1.1rem;
-      padding: 0.85rem 0.95rem 1rem;
-      border-left: none;
-      border-right: none;
+      padding: 0.75rem 0.85rem 0.85rem;
     }
+  }
+  .next {
+    margin-top: 2.5rem;
+    font-weight: 600;
   }
 </style>

--- a/sites/paper/src/styles/global.css
+++ b/sites/paper/src/styles/global.css
@@ -100,29 +100,17 @@ pre code {
   display: flex;
   align-items: baseline;
   gap: 1rem;
-  padding: 1.4rem 1.75rem;
-  max-width: 1200px;
+  padding: 1.1rem 1.5rem;
+  max-width: 1120px;
   margin: 0 auto;
 }
 
 /* Layout: sidebar + content */
 .layout {
   display: flex;
-  max-width: 1200px;
+  max-width: 1120px;
   margin: 0 auto;
   align-items: flex-start;
-}
-
-/* Home: no sidebar. The content runs the full centered width so the hero and
-   playground breathe. The reading column on docs pages is unaffected. */
-.layout.is-home {
-  display: block;
-}
-.is-home .content {
-  max-width: none;
-  /* Left padding matches the masthead so the headline lines up under the
-     "Paper" wordmark — a deliberate vertical edge down the page. */
-  padding: 0 1.75rem 6rem;
 }
 .sidebar {
   width: 210px;
@@ -169,31 +157,7 @@ pre code {
   flex: 1;
   min-width: 0;
   max-width: 760px;
-  padding: 3.25rem 2.5rem 5rem;
-}
-/* Docs lead: the headline + first paragraph get the same spacious, tight-tracked
-   treatment as the landing so the pages read as one family. */
-.content > h1 {
-  font-size: clamp(2rem, 3.6vw, 2.6rem);
-  line-height: 1.1;
-  letter-spacing: -0.03em;
-  margin: 0 0 1rem;
-}
-.content > h1 + p {
-  font-size: 17px;
-  line-height: 1.6;
-  color: var(--slate);
-  margin-top: 0;
-}
-/* "Next page" footer link — a divider + breathing room closes each doc page. */
-.next {
-  margin-top: 3.5rem;
-  padding-top: 1.5rem;
-  border-top: 1px solid var(--chrome);
-  font-weight: 600;
-}
-.next a {
-  font-size: 1.05rem;
+  padding: 2.25rem 2.5rem 4rem;
 }
 /* The home page leads with the playground — let it use the full width
    beside the sidebar instead of the narrow reading column. */
@@ -203,14 +167,8 @@ pre code {
 
 @media (max-width: 820px) {
   .masthead-inner {
-    padding: 0.95rem 1.1rem;
+    padding: 0.85rem 1.1rem;
     gap: 0.6rem;
-  }
-  .is-home .content {
-    padding: 0 1.1rem 4rem;
-  }
-  .hero {
-    padding: 3rem 0 1.5rem;
   }
   .layout {
     flex-direction: column;
@@ -265,27 +223,25 @@ pre code {
 
 /* Hero */
 .hero {
-  padding: 5.5rem 0 2.5rem;
-  max-width: 920px;
+  padding: 2.5rem 0 1rem;
 }
 .hero h1 {
-  font-size: clamp(2.5rem, 6.5vw, 4.5rem);
-  line-height: 1;
-  letter-spacing: -0.04em;
-  margin: 0 0 1.25rem;
+  font-size: clamp(2rem, 5vw, 3rem);
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+  margin: 0 0 0.75rem;
 }
 .hero p {
-  font-size: 19px;
-  line-height: 1.6;
+  font-size: 17px;
   color: var(--slate);
   margin: 0;
-  max-width: 40em;
+  max-width: 36em;
 }
 .badges {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-top: 2rem;
+  margin-top: 0.85rem;
 }
 .badge {
   font-size: 12px;


### PR DESCRIPTION
## What

Brings the Paper docs landing back to the **sidebar layout** (the version still live at beaket.github.io/ui/paper — the recent redesign hadn't shipped) and reworks the hero/intro copy.

## Changes

**Layout** — `base.astro`, `global.css`, `index.astro` reverted to the pre-redesign sidebar form. Drops the home full-width treatment and the masthead `Docs` link (the sidebar already handles docs nav).

**Hero copy**
- Tightened to *what it is* + *"Drop it into your app as a dependency."*
- Removed the cursor/syntax sentence (the live demo already shows it) and the badge row.
- Trimmed hero spacing so the editor sits higher in the first view (title's intentional top offset kept).

**"How it works" → "Why Paper"**
- Replaced implementation detail with the real, documented motivation: live preview rewrites the DOM as you type, which breaks IME composition mid-character.
- Claims verified against the package's `DECISIONS.md` (the composing-guard invariant) and public issues in mature editors.
- Uses **Japanese/Korean** as concrete examples; Chinese is fallback-only in the font stack (shared Han glyphs unify to Japanese forms), so it's deliberately not claimed. No competitors named.

## Verification

Checked live against the local dev server and the deployed site side-by-side; layout matches deployed, copy claims cross-checked with repo docs + source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)