### PR TITLE
docs(paper): syntax-highlight code blocks (dark theme + copy button)

### DIFF
--- a/sites/paper/src/components/code-block.astro
+++ b/sites/paper/src/components/code-block.astro
@@ -1,0 +1,93 @@
+---
+import { Code } from 'astro:components';
+
+interface Props {
+  code: string;
+  lang?: 'tsx' | 'ts' | 'js' | 'bash' | 'css';
+}
+
+const { code, lang = 'tsx' } = Astro.props;
+---
+
+<div class="code-block">
+  <button class="copy-btn" type="button" aria-label="Copy code">COPY</button>
+  {/* A dark Shiki theme so the block stays black in both light and dark page modes. */}
+  <Code code={code} lang={lang} theme="github-dark" />
+</div>
+
+<style>
+  .code-block {
+    position: relative;
+    margin: 1rem 0;
+  }
+  /* The Shiki <pre> carries its own inline dark background; we add the brutalist
+     frame (border + offset shadow) and typography to match the page chrome. */
+  .code-block :global(.astro-code) {
+    margin: 0;
+    padding: 1rem;
+    overflow-x: auto;
+    border: 1px solid var(--chrome);
+    box-shadow: var(--shadow-offset);
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, monospace;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+  /* Neutralize the page's inline-code styling inside the highlighted block. */
+  .code-block :global(.astro-code code) {
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+  }
+
+  /* Copy button — light-on-dark to sit on the always-dark block (no white fill). */
+  .copy-btn {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    z-index: 1;
+    padding: 0.3rem 0.5rem;
+    font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, monospace;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    line-height: 1;
+    color: #c9d1d9;
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    cursor: pointer;
+  }
+  .copy-btn:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.14);
+  }
+  .copy-btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+  .copy-btn.copied {
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.4);
+  }
+</style>
+
+<script>
+  document.querySelectorAll<HTMLElement>('.code-block').forEach((block) => {
+    const btn = block.querySelector<HTMLButtonElement>('.copy-btn');
+    const pre = block.querySelector<HTMLElement>('.astro-code');
+    if (!btn || !pre) return;
+    btn.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(pre.innerText);
+        btn.textContent = 'COPIED';
+        btn.classList.add('copied');
+        setTimeout(() => {
+          btn.textContent = 'COPY';
+          btn.classList.remove('copied');
+        }, 1500);
+      } catch {
+        /* clipboard unavailable (e.g. non-secure context) — no-op */
+      }
+    });
+  });
+</script>

--- a/sites/paper/src/pages/installation.astro
+++ b/sites/paper/src/pages/installation.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/base.astro';
+import CodeBlock from '../components/code-block.astro';
 const base = import.meta.env.BASE_URL;
 const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p);
 
@@ -14,7 +15,7 @@ npm install react react-dom`;
 
   <p>Paper ships as a standalone npm package — there is no copy-paste or CLI step. Install it from npm:</p>
 
-  <pre><code>{installCode}</code></pre>
+  <CodeBlock code={installCode} lang="bash" />
 
   <p>
     The package exposes two entry points: the framework-agnostic core at <code>@beaket/paper</code> and a

--- a/sites/paper/src/pages/styling.astro
+++ b/sites/paper/src/pages/styling.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/base.astro';
+import CodeBlock from '../components/code-block.astro';
 const base = import.meta.env.BASE_URL;
 const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p);
 
@@ -27,7 +28,7 @@ const cssCode = `.my-editor-wrapper {
     <code>:root</code> or any ancestor of the editor and it follows — no <code>!important</code>, no
     specificity fights:
   </p>
-  <pre><code>{cssCode}</code></pre>
+  <CodeBlock code={cssCode} lang="css" />
   <blockquote>
     <code>letter-spacing</code> is intentionally <strong>not</strong> exposed — negative spacing breaks
     mixed-script CJK, so it is fixed at <code>0</code> (a CJK-first guard).

--- a/sites/paper/src/pages/usage.astro
+++ b/sites/paper/src/pages/usage.astro
@@ -1,5 +1,6 @@
 ---
 import Base from '../layouts/base.astro';
+import CodeBlock from '../components/code-block.astro';
 const base = import.meta.env.BASE_URL;
 const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p);
 
@@ -36,7 +37,7 @@ const editor = createEditor(document.querySelector("#editor")!, {
   <h1>Usage</h1>
 
   <h2 id="react">React</h2>
-  <pre><code>{reactCode}</code></pre>
+  <CodeBlock code={reactCode} lang="tsx" />
   <p>
     The editor is <strong>uncontrolled</strong>: pass <code>defaultValue</code> for the initial
     document and call <code>ref.current.setValue(...)</code> to replace it programmatically.
@@ -46,7 +47,7 @@ const editor = createEditor(document.querySelector("#editor")!, {
   </p>
 
   <h3>Reading &amp; replacing the document</h3>
-  <pre><code>{setValueCode}</code></pre>
+  <CodeBlock code={setValueCode} lang="ts" />
   <p>
     For anything the curated handle does not expose, <code>ref.current.getView()</code> returns the
     underlying CodeMirror <code>EditorView</code> as an escape hatch. See the
@@ -55,7 +56,7 @@ const editor = createEditor(document.querySelector("#editor")!, {
 
   <h2 id="core">Framework-agnostic core</h2>
   <p>The core has zero React. Mount it onto any element and it returns the CodeMirror <code>EditorView</code>:</p>
-  <pre><code>{coreCode}</code></pre>
+  <CodeBlock code={coreCode} lang="ts" />
   <p>
     The core takes <code>doc</code> where the React wrapper takes <code>defaultValue</code>; the
     callback options (<code>onChange</code>, <code>onSelect</code>, <code>onInsertImage</code>,


### PR DESCRIPTION
## What

Code blocks on the Paper docs site were authored as raw `<pre><code>{string}</code></pre>`, so Astro's Shiki highlighting never kicked in — they rendered as plain monospace. This adds real syntax highlighting with a dark theme and a copy button.

## Changes

- **New `sites/paper/src/components/code-block.astro`** — runs the code through Astro's build-time `<Code>` (Shiki) with the `github-dark` theme, so blocks stay **dark in both light and dark page modes**. Wrapped in the site's brutalist frame (border + offset shadow).
- **`COPY` button** — uppercase label, light-on-dark styling (no white fill) to sit on the dark block, top-right, with a `COPIED` feedback state. Wired to `navigator.clipboard`.
- Replaced all **5 raw blocks** across `installation` (bash), `styling` (css), and `usage` (tsx / ts ×2) with `<CodeBlock>`.

## Notes

- Independent of #462 (only file overlap with that PR is unrelated CSS sections); mergeable in any order.
- `pnpm build` passes; all 5 pages render.
- Clipboard write couldn't be auto-verified (browser-automation "document not focused" restriction) — it's the standard `clipboard.writeText` pattern and works on a real click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)