### PR TITLE
fix(paper): remove duplicate copy button on code blocks

### DIFF
--- a/sites/paper/src/layouts/base.astro
+++ b/sites/paper/src/layouts/base.astro
@@ -79,32 +79,7 @@ const year = new Date().getFullYear();
         const open = nav?.classList.toggle('open');
         toggle.setAttribute('aria-expanded', String(!!open));
       });
-
-      // Copy buttons on code blocks
-      document.querySelectorAll('pre').forEach((pre) => {
-        const button = document.createElement('button');
-        button.textContent = 'Copy';
-        button.setAttribute('aria-label', 'Copy code');
-        Object.assign(button.style, {
-          position: 'absolute',
-          top: '0.5rem',
-          right: '0.5rem',
-          font: 'inherit',
-          fontSize: '12px',
-          padding: '0.15rem 0.5rem',
-          background: 'var(--paper)',
-          color: 'var(--ink)',
-          border: '1px solid var(--chrome)',
-          cursor: 'pointer',
-        });
-        pre.style.position = 'relative';
-        button.addEventListener('click', async () => {
-          await navigator.clipboard.writeText(pre.querySelector('code')?.textContent || pre.textContent || '');
-          button.textContent = 'Copied';
-          setTimeout(() => (button.textContent = 'Copy'), 1500);
-        });
-        pre.appendChild(button);
-      });
+      // Code-block copy buttons live in the CodeBlock component (code-block.astro).
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Problem

After #463 added the `CodeBlock` component (`code-block.astro`) with its own per-block copy button, every code block on the Paper docs site rendered **two** overlapping copy buttons in the top-right corner — the new dark "COPY" button plus a leftover white "Copy" button.

The duplicate came from an older script in `base.astro` that appended a copy button to every `<pre>` on the page.

## Fix

All real code blocks (`<pre>`) on the site now go exclusively through the `CodeBlock` component (verified: `api`/`index` pages only use inline `<code>`, no `<pre>`). The layout-level copy script is therefore redundant, so it's removed.

Result: a single copy button per block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)