### PR TITLE
docs(paper): tighten Installation copy + consistent page-title divider

### DIFF
--- a/sites/paper/src/pages/installation.astro
+++ b/sites/paper/src/pages/installation.astro
@@ -4,35 +4,22 @@ import CodeBlock from '../components/code-block.astro';
 const base = import.meta.env.BASE_URL;
 const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p);
 
-const installCode = `npm install @beaket/paper
-
-# the React wrapper also needs react / react-dom (optional peer deps)
-npm install react react-dom`;
+const installCode = `npm install @beaket/paper`;
 ---
 
 <Base title="Installation — Paper">
   <h1>Installation</h1>
 
-  <p>Paper ships as a standalone npm package — there is no copy-paste or CLI step. Install it from npm:</p>
+  <p>Paper is published as a standalone npm package — install it from npm and import it like any other dependency:</p>
 
   <CodeBlock code={installCode} lang="bash" />
 
   <p>
     The package exposes two entry points: the framework-agnostic core at <code>@beaket/paper</code> and a
-    thin React wrapper at <code>@beaket/paper/react</code>. React and <code>react-dom</code> are
-    <strong>optional</strong> peer dependencies — install them only if you use the React wrapper.
+    thin React wrapper at <code>@beaket/paper/react</code>. The core has no peer dependencies — it bundles
+    its CodeMirror 6 engine. <code>react</code> and <code>react-dom</code> (<code>&gt;=18</code>) are
+    <strong>optional</strong> peer dependencies for the wrapper — install them only if you use it.
   </p>
-
-  <h2>Requirements</h2>
-  <table>
-    <thead><tr><th>Peer</th><th>Range</th><th>When</th></tr></thead>
-    <tbody>
-      <tr><td><code>react</code></td><td><code>&gt;=18</code></td><td>Only for <code>@beaket/paper/react</code>.</td></tr>
-      <tr><td><code>react-dom</code></td><td><code>&gt;=18</code></td><td>Only for <code>@beaket/paper/react</code>.</td></tr>
-    </tbody>
-  </table>
-
-  <p>The core itself has no peer dependencies — it bundles its CodeMirror 6 engine.</p>
 
   <blockquote>
     Paper is <strong>ESM-only</strong> (no CommonJS build). Use it from an ESM project or a bundler

--- a/sites/paper/src/styles/global.css
+++ b/sites/paper/src/styles/global.css
@@ -252,6 +252,19 @@ pre code {
 }
 
 /* Content */
+/* Page title — a consistent rule under every content-page <h1>, so the
+   divider no longer depends on a section <h2> happening to sit near the top.
+   The hero <h1> is nested in .hero, so .content > h1 excludes it. */
+.content > h1 {
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--chrome);
+}
+/* When a section heading butts right against the title, the title rule is the
+   only divider — drop the h2's own top rule so they don't stack into two lines. */
+.content > h1 + h2 {
+  border-top: none;
+  padding-top: 0;
+}
 h2 {
   font-size: 1.5rem;
   letter-spacing: -0.02em;


### PR DESCRIPTION
## Installation copy

- **Drop the insider framing.** *"there is no copy-paste or CLI step"* only makes sense to someone who knows `@beaket/ui`'s copy-paste model. For a standalone Paper reader it's noise — replaced with a plain "install it from npm and import it like any other dependency."
- **Lean install snippet.** Reduced to `npm install @beaket/paper`. The old `npm install react react-dom` line + "optional peer deps" comment contradicted Paper's framework-agnostic positioning — a vanilla/Vue reader shouldn't be told to install React up front. The optional-React detail still lives in the paragraph below.
- **Remove the Requirements section.** The H2 + 2-row table just restated the entry-points paragraph and re-introduced React bias (a "Requirements" table whose only rows are `react`/`react-dom`). Its one unique fact (`>=18`) and the "core has no peer dependencies" note fold into the paragraph above.

## Page-title divider

Removing the Installation table left that page with **no `<h2>`**, and the "rule under the title" was actually the first section `<h2>`'s `border-top` — so Installation lost its divider entirely.

Fix: give content-page `<h1>` a consistent `border-bottom`, so the title rule no longer depends on a section heading sitting near the top. When an `<h2>` butts directly against the title (e.g. Usage), its top rule is suppressed so the two don't stack into a double line.

No changeset — docs-site-only change (`sites/paper/`), nothing published to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)