### PR TITLE
docs(paper): live selection→highlight demo on Usage

### DIFF
--- a/sites/paper/src/components/highlights-demo.tsx
+++ b/sites/paper/src/components/highlights-demo.tsx
@@ -107,9 +107,7 @@ export function HighlightsDemo() {
         </div>
         <div className="hd-row">
           <span className="hd-key">highlights</span>
-          <span className="hd-val">
-            {highlights.length ? JSON.stringify(highlights, null, 2) : "[]"}
-          </span>
+          <span className="hd-val">{highlights.length ? JSON.stringify(highlights) : "[]"}</span>
         </div>
         <div className="hd-row">
           <span className="hd-key">activeHighlightId</span>
@@ -135,7 +133,7 @@ export function HighlightsDemo() {
            unreadable on the dark canvas). The .cm-editor scope wins over Paper's
            theme rule on specificity. Active is the stronger tone. */
         .hd-paper .cm-editor .cm-annotation-highlight {
-          background-color: #fff3b0;
+          background-color: #ffe066;
           color: #232a35;
         }
         .hd-paper .cm-editor .cm-annotation-active {

--- a/sites/paper/src/components/highlights-demo.tsx
+++ b/sites/paper/src/components/highlights-demo.tsx
@@ -1,5 +1,4 @@
-import type { Anchor } from "@beaket/paper";
-import { Paper, type SelectionInfo } from "@beaket/paper/react";
+import { Paper, type HighlightInput, type SelectionInfo } from "@beaket/paper/react";
 import { useRef, useState } from "react";
 
 const SEED = `# Annotating with Paper
@@ -10,24 +9,17 @@ click the highlight to make it active. The editor only reports the
 selection; you draw the toolbar and own the list.
 `;
 
-/** What we keep per highlight. \`anchor\` is opaque — Paper hands it to us and we
- *  hand it back; \`quote\` is ours, just for the data panel below. */
-interface Stored {
-  id: string;
-  anchor: Anchor;
-  quote: string;
-}
-
 export function HighlightsDemo() {
   const [sel, setSel] = useState<SelectionInfo | null>(null);
-  const [stored, setStored] = useState<Stored[]>([]);
+  // Exactly what the prop wants: { id, anchor }. We store it verbatim and hand it back.
+  const [highlights, setHighlights] = useState<HighlightInput[]>([]);
   const [activeId, setActiveId] = useState<string | null>(null);
   const nextId = useRef(1);
 
   const saveHighlight = () => {
     if (!sel) return;
     const id = `h${nextId.current++}`;
-    setStored((list) => [...list, { id, anchor: sel.anchor, quote: sel.text }]);
+    setHighlights((list) => [...list, { id, anchor: sel.anchor }]);
     setSel(null); // selection consumed — hide the toolbar
   };
 
@@ -52,29 +44,28 @@ export function HighlightsDemo() {
       <div className="hd-paper">
         <Paper
           defaultValue={SEED}
-          highlights={stored.map((h) => ({ id: h.id, anchor: h.anchor }))}
+          highlights={highlights}
           activeHighlightId={activeId}
           onSelect={setSel}
           onHighlightClick={setActiveId}
         />
       </div>
 
+      {/* The actual data each surface deals in — the contract, not a friendly label. */}
       <div className="hd-panel">
         <div className="hd-row">
-          <span className="hd-key">selection</span>
-          <span className="hd-val">{sel?.text ? `"${sel.text}"` : "—"}</span>
+          <span className="hd-key">onSelect</span>
+          <span className="hd-val">{sel ? formatSelection(sel) : "null"}</span>
         </div>
         <div className="hd-row">
           <span className="hd-key">highlights</span>
           <span className="hd-val">
-            {stored.length
-              ? `[ ${stored.map((h) => `${h.id}: "${truncate(h.quote)}"`).join(", ")} ]`
-              : "[]"}
+            {highlights.length ? JSON.stringify(highlights, null, 2) : "[]"}
           </span>
         </div>
         <div className="hd-row">
-          <span className="hd-key">active</span>
-          <span className="hd-val">{activeId ?? "null"}</span>
+          <span className="hd-key">activeHighlightId</span>
+          <span className="hd-val">{activeId ? `"${activeId}"` : "null"}</span>
         </div>
       </div>
 
@@ -113,18 +104,28 @@ export function HighlightsDemo() {
           font-size: 12px;
           line-height: 1.7;
         }
-        .hd-row { display: flex; gap: 0.75rem; }
+        .hd-row { display: flex; gap: 0.75rem; align-items: flex-start; }
+        .hd-row + .hd-row { margin-top: 0.35rem; }
         .hd-key {
           flex-shrink: 0;
-          width: 5.5rem;
+          width: 8.5rem;
           color: var(--steel, #686b6f);
         }
-        .hd-val { color: var(--ink); word-break: break-word; min-width: 0; }
+        .hd-val {
+          color: var(--ink);
+          white-space: pre-wrap;
+          word-break: break-word;
+          min-width: 0;
+        }
       `}</style>
     </div>
   );
 }
 
-function truncate(s: string, n = 24) {
-  return s.length > n ? `${s.slice(0, n)}…` : s;
+/** A compact one-liner of the onSelect payload — the readable text plus the
+ *  viewport rect you'd position UI from (anchor is shown once it's stored). */
+function formatSelection(sel: SelectionInfo) {
+  const r = sel.rect;
+  const rect = r ? `, rect: { left: ${Math.round(r.left)}, top: ${Math.round(r.top)} }` : "";
+  return `{ text: ${JSON.stringify(sel.text)}${rect} }`;
 }

--- a/sites/paper/src/components/highlights-demo.tsx
+++ b/sites/paper/src/components/highlights-demo.tsx
@@ -126,6 +126,22 @@ export function HighlightsDemo() {
           padding: 1rem 1.25rem;
           min-height: 190px;
         }
+        /* Recolor the highlight marks to a highlighter yellow so they read as
+           highlights at a glance. We target the mark classes directly rather
+           than Paper's --accent-weak / --accent-sel tokens, because those are
+           shared with the slash menu + table selection (overriding them would
+           tint those yellow too). Opaque fill + dark ink keeps the text legible
+           in BOTH light and dark mode (a translucent tint leaves white text
+           unreadable on the dark canvas). The .cm-editor scope wins over Paper's
+           theme rule on specificity. Active is the stronger tone. */
+        .hd-paper .cm-editor .cm-annotation-highlight {
+          background-color: #fff3b0;
+          color: #232a35;
+        }
+        .hd-paper .cm-editor .cm-annotation-active {
+          background-color: #ffd60a;
+          color: #232a35;
+        }
         .hd-toolbar {
           position: fixed;
           z-index: 10;

--- a/sites/paper/src/components/highlights-demo.tsx
+++ b/sites/paper/src/components/highlights-demo.tsx
@@ -1,0 +1,130 @@
+import type { Anchor } from "@beaket/paper";
+import { Paper, type SelectionInfo } from "@beaket/paper/react";
+import { useRef, useState } from "react";
+
+const SEED = `# Annotating with Paper
+
+Select any sentence in this paragraph and a small toolbar appears at the
+selection. Hit **Highlight** and the range is stored as an anchor — then
+click the highlight to make it active. The editor only reports the
+selection; you draw the toolbar and own the list.
+`;
+
+/** What we keep per highlight. \`anchor\` is opaque — Paper hands it to us and we
+ *  hand it back; \`quote\` is ours, just for the data panel below. */
+interface Stored {
+  id: string;
+  anchor: Anchor;
+  quote: string;
+}
+
+export function HighlightsDemo() {
+  const [sel, setSel] = useState<SelectionInfo | null>(null);
+  const [stored, setStored] = useState<Stored[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const nextId = useRef(1);
+
+  const saveHighlight = () => {
+    if (!sel) return;
+    const id = `h${nextId.current++}`;
+    setStored((list) => [...list, { id, anchor: sel.anchor, quote: sel.text }]);
+    setSel(null); // selection consumed — hide the toolbar
+  };
+
+  // sel.rect is viewport-relative (from view.coordsAtPos), so position: fixed.
+  const toolbar =
+    sel && sel.rect ? (
+      <div className="hd-toolbar" style={{ left: sel.rect.left, top: sel.rect.top - 38 }}>
+        <button
+          type="button"
+          className="hd-tool-btn"
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={saveHighlight}
+        >
+          Highlight
+        </button>
+      </div>
+    ) : null;
+
+  return (
+    <div className="hd-root">
+      {toolbar}
+      <div className="hd-paper">
+        <Paper
+          defaultValue={SEED}
+          highlights={stored.map((h) => ({ id: h.id, anchor: h.anchor }))}
+          activeHighlightId={activeId}
+          onSelect={setSel}
+          onHighlightClick={setActiveId}
+        />
+      </div>
+
+      <div className="hd-panel">
+        <div className="hd-row">
+          <span className="hd-key">selection</span>
+          <span className="hd-val">{sel?.text ? `"${sel.text}"` : "—"}</span>
+        </div>
+        <div className="hd-row">
+          <span className="hd-key">highlights</span>
+          <span className="hd-val">
+            {stored.length
+              ? `[ ${stored.map((h) => `${h.id}: "${truncate(h.quote)}"`).join(", ")} ]`
+              : "[]"}
+          </span>
+        </div>
+        <div className="hd-row">
+          <span className="hd-key">active</span>
+          <span className="hd-val">{activeId ?? "null"}</span>
+        </div>
+      </div>
+
+      <style>{`
+        .hd-root { position: relative; }
+        .hd-paper {
+          background: var(--beaket-paper-paper, var(--paper, #fff));
+          border: 1px solid var(--chrome);
+          box-shadow: var(--shadow-offset, 2px 2px 0 0 var(--chrome));
+          padding: 1rem 1.25rem;
+          min-height: 190px;
+        }
+        .hd-toolbar {
+          position: fixed;
+          z-index: 10;
+          transform: translateX(-50%);
+        }
+        .hd-tool-btn {
+          font: inherit;
+          font-size: 12px;
+          font-weight: 600;
+          padding: 0.3rem 0.7rem;
+          color: var(--paper);
+          background: var(--ink);
+          border: 1px solid var(--ink);
+          box-shadow: var(--shadow-offset, 2px 2px 0 0 var(--chrome));
+          cursor: pointer;
+          white-space: nowrap;
+        }
+        .hd-panel {
+          margin-top: 0.85rem;
+          padding: 0.75rem 0.9rem;
+          background: var(--frost, #f3f4f6);
+          border: 1px solid var(--chrome);
+          font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, monospace;
+          font-size: 12px;
+          line-height: 1.7;
+        }
+        .hd-row { display: flex; gap: 0.75rem; }
+        .hd-key {
+          flex-shrink: 0;
+          width: 5.5rem;
+          color: var(--steel, #686b6f);
+        }
+        .hd-val { color: var(--ink); word-break: break-word; min-width: 0; }
+      `}</style>
+    </div>
+  );
+}
+
+function truncate(s: string, n = 24) {
+  return s.length > n ? `${s.slice(0, n)}…` : s;
+}

--- a/sites/paper/src/components/highlights-demo.tsx
+++ b/sites/paper/src/components/highlights-demo.tsx
@@ -1,5 +1,10 @@
-import { Paper, type HighlightInput, type SelectionInfo } from "@beaket/paper/react";
-import { useRef, useState } from "react";
+import {
+  Paper,
+  type HighlightInput,
+  type PaperHandle,
+  type SelectionInfo,
+} from "@beaket/paper/react";
+import { useEffect, useRef, useState } from "react";
 
 const SEED = `# Annotating with Paper
 
@@ -9,12 +14,22 @@ click the highlight to make it active. The editor only reports the
 selection; you draw the toolbar and own the list.
 `;
 
+// Start in the end-state: one highlight already stored and active, so the
+// rendered mark + populated data panel are visible before you touch anything.
+// The anchor is just { quote, offset } — quote is plain source text, offset
+// computed so it resolves exactly. (Re-resolution matches by quote anyway.)
+const SEED_QUOTE = "the range is stored as an anchor";
+const INITIAL_HIGHLIGHTS: HighlightInput[] = [
+  { id: "h1", anchor: { quote: SEED_QUOTE, offset: SEED.indexOf(SEED_QUOTE) } },
+];
+
 export function HighlightsDemo() {
+  const paperRef = useRef<PaperHandle>(null);
   const [sel, setSel] = useState<SelectionInfo | null>(null);
   // Exactly what the prop wants: { id, anchor }. We store it verbatim and hand it back.
-  const [highlights, setHighlights] = useState<HighlightInput[]>([]);
-  const [activeId, setActiveId] = useState<string | null>(null);
-  const nextId = useRef(1);
+  const [highlights, setHighlights] = useState<HighlightInput[]>(INITIAL_HIGHLIGHTS);
+  const [activeId, setActiveId] = useState<string | null>("h1");
+  const nextId = useRef(2);
 
   const saveHighlight = () => {
     if (!sel) return;
@@ -23,7 +38,39 @@ export function HighlightsDemo() {
     setSel(null); // selection consumed — hide the toolbar
   };
 
-  // sel.rect is viewport-relative (from view.coordsAtPos), so position: fixed.
+  // rect is captured once at selection time and is viewport-relative, so a
+  // position:fixed toolbar drifts off the text on scroll/resize. Re-read the
+  // live selection coords from the view to keep it pinned (and close it if the
+  // selection collapsed). Depend on `hasSel` (not `sel`) so we don't resubscribe
+  // every reposition frame.
+  const hasSel = sel !== null;
+  useEffect(() => {
+    if (!hasSel) return;
+    const reposition = () => {
+      const view = paperRef.current?.getView();
+      if (!view) return;
+      const main = view.state.selection.main;
+      if (main.empty) {
+        setSel(null);
+        return;
+      }
+      const c = view.coordsAtPos(main.head);
+      if (c) {
+        setSel((prev) =>
+          prev
+            ? { ...prev, rect: { left: c.left, top: c.top, right: c.right, bottom: c.bottom } }
+            : prev,
+        );
+      }
+    };
+    window.addEventListener("scroll", reposition, true);
+    window.addEventListener("resize", reposition);
+    return () => {
+      window.removeEventListener("scroll", reposition, true);
+      window.removeEventListener("resize", reposition);
+    };
+  }, [hasSel]);
+
   const toolbar =
     sel && sel.rect ? (
       <div className="hd-toolbar" style={{ left: sel.rect.left, top: sel.rect.top - 38 }}>
@@ -43,6 +90,7 @@ export function HighlightsDemo() {
       {toolbar}
       <div className="hd-paper">
         <Paper
+          ref={paperRef}
           defaultValue={SEED}
           highlights={highlights}
           activeHighlightId={activeId}

--- a/sites/paper/src/pages/api.astro
+++ b/sites/paper/src/pages/api.astro
@@ -39,12 +39,12 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
   </table>
 
   <h2 id="core">Core <code>createEditor(parent, options)</code></h2>
-  <p>The vanilla core takes the mount element and an <code>EditorOptions</code> object, returning the CodeMirror <code>EditorView</code>. The React props above map onto these (minus the React-specific <code>highlights</code> / <code>activeHighlightId</code> / <code>className</code> wiring):</p>
+  <p>The vanilla core takes the mount element and an <code>EditorOptions</code> object, returning the CodeMirror <code>EditorView</code>. These options are the editor's own surface; <code>highlights</code>, <code>activeHighlightId</code>, and <code>className</code> are React-wrapper additions, not core options:</p>
   <table>
     <thead><tr><th>Option</th><th>Type</th><th>Notes</th></tr></thead>
     <tbody>
-      <tr><td><code>doc</code></td><td><code>string</code></td><td>Initial markdown (the core's name for <code>defaultValue</code>). Empty if omitted.</td></tr>
-      <tr><td><code>onChange</code></td><td><code>(value: string) =&gt; void</code></td><td>Same contract as the React prop.</td></tr>
+      <tr><td><code>doc</code></td><td><code>string</code></td><td>Initial markdown document. Empty if omitted. (The React wrapper exposes this as <code>defaultValue</code>.)</td></tr>
+      <tr><td><code>onChange</code></td><td><code>(value: string) =&gt; void</code></td><td>Same contract as in the props table above.</td></tr>
       <tr><td><code>onInsertImage</code></td><td><code>ImageResolver</code></td><td>Image placement resolver.</td></tr>
       <tr><td><code>slashItems</code></td><td><code>SlashItemsConfig</code></td><td>Slash-menu customization.</td></tr>
       <tr><td><code>onSelect</code></td><td><code>(sel: SelectionInfo | null) =&gt; void</code></td><td>Selection report.</td></tr>

--- a/sites/paper/src/pages/installation.astro
+++ b/sites/paper/src/pages/installation.astro
@@ -34,10 +34,12 @@ npm install react react-dom`;
 
   <p>The core itself has no peer dependencies — it bundles its CodeMirror 6 engine.</p>
 
-  <blockquote>
-    Paper is <strong>ESM-only</strong> (no CommonJS build). Use it from an ESM project or a bundler
-    (Vite, Next.js, Remix, etc.) — a bare CommonJS <code>require()</code> won't resolve it.
-  </blockquote>
+  <p class="callout callout-note">
+    <svg class="callout-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z" />
+    </svg>
+    <span><strong>Note</strong> — Paper is ESM-only (no CommonJS build). Use it from an ESM project or a bundler (Vite, Next.js, Remix, etc.) — a bare CommonJS <code>require()</code> won't resolve it.</span>
+  </p>
 
   <p class="next"><a href={withBase('usage')}>Usage →</a></p>
 </Base>

--- a/sites/paper/src/pages/styling.astro
+++ b/sites/paper/src/pages/styling.astro
@@ -29,10 +29,12 @@ const cssCode = `.my-editor-wrapper {
     specificity fights:
   </p>
   <CodeBlock code={cssCode} lang="css" />
-  <blockquote>
-    <code>letter-spacing</code> is intentionally <strong>not</strong> exposed — negative spacing breaks
-    mixed-script CJK, so it is fixed at <code>0</code> (a CJK-first guard).
-  </blockquote>
+  <p class="callout callout-note">
+    <svg class="callout-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z" />
+    </svg>
+    <span><strong>Note</strong> — <code>letter-spacing</code> is intentionally not exposed: negative spacing breaks mixed-script CJK, so it is fixed at <code>0</code> (a CJK-first guard).</span>
+  </p>
 
   <h2 id="bridge">Design-token bridge</h2>
   <p>
@@ -46,7 +48,7 @@ const cssCode = `.my-editor-wrapper {
   <p>
     The editor follows the OS <code>prefers-color-scheme</code> automatically — no setup, no class to
     toggle. Every token carries a dark-aware default, so body text, surfaces, and the code-syntax ramp
-    all flip together (the dark ramp mirrors GitHub Dark Default).
+    all flip together.
   </p>
   <p>
     Theming still wins in both modes: a token you set on <code>:root</code> or an ancestor —

--- a/sites/paper/src/pages/usage.astro
+++ b/sites/paper/src/pages/usage.astro
@@ -66,6 +66,7 @@ function Annotator() {
   <h1>Usage</h1>
 
   <h2 id="react">React</h2>
+  <p>The wrapper is the quickest way in — render <code>&lt;Paper&gt;</code> and read edits from <code>onChange</code>:</p>
   <CodeBlock code={reactCode} lang="tsx" />
   <p>
     The editor is <strong>uncontrolled</strong>: pass <code>defaultValue</code> for the initial

--- a/sites/paper/src/pages/usage.astro
+++ b/sites/paper/src/pages/usage.astro
@@ -90,8 +90,8 @@ function Annotator() {
     or <code>null</code> when empty — and renders a <code>highlights</code> list you own. It draws no toolbar
     of its own: you place UI from <code>rect</code> and persist the opaque <code>anchor</code>.
   </p>
-  <p class="tip">
-    <svg class="tip-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+  <p class="callout callout-tip">
+    <svg class="callout-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
       <path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863.5 8 .5s5.5 1.81 5.5 4.75c0 1.516-.701 2.5-1.318 3.282-.095.115-.184.22-.268.32-.207.245-.383.453-.541.68-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z" />
     </svg>
     <span><strong>Tip</strong> — drag a sentence in the editor below to watch the whole loop: select → a toolbar appears → save → click the highlight to activate it.</span>
@@ -124,31 +124,5 @@ function Annotator() {
 <style>
   .demo {
     margin: 1.25rem 0;
-  }
-  /* GitHub-style "Tip" admonition: green accent, icon + label, left rule. */
-  .tip {
-    --tip: #1a7f37;
-    display: flex;
-    gap: 0.55rem;
-    margin: 1.25rem 0;
-    padding: 0.7rem 0.95rem;
-    border: 1px solid color-mix(in srgb, var(--tip) 35%, var(--chrome));
-    border-left: 3px solid var(--tip);
-    background: color-mix(in srgb, var(--tip) 7%, var(--paper));
-    color: var(--slate);
-    font-size: 14px;
-  }
-  .tip-icon {
-    flex-shrink: 0;
-    margin-top: 3px;
-    color: var(--tip);
-  }
-  .tip strong {
-    color: var(--tip);
-  }
-  @media (prefers-color-scheme: dark) {
-    .tip {
-      --tip: #3fb950;
-    }
   }
 </style>

--- a/sites/paper/src/pages/usage.astro
+++ b/sites/paper/src/pages/usage.astro
@@ -87,8 +87,13 @@ function Annotator() {
   <p>
     Paper reports the live selection through <code>onSelect</code> — <code>&#123; text, anchor, rect &#125;</code>,
     or <code>null</code> when empty — and renders a <code>highlights</code> list you own. It draws no toolbar
-    of its own: you place UI from <code>rect</code> and persist the opaque <code>anchor</code>. Drag a
-    sentence below to watch the whole loop.
+    of its own: you place UI from <code>rect</code> and persist the opaque <code>anchor</code>.
+  </p>
+  <p class="tip">
+    <svg class="tip-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863.5 8 .5s5.5 1.81 5.5 4.75c0 1.516-.701 2.5-1.318 3.282-.095.115-.184.22-.268.32-.207.245-.383.453-.541.68-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z" />
+    </svg>
+    <span><strong>Tip</strong> — drag a sentence in the editor below to watch the whole loop: select → a toolbar appears → save → click the highlight to activate it.</span>
   </p>
   <div class="demo">
     <HighlightsDemo client:only="react" />
@@ -118,5 +123,31 @@ function Annotator() {
 <style>
   .demo {
     margin: 1.25rem 0;
+  }
+  /* GitHub-style "Tip" admonition: green accent, icon + label, left rule. */
+  .tip {
+    --tip: #1a7f37;
+    display: flex;
+    gap: 0.55rem;
+    margin: 1.25rem 0;
+    padding: 0.7rem 0.95rem;
+    border: 1px solid color-mix(in srgb, var(--tip) 35%, var(--chrome));
+    border-left: 3px solid var(--tip);
+    background: color-mix(in srgb, var(--tip) 7%, var(--paper));
+    color: var(--slate);
+    font-size: 14px;
+  }
+  .tip-icon {
+    flex-shrink: 0;
+    margin-top: 3px;
+    color: var(--tip);
+  }
+  .tip strong {
+    color: var(--tip);
+  }
+  @media (prefers-color-scheme: dark) {
+    .tip {
+      --tip: #3fb950;
+    }
   }
 </style>

--- a/sites/paper/src/pages/usage.astro
+++ b/sites/paper/src/pages/usage.astro
@@ -1,6 +1,7 @@
 ---
 import Base from '../layouts/base.astro';
 import CodeBlock from '../components/code-block.astro';
+import { HighlightsDemo } from '../components/highlights-demo';
 const base = import.meta.env.BASE_URL;
 const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p);
 
@@ -31,6 +32,34 @@ const editor = createEditor(document.querySelector("#editor")!, {
   doc: "# Hello",
   onChange: (markdown) => console.log(markdown),
 });`;
+
+const highlightsCode = `import { Paper, type SelectionInfo, type HighlightInput } from "@beaket/paper/react";
+import { useState } from "react";
+
+function Annotator() {
+  const [sel, setSel] = useState<SelectionInfo | null>(null);
+  const [highlights, setHighlights] = useState<HighlightInput[]>([]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  return (
+    <>
+      {/* Paper reports the selection; you draw the toolbar from sel.rect. */}
+      {sel?.rect && (
+        <Toolbar rect={sel.rect} onPick={() => {
+          setHighlights((hs) => [...hs, { id: crypto.randomUUID(), anchor: sel.anchor }]);
+          setSel(null); // selection consumed
+        }} />
+      )}
+
+      <Paper
+        highlights={highlights}          // live prop — re-resolved on change (IME-safe)
+        activeHighlightId={activeId}     // live prop — declarative visual sync
+        onSelect={setSel}                // { text, anchor, rect } | null
+        onHighlightClick={setActiveId}   // a highlight was clicked
+      />
+    </>
+  );
+}`;
 ---
 
 <Base title="Usage — Paper">
@@ -54,6 +83,25 @@ const editor = createEditor(document.querySelector("#editor")!, {
     <a href={withBase('api')}>API Reference</a> for the full prop and handle surface.
   </p>
 
+  <h2 id="highlights">Selections &amp; highlights</h2>
+  <p>
+    Paper reports the live selection through <code>onSelect</code> — <code>&#123; text, anchor, rect &#125;</code>,
+    or <code>null</code> when empty — and renders a <code>highlights</code> list you own. It draws no toolbar
+    of its own: you place UI from <code>rect</code> and persist the opaque <code>anchor</code>. Drag a
+    sentence below to watch the whole loop.
+  </p>
+  <div class="demo">
+    <HighlightsDemo client:only="react" />
+  </div>
+  <CodeBlock code={highlightsCode} lang="tsx" />
+  <p>
+    The <code>anchor</code> from <code>onSelect</code> is built for exactly this — store it in
+    <code>highlights</code> and Paper re-resolves it against the document (deferred during IME) on every
+    change, while <code>activeHighlightId</code> syncs the visual emphasis declaratively. The full demo
+    component (toolbar positioning, state) is on
+    <a href="https://github.com/beaket/ui/blob/main/sites/paper/src/components/highlights-demo.tsx">GitHub ↗</a>.
+  </p>
+
   <h2 id="core">Framework-agnostic core</h2>
   <p>The core has zero React. Mount it onto any element and it returns the CodeMirror <code>EditorView</code>:</p>
   <CodeBlock code={coreCode} lang="ts" />
@@ -66,3 +114,9 @@ const editor = createEditor(document.querySelector("#editor")!, {
 
   <p class="next"><a href={withBase('api')}>API Reference →</a></p>
 </Base>
+
+<style>
+  .demo {
+    margin: 1.25rem 0;
+  }
+</style>

--- a/sites/paper/src/pages/usage.astro
+++ b/sites/paper/src/pages/usage.astro
@@ -112,10 +112,10 @@ function Annotator() {
   <p>The core has zero React. Mount it onto any element and it returns the CodeMirror <code>EditorView</code>:</p>
   <CodeBlock code={coreCode} lang="ts" />
   <p>
-    The core takes <code>doc</code> where the React wrapper takes <code>defaultValue</code>; the
-    callback options (<code>onChange</code>, <code>onSelect</code>, <code>onInsertImage</code>,
-    <code>slashItems</code>) are shared. The React-only props (<code>highlights</code>,
-    <code>activeHighlightId</code>, <code>className</code>) are wiring on top of the core surface.
+    It takes the initial document as <code>doc</code>, plus the options the editor accepts anywhere —
+    <code>onChange</code>, <code>onSelect</code>, <code>onInsertImage</code>, <code>slashItems</code>.
+    Highlights are driven imperatively here, via <code>setHighlightsEffect</code> and
+    <code>setActiveHighlightEffect</code>. The React wrapper is thin wiring over exactly this surface.
   </p>
 
   <p class="next"><a href={withBase('api')}>API Reference →</a></p>

--- a/sites/paper/src/styles/global.css
+++ b/sites/paper/src/styles/global.css
@@ -270,6 +270,40 @@ blockquote {
   background: var(--frost);
   color: var(--slate);
 }
+
+/* Admonition callouts (GitHub-style), shared across pages for consistency.
+   Type → color: tip = green, note = blue (the site accent, already dark-aware). */
+.callout {
+  display: flex;
+  gap: 0.55rem;
+  margin: 1.25rem 0;
+  padding: 0.7rem 0.95rem;
+  border: 1px solid color-mix(in srgb, var(--callout) 35%, var(--chrome));
+  border-left: 3px solid var(--callout);
+  background: color-mix(in srgb, var(--callout) 7%, var(--paper));
+  color: var(--slate);
+  font-size: 14px;
+}
+.callout-icon {
+  flex-shrink: 0;
+  margin-top: 3px;
+  color: var(--callout);
+}
+.callout strong {
+  color: var(--callout);
+}
+.callout-tip {
+  --callout: #1a7f37;
+}
+.callout-note {
+  --callout: var(--accent);
+}
+@media (prefers-color-scheme: dark) {
+  .callout-tip {
+    --callout: #3fb950;
+  }
+}
+
 table {
   border-collapse: collapse;
   width: 100%;


### PR DESCRIPTION
## Why

`onSelect` / `highlights` is the one part of Paper a code snippet can't convey. The editor only **reports** the selection (`{ text, anchor, rect }`) and renders a `highlights` list — the host draws the toolbar and owns persistence. As code, "what actually happens when I drag?" stays unanswered.

## What

New **"Selections & highlights"** section on the Usage page (placed between the React and core sections, since `highlights` is a React-only prop), with a live demo that runs the whole loop:

```
drag a sentence
  → onSelect { text, anchor, rect }
  → a [Highlight] toolbar appears at rect   (host-drawn — Paper draws nothing)
  → click it → anchor pushed to `highlights` → rendered
  → click the highlight → onHighlightClick → activeHighlightId
```

A small **data panel** under the editor shows the live `selection`, the `highlights` array, and the `active` id — so the *"editor reports data, you draw the UI"* contract is **visible**, not just described.

The page shows a **trimmed** version of the wiring (toolbar positioning elided); the full self-contained component is `highlights-demo.tsx`, linked from the section.

## Verified

- Live loop exercised in-browser: select → toolbar → save (highlight rendered, `highlights [ h1: … ]`) → click highlight (`active h1`). All panel states correct.
- `pnpm build` clean — all 5 pages build, including `/usage`.

No changeset — docs-site-only (`sites/paper/`), nothing published to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)