### PR TITLE
feat(paper): add colorScheme prop + light/dark demo toggle

### DIFF
--- a/.changeset/paper-color-scheme-prop.md
+++ b/.changeset/paper-color-scheme-prop.md
@@ -1,0 +1,5 @@
+---
+"@beaket/paper": minor
+---
+
+Add a `colorScheme` prop (`"light" | "dark" | "system"`). Previously the editor only followed the OS `prefers-color-scheme`; now a consumer with its own theme toggle can force light or dark. It's a live prop — flipped via a CodeMirror compartment, so switching never recreates the editor or drops the document. The vanilla core exposes the same `colorScheme` option plus a `setColorScheme(view, scheme)` helper. `"system"` remains the default, so existing usage is unchanged.

--- a/packages/paper/src/editor/create-editor.ts
+++ b/packages/paper/src/editor/create-editor.ts
@@ -23,7 +23,7 @@ import type { SlashItemsConfig } from "./extensions/slash-command";
 import { slashCommand } from "./extensions/slash-command";
 import { tableAutoConvert } from "./extensions/table-auto-convert";
 import { tableWidget } from "./extensions/table-widget";
-import { baseTheme, darkThemeStyle } from "./theme";
+import { baseTheme, type ColorScheme, darkThemeStyle } from "./theme";
 export { defaultSlashItems } from "./extensions/slash-command";
 export type { SlashItemsConfig, SlashItemSpec } from "./extensions/slash-command";
 
@@ -61,6 +61,11 @@ export interface EditorOptions {
    * The consumer draws the floating action button from rect. Held during IME composition, fired after it settles.
    */
   onSelect?: (sel: SelectionInfo | null) => void;
+  /**
+   * Light/dark scheme. "system" (default) follows the OS `prefers-color-scheme`; "light"/"dark" force
+   * the scheme regardless of OS. Live-flippable via `setColorScheme(view, …)` without recreating the editor.
+   */
+  colorScheme?: ColorScheme;
 }
 
 /** The full extension set of the production editor — tests use this as-is too */
@@ -70,7 +75,7 @@ export function editorExtensions(opts: EditorOptions = {}): Extension[] {
     keymap.of([...defaultKeymap, ...historyKeymap]),
     EditorView.lineWrapping,
     baseTheme,
-    darkThemeStyle(),
+    darkThemeStyle(opts.colorScheme),
     markdownExtension(),
     inlineSyntaxHiding(),
     blockSyntaxHiding(),

--- a/packages/paper/src/editor/theme.test.ts
+++ b/packages/paper/src/editor/theme.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { darkThemeCss, darkTokens, tokens } from "./theme";
+import { colorSchemeClass, darkThemeCss, darkTokens, tokens } from "./theme";
 
 // Token reconciliation + public theming contract (ADR-0013 decision 6).
 //
@@ -143,5 +143,28 @@ describe("darkThemeCss emits a scoped prefers-color-scheme block", () => {
       expect(css).toContain(`${name}: ${value};`);
     }
     expect(css).toContain("--ink: var(--beaket-paper-ink, var(--color-ink, #e6eaee));");
+  });
+
+  // colorScheme "dark" forces dark regardless of OS, so the same tokens also ship in an
+  // unconditional block keyed on a second class — the only thing the scheme flips is which class
+  // the editor root wears (a live compartment swap), not the stylesheet.
+  it("also emits an unconditional forced-dark block (outside the media query)", () => {
+    const forced = css.slice(css.indexOf("}}") + 2); // everything after the media block closes
+    expect(forced).toContain(".cm-editor.cm-beaket-paper-dark{");
+    expect(forced).not.toContain("@media");
+    for (const [name, value] of Object.entries(darkTokens)) {
+      expect(forced).toContain(`${name}: ${value};`);
+    }
+  });
+});
+
+// colorScheme → root class is the branch that decides which token block each mode wears (the
+// stylesheet above is static). "system" follows the OS (media-gated class), "dark" forces the
+// unconditional block, "light" wears no class so even the OS media block can't darken it.
+describe("colorSchemeClass selects the editor-root class per scheme", () => {
+  it("maps system → OS-follow class, dark → forced class, light → none", () => {
+    expect(colorSchemeClass("system")).toBe("cm-beaket-paper");
+    expect(colorSchemeClass("dark")).toBe("cm-beaket-paper-dark");
+    expect(colorSchemeClass("light")).toBe("");
   });
 });

--- a/packages/paper/src/editor/theme.ts
+++ b/packages/paper/src/editor/theme.ts
@@ -1,4 +1,4 @@
-import type { Extension } from "@codemirror/state";
+import { Compartment, type Extension } from "@codemirror/state";
 import { EditorView, ViewPlugin } from "@codemirror/view";
 
 // CJK tier-1 typography default. Japanese fonts are placed BEFORE Korean fonts (key): Apple SD
@@ -180,25 +180,65 @@ export const baseTheme = EditorView.theme({
 // targets `.cm-editor.<scope>`. Two classes = specificity (0,2,0), which outranks baseTheme's single
 // generated class (0,1,0) — so in dark mode these tokens win regardless of source order, while the
 // `--beaket-paper-*` override and `--color-*` porcelain bridge inside each var() chain still apply.
-const DARK_SCOPE_CLASS = "cm-beaket-paper";
+// Color scheme as a public prop (`colorScheme` on EditorOptions/PaperProps):
+// - "system" (default) → follow the OS via `prefers-color-scheme` (the original behavior).
+// - "dark"            → force dark regardless of OS.
+// - "light"           → force light regardless of OS (suppress the OS dark block).
+// The injected stylesheet carries BOTH a media-gated block (keyed on DARK_SCOPE_CLASS) and an
+// unconditional forced-dark block (keyed on DARK_FORCE_CLASS). The scheme only decides which scope
+// class the editor root wears — so flipping it is a single live class swap (`setColorScheme`), no
+// recreation. "light" wears neither class, so even the OS media block can't match it.
+export type ColorScheme = "light" | "dark" | "system";
+
+const DARK_SCOPE_CLASS = "cm-beaket-paper"; // OS-follow: only goes dark inside the media query
+const DARK_FORCE_CLASS = "cm-beaket-paper-dark"; // forced dark: unconditional
 const DARK_STYLE_ID = "beaket-paper-dark-tokens";
 
-/** Serializes `darkTokens` into the scoped dark-mode stylesheet text. Exported for the wiring test. */
+/** Maps a color scheme to the editor-root class that selects its token block (empty = forced light). */
+export function colorSchemeClass(scheme: ColorScheme): string {
+  if (scheme === "dark") return DARK_FORCE_CLASS;
+  if (scheme === "light") return "";
+  return DARK_SCOPE_CLASS;
+}
+
+/**
+ * Serializes `darkTokens` into the dark-mode stylesheet text. Exported for the wiring test.
+ * Emits the OS-follow block (media-gated) and the forced-dark block (unconditional) from one source.
+ */
 export function darkThemeCss(): string {
   const decls = Object.entries(darkTokens)
     .map(([name, value]) => `${name}: ${value};`)
     .join(" ");
-  return `@media (prefers-color-scheme: dark){.cm-editor.${DARK_SCOPE_CLASS}{${decls}}}`;
+  return (
+    `@media (prefers-color-scheme: dark){.cm-editor.${DARK_SCOPE_CLASS}{${decls}}}` +
+    `.cm-editor.${DARK_FORCE_CLASS}{${decls}}`
+  );
+}
+
+// The scope class lives in a compartment so `colorScheme` can flip live (no editor recreation, which
+// would wipe the user's document). Module-level: a Compartment is just an identity key, and a
+// reconfigure dispatched to a specific view only touches that view's slot — safe across many editors.
+const colorSchemeCompartment = new Compartment();
+
+function colorSchemeAttr(scheme: ColorScheme): Extension {
+  const cls = colorSchemeClass(scheme);
+  // Drive native `color-scheme` too, so scrollbars/inputs inside the editor match the active scheme
+  // (a forced-light editor on a dark OS would otherwise get dark native scrollbars, and vice versa).
+  // "system" → "light dark" follows the OS, matching the media-gated token block.
+  const attrs: Record<string, string> = {
+    style: `color-scheme: ${scheme === "system" ? "light dark" : scheme};`,
+  };
+  if (cls) attrs.class = cls;
+  return EditorView.editorAttributes.of(attrs);
 }
 
 /**
- * Dark mode. Stamps the scope class on the editor and injects the dark token stylesheet once per
- * document/shadow root (idempotent by id). Self-contained — the consumer flips automatically with the
- * OS color scheme; `--beaket-paper-*` overrides and the porcelain bridge keep working in both modes.
+ * Dark mode. Injects the dark token stylesheet once per document/shadow root (idempotent by id) and
+ * stamps the scope class for `scheme`. Self-contained — `--beaket-paper-*` overrides and the porcelain
+ * bridge keep working in every mode. Default "system" reproduces the original OS-follow behavior.
  */
-export function darkThemeStyle(): Extension {
+export function darkThemeStyle(scheme: ColorScheme = "system"): Extension {
   return [
-    EditorView.editorAttributes.of({ class: DARK_SCOPE_CLASS }),
     ViewPlugin.define((view) => {
       const root = view.dom.getRootNode() as Document | ShadowRoot;
       const host: ParentNode & Node =
@@ -211,5 +251,11 @@ export function darkThemeStyle(): Extension {
       }
       return {};
     }),
+    colorSchemeCompartment.of(colorSchemeAttr(scheme)),
   ];
+}
+
+/** Live-flips the editor's color scheme without recreating it (so the document is preserved). */
+export function setColorScheme(view: EditorView, scheme: ColorScheme): void {
+  view.dispatch({ effects: colorSchemeCompartment.reconfigure(colorSchemeAttr(scheme)) });
 }

--- a/packages/paper/src/index.ts
+++ b/packages/paper/src/index.ts
@@ -2,6 +2,9 @@
 // The framework-agnostic core is the main body. The React wrapper is a separate subpath `./react` (src/react/index.ts).
 export { createEditor, defaultSlashItems } from "./editor/create-editor";
 export type { EditorOptions, SlashItemSpec, SlashItemsConfig } from "./editor/create-editor";
+// Color scheme: the `colorScheme` option plus a live-flip helper (no recreation) for vanilla consumers.
+export { setColorScheme } from "./editor/theme";
+export type { ColorScheme } from "./editor/theme";
 // The `onInsertImage` option/prop type, so consumers can annotate their own resolver.
 export type { ImageResolver } from "./editor/extensions/image-drop";
 // Anchor pure functions (ADR-0014 step A). Vanilla core consumers use these for selection→anchor→re-resolution directly.

--- a/packages/paper/src/react/index.ts
+++ b/packages/paper/src/react/index.ts
@@ -1,6 +1,8 @@
 // `@beaket/paper/react` entry — thin wrapper only (ADR-0013 exports map). React = optional peerDep.
 export { Paper } from "./paper";
 export type { PaperHandle, PaperProps } from "./paper";
+// Color scheme prop type ("light" | "dark" | "system") for the `colorScheme` prop.
+export type { ColorScheme } from "../editor/theme";
 // Re-export the highlight input type (core-owned, ADR-0014).
 export type { Anchor, AnchorStatus } from "../editor/anchor";
 export type { HighlightInput } from "../editor/extensions/highlight-layer";

--- a/packages/paper/src/react/paper.tsx
+++ b/packages/paper/src/react/paper.tsx
@@ -5,6 +5,8 @@ import type { EditorOptions } from "../editor/create-editor";
 import { createEditor } from "../editor/create-editor";
 import type { HighlightController, HighlightInput } from "../editor/extensions/highlight-layer";
 import { createHighlightController } from "../editor/extensions/highlight-layer";
+import type { ColorScheme } from "../editor/theme";
+import { setColorScheme } from "../editor/theme";
 import type { ValueController } from "../editor/value-controller";
 import { createValueController } from "../editor/value-controller";
 
@@ -42,6 +44,8 @@ export interface PaperProps {
   onSelect?: EditorOptions["onSelect"];
   onInsertImage?: EditorOptions["onInsertImage"];
   slashItems?: EditorOptions["slashItems"];
+  /** Light/dark scheme. "system" (default) follows the OS; "light"/"dark" force it. Live prop — flips without recreation. */
+  colorScheme?: ColorScheme;
   className?: string;
 }
 
@@ -56,6 +60,7 @@ export const Paper = forwardRef<PaperHandle, PaperProps>(function Paper(
     onSelect,
     onInsertImage,
     slashItems,
+    colorScheme,
     className,
   },
   ref,
@@ -85,6 +90,7 @@ export const Paper = forwardRef<PaperHandle, PaperProps>(function Paper(
       onSelect: (sel) => onSelectRef.current?.(sel),
       onInsertImage,
       slashItems,
+      colorScheme,
     });
     viewRef.current = view;
     controllerRef.current = createValueController(view);
@@ -111,6 +117,11 @@ export const Paper = forwardRef<PaperHandle, PaperProps>(function Paper(
   useEffect(() => {
     highlightRef.current?.setActiveHighlight(activeHighlightId ?? null);
   }, [activeHighlightId]);
+
+  // colorScheme is a live prop — flipped via a compartment reconfigure (no recreation, document kept).
+  useEffect(() => {
+    if (viewRef.current) setColorScheme(viewRef.current, colorScheme ?? "system");
+  }, [colorScheme]);
 
   useImperativeHandle(
     ref,

--- a/sites/paper/src/components/editor-playground.tsx
+++ b/sites/paper/src/components/editor-playground.tsx
@@ -1,4 +1,4 @@
-import { Paper, type PaperHandle } from "@beaket/paper/react";
+import { type ColorScheme, Paper, type PaperHandle } from "@beaket/paper/react";
 import { useRef, useState } from "react";
 
 const INITIAL = `# Paper
@@ -31,11 +31,18 @@ const FONTS = [
   { name: "Serif", value: "Georgia, 'Times New Roman', serif" },
 ];
 
+const SCHEMES: { name: string; value: ColorScheme }[] = [
+  { name: "Light", value: "light" },
+  { name: "Dark", value: "dark" },
+  { name: "System", value: "system" },
+];
+
 export function EditorPlayground() {
   const ref = useRef<PaperHandle>(null);
   const [markdown, setMarkdown] = useState(INITIAL);
   const [accent, setAccent] = useState(ACCENTS[0].value);
   const [font, setFont] = useState(FONTS[0].value);
+  const [scheme, setScheme] = useState<ColorScheme>("system");
   const [showSource, setShowSource] = useState(false);
 
   // The editor reads its visual tokens from --beaket-paper-* on any ancestor.
@@ -45,7 +52,9 @@ export function EditorPlayground() {
   } as React.CSSProperties;
 
   return (
-    <div style={tokenStyle}>
+    // data-pg-theme darkens the surrounding card/toolbar to match a *forced* editor scheme.
+    // "system" is left unset so the chrome follows the docs page (which already tracks the OS).
+    <div style={tokenStyle} data-pg-theme={scheme === "system" ? undefined : scheme}>
       <div className="pg-toolbar">
         <div className="pg-group">
           <span className="pg-label">Accent</span>
@@ -80,11 +89,25 @@ export function EditorPlayground() {
             </button>
           ))}
         </div>
+        <div className="pg-group">
+          <span className="pg-label">Theme</span>
+          {SCHEMES.map((s) => (
+            <button
+              key={s.value}
+              type="button"
+              className="pg-btn"
+              aria-pressed={scheme === s.value}
+              onClick={() => setScheme(s.value)}
+            >
+              {s.name}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* The editor ships no container chrome — the host supplies the paper card. */}
       <div className="pg-paper">
-        <Paper ref={ref} defaultValue={INITIAL} onChange={setMarkdown} />
+        <Paper ref={ref} defaultValue={INITIAL} onChange={setMarkdown} colorScheme={scheme} />
       </div>
 
       <div className="pg-footer">
@@ -97,6 +120,16 @@ export function EditorPlayground() {
       {showSource && <pre className="pg-source">{markdown}</pre>}
 
       <style>{`
+        /* A *forced* editor scheme overrides the local docs tokens so the card, toolbar, footer and
+           source view track the editor instead of sitting light under a dark editor. Values mirror the
+           docs-site palette in global.css (light :root + the prefers-color-scheme: dark block). The
+           editor paints its own surface from its dark tokens — these only dress the chrome around it. */
+        [data-pg-theme="light"] {
+          --ink: #232a35; --paper: #ffffff; --frost: #f3f4f6; --chrome: #c0c4ca; --steel: #686b6f;
+        }
+        [data-pg-theme="dark"] {
+          --ink: #e8eaec; --paper: #16181c; --frost: #23272e; --chrome: #3e4145; --steel: #9aa0a6;
+        }
         .pg-toolbar {
           display: flex;
           flex-wrap: wrap;

--- a/sites/paper/src/pages/api.astro
+++ b/sites/paper/src/pages/api.astro
@@ -21,6 +21,7 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
       <tr><td><code>onSelect</code></td><td><code>(sel: SelectionInfo | null) =&gt; void</code></td><td>Selection report <code>&#123; text, anchor, rect &#125;</code>, <code>null</code> when empty. Draw a floating toolbar from <code>rect</code>.</td></tr>
       <tr><td><code>onInsertImage</code></td><td><code>ImageResolver</code></td><td>Decides the URL for a dropped/pasted image. Upload/storage is yours. Default: in-session <code>blob:</code> URL.</td></tr>
       <tr><td><code>slashItems</code></td><td><code>SlashItemsConfig</code></td><td>Customize the <code>/</code> menu. Array = full replacement; <code>(defaults) =&gt; items</code> = derive from defaults (recommended).</td></tr>
+      <tr><td><code>colorScheme</code></td><td><code>"light" | "dark" | "system"</code></td><td><strong>Live</strong> prop. <code>"system"</code> (default) follows the OS <code>prefers-color-scheme</code>; <code>"light"</code>/<code>"dark"</code> force the scheme. Flips without recreating the editor, so the document is kept.</td></tr>
       <tr><td><code>className</code></td><td><code>string</code></td><td>Class on the editor container element.</td></tr>
     </tbody>
   </table>
@@ -47,6 +48,7 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
       <tr><td><code>onChange</code></td><td><code>(value: string) =&gt; void</code></td><td>Same contract as in the props table above.</td></tr>
       <tr><td><code>onInsertImage</code></td><td><code>ImageResolver</code></td><td>Image placement resolver.</td></tr>
       <tr><td><code>slashItems</code></td><td><code>SlashItemsConfig</code></td><td>Slash-menu customization.</td></tr>
+      <tr><td><code>colorScheme</code></td><td><code>"light" | "dark" | "system"</code></td><td>Light/dark scheme. Flip live (without recreating) via <code>setColorScheme(view, scheme)</code>.</td></tr>
       <tr><td><code>onSelect</code></td><td><code>(sel: SelectionInfo | null) =&gt; void</code></td><td>Selection report.</td></tr>
       <tr><td><code>onHighlightStatusChange</code> / <code>onHighlightClick</code></td><td>callbacks</td><td>Highlight surface. The highlight <em>list</em> is set imperatively via <code>setHighlightsEffect</code>.</td></tr>
     </tbody>

--- a/sites/paper/src/pages/index.astro
+++ b/sites/paper/src/pages/index.astro
@@ -42,6 +42,15 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
     background: var(--frost);
     padding: 1rem 1.25rem 1.25rem;
   }
+  /* When the editor scheme is *forced* (data-pg-theme set by the playground), pull the frame's
+     --frost to match so the toolbar rail doesn't stay on the OS theme under a flipped editor.
+     Values mirror global.css's light :root / dark block. "system" leaves the attribute unset. */
+  .playground-frame:has([data-pg-theme="light"]) {
+    --frost: #f3f4f6;
+  }
+  .playground-frame:has([data-pg-theme="dark"]) {
+    --frost: #23272e;
+  }
   .hint {
     font-size: 13px;
     color: var(--steel);


### PR DESCRIPTION
## What

Adds a `colorScheme` prop to `@beaket/paper` and a **Light / Dark / System** toggle on the docs intro page so visitors can preview the editor's dark mode without changing their OS setting.

## Why

The editor's dark mode was wired **only** to `@media (prefers-color-scheme: dark)` — there was no way to force light or dark independently of the OS. That blocks two things: a consumer app with its own theme toggle, and showcasing the editor's dark mode in the demo (a dark-OS visitor couldn't see light, and vice versa).

## Changes

**Package (`@beaket/paper`)**
- New `colorScheme: "light" | "dark" | "system"` prop / `EditorOptions` field. Default `"system"` reproduces the old OS-follow behavior, so existing usage is unchanged.
- The dark token stylesheet now emits both the OS-gated block **and** an unconditional forced-dark block from one source; the scheme only decides which scope class the editor root wears.
- Flips **live** via a CodeMirror compartment (`setColorScheme(view, scheme)`) — no editor recreation, so the document is preserved.
- Native `color-scheme` is set on the editor root too, so scrollbars/native controls match the forced scheme.
- `setColorScheme` + `ColorScheme` re-exported from both the core and `/react` entries.

**Docs demo (`sites/paper`)**
- Playground gains a Theme button group. Forced modes also darken/lighten the surrounding card, toolbar, and frame (`[data-pg-theme]` + a `:has()` frost override).
- `colorScheme` documented in the API reference (props + core options tables).

## Verification

- Browser-verified all three modes against a **dark** OS: `Light` forces light, `Dark` forces dark, `System` follows OS — and typed content survives every flip.
- Package: 218 tests pass (incl. new `colorSchemeClass` + forced-dark-block wiring tests), `tsc --noEmit` clean, docs site builds, prettier clean.

Changeset: `@beaket/paper` **minor**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)