### PR TITLE
docs(paper): animate hero headline + focus demo editor on load

### DIFF
--- a/sites/paper/src/components/editor-playground.tsx
+++ b/sites/paper/src/components/editor-playground.tsx
@@ -1,16 +1,16 @@
 import { type ColorScheme, Paper, type PaperHandle } from "@beaket/paper/react";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
-const INITIAL = `# Paper
+// The heading keeps a trailing space (via ${" "} so formatters can't strip it) —
+// the load caret sits after it, one space clear of "Paper" rather than jammed against it.
+const INITIAL = `# Paper${" "}
 
-A markdown-first, **CJK-first** editor. Only the line under your cursor shows raw
-syntax — everything else renders (the Obsidian model).
+A markdown-first, CJK-first **Live Preview** editor built on CodeMirror 6.
 
 Try it:
 
 - Type \`/\` to open the slash menu
 - Drop an image, paste a table, write some \`code\`
-- Mix scripts freely — 한국어, 日本語, English
 
 | Feature | Status |
 | --- | --- |
@@ -44,6 +44,21 @@ export function EditorPlayground() {
   const [font, setFont] = useState(FONTS[0].value);
   const [scheme, setScheme] = useState<ColorScheme>("system");
   const [showSource, setShowSource] = useState(false);
+
+  // On load, drop the caret at the end of the "# Paper " heading line (after the
+  // trailing space, a space clear of "Paper") so the page reads as an editor you can
+  // start writing in. (The table renders as an atomic widget, so a caret can't sit
+  // inside a cell — a selection there gets pushed past the table.) Skip on touch —
+  // autofocusing there pops the keyboard and buries the hero. preventScroll + a
+  // selection-only dispatch (no scrollIntoView) keep the page from yanking down past
+  // the hero on focus.
+  useEffect(() => {
+    if (!window.matchMedia("(pointer: fine)").matches) return;
+    const view = ref.current?.getView();
+    if (!view) return;
+    view.dispatch({ selection: { anchor: INITIAL.indexOf("\n") } });
+    view.contentDOM.focus({ preventScroll: true });
+  }, []);
 
   // The editor reads its visual tokens from --beaket-paper-* on any ancestor.
   const tokenStyle = {

--- a/sites/paper/src/pages/index.astro
+++ b/sites/paper/src/pages/index.astro
@@ -7,7 +7,10 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
 
 <Base title="Paper — markdown-first editor" bodyClass="home">
   <section class="hero">
-    <h1>Write markdown<br />the way it reads.</h1>
+    <h1 class="type" aria-label="Write markdown the way it reads.">
+      <span class="tl" aria-hidden="true"><span class="tt">Write markdown</span></span>
+      <span class="tl" aria-hidden="true"><span class="tt">the way it reads.</span></span>
+    </h1>
     <p>
       <strong>Paper</strong> is a markdown-first, CJK-first <strong>Live Preview</strong> editor built
       on CodeMirror 6.<br />
@@ -67,4 +70,111 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
     margin-top: 2.5rem;
     font-weight: 600;
   }
+
+  /* Typewriter hero — a script (below) types each line out character-by-character
+     with a human cadence: jittered delays, a beat at the period, one self-
+     corrected typo, and a caret that stays solid while typing then blinks when
+     idle. The full headline lives in the static HTML (h1 carries the aria-label;
+     the lines are aria-hidden) so no-JS / SEO / screen readers get clean text. */
+  .hero h1.type .tl {
+    display: block;
+    /* Reserve one line's height so emptying the text for the typewriter doesn't
+       collapse the headline and shove the page up ("쿵"). 1lh = the line box. */
+    min-height: 1lh;
+  }
 </style>
+
+<!-- Caret styles must be global: the caret is created in JS (document.createElement),
+     so it never gets Astro's scoped-style hash attribute — a scoped `.cr` rule would
+     silently not match it, leaving the caret unstyled (zero-size, invisible). -->
+<style is:global>
+  .hero h1.type .cr {
+    display: inline-block;
+    width: 0.06em;
+    height: 0.92em;
+    margin-left: 0.04em;
+    vertical-align: -0.1em;
+    /* Caret = the text colour, like a real OS caret: black in light mode, white
+       in dark. --ink is the headline's own colour and flips with the OS scheme. */
+    background: var(--ink);
+    transition: opacity 0.6s ease;
+  }
+  /* Resting caret blinks after typing finishes; the script then stops the blink
+     and fades it out (opacity transition above) before removing it. */
+  .hero h1.type .cr.blink {
+    animation: tw-caret-blink 1s step-end infinite;
+  }
+  @keyframes tw-caret-blink {
+    50% {
+      opacity: 0;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .hero h1.type .cr {
+      display: none;
+    }
+  }
+</style>
+
+<script>
+  // Humanized typewriter for the hero. The lines already hold the full text in
+  // the static HTML; we clear them and retype with a human cadence so no-JS and
+  // reduced-motion users keep the clean headline untouched.
+  const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const h1 = document.querySelector('.hero h1.type');
+  if (h1 && !reduce) {
+    const lines = Array.from(h1.querySelectorAll<HTMLElement>('.tt'));
+    const targets = lines.map((l) => l.textContent ?? '');
+    lines.forEach((l) => (l.textContent = ''));
+
+    const caret = document.createElement('span');
+    caret.className = 'cr';
+
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+    const rand = (min: number, max: number) => min + Math.random() * (max - min);
+    // A plausible neighbouring key for the occasional fat-finger.
+    const slip = (ch: string) => {
+      const near: Record<string, string> = { d: 's', e: 'r', a: 's', r: 't', t: 'y', s: 'd', i: 'o', y: 't' };
+      const low = ch.toLowerCase();
+      const alt = near[low] ?? 'n';
+      return ch === low ? alt : alt.toUpperCase();
+    };
+
+    async function typeInto(el: HTMLElement, text: string, typoAt?: number) {
+      el.parentElement?.appendChild(caret); // caret rides at the typing frontier
+      for (let i = 0; i < text.length; i++) {
+        const ch = text[i];
+        if (i === typoAt) {
+          // fat-finger, notice, backspace, recover
+          el.textContent += slip(ch);
+          await sleep(rand(170, 280));
+          el.textContent = el.textContent.slice(0, -1);
+          await sleep(rand(120, 200));
+        }
+        el.textContent += ch;
+        let d = rand(42, 102); // humans aren't metronomes
+        if (ch === ' ') d *= 0.6;
+        if (/[.,;:—]/.test(ch)) d += rand(170, 320); // beat at punctuation
+        await sleep(d);
+      }
+    }
+
+    (async () => {
+      await sleep(280);
+      await typeInto(lines[0], targets[0]);
+      await sleep(rand(140, 240));
+      await typeInto(lines[1], targets[1], 14); // typo on the "d" of "reads"
+      caret.classList.add('blink'); // rest a beat, blinking...
+      // Stop inside an ON phase of the 1s blink (ON 0-0.5s, OFF 0.5-1s each
+      // cycle): 2.3s lands mid-ON, so the caret is already lit when we take over
+      // and the fade reads as "on → gently gone" with no pop-back-on flicker.
+      await sleep(2300);
+      caret.classList.remove('blink');
+      caret.style.opacity = '1';
+      void caret.offsetHeight;
+      caret.style.opacity = '0';
+      await sleep(700);
+      caret.remove();
+    })();
+  }
+</script>


### PR DESCRIPTION
## What

Two docs-site polish changes on the `@beaket/paper` landing page (`sites/paper/`):

### Hero headline typewriter
The hero `<h1>` now types itself out character-by-character — the page enacts its own tagline.
- Humanized cadence: jittered per-char delays, a beat at punctuation, one self-corrected typo (type → backspace → fix).
- Caret follows the typing frontier, blinks for a beat when done, then fades out and is removed.
- Caret colour = `--ink` (white in dark mode, black in light, follows the OS scheme), styled via `<style is:global>` since it's created in JS.
- **No regressions for non-visual users:** the full headline lives in the static HTML (`aria-label`); under `prefers-reduced-motion` / no-JS it just shows plainly.
- Each line reserves its height (`min-height: 1lh`) so clearing the text for the animation doesn't cause a layout shift.

### Demo editor on load
- Refreshed the starter document (Paper intro + Try-it list + feature table).
- On load, the caret lands one space after the `# Paper` heading so visitors can start typing immediately — `pointer: fine` only (no keyboard pop-up on touch) and `preventScroll` so the page doesn't yank past the hero.

## Notes
- `sites/paper`-only change (docs site), no `packages/paper` edits → no changeset (matches prior site-only commits like #466).
- The table renders as an atomic widget, so a caret can't sit inside a cell (a selection there is pushed past the table) — hence the caret rests at the heading.

## Verify
`pnpm --filter paper-site dev` → load `/ui/paper/`: headline types out then settles, caret in the demo sits after `# Paper `.

🤖 Generated with [Claude Code](https://claude.com/claude-code)