### PR TITLE
fix(paper): demo editor overlays + source view follow the forced theme

### DIFF
--- a/sites/paper/src/components/editor-playground.tsx
+++ b/sites/paper/src/components/editor-playground.tsx
@@ -145,6 +145,21 @@ export function EditorPlayground() {
         [data-pg-theme="dark"] {
           --ink: #e8eaec; --paper: #16181c; --frost: #23272e; --chrome: #3e4145; --steel: #9aa0a6;
         }
+        /* Re-bridge the editor's porcelain vars to the *forced* palette. global.css resolves
+           --color-* at :root against the OS scheme and that computed value inherits down — so
+           overriding only --paper/--frost above doesn't reach the editor's tokens, which read
+           --color-paper/--color-frost. Without this, a forced-light editor under a dark OS leaks
+           dark into overlays that paint those tokens directly: the slash menu, the "Copied" toast
+           and the table row/col insert handles. Re-declaring --color-* here re-resolves them
+           against the forced --paper/--ink/etc. on this element. */
+        [data-pg-theme="light"],
+        [data-pg-theme="dark"] {
+          --color-ink: var(--ink);
+          --color-paper: var(--paper);
+          --color-frost: var(--frost);
+          --color-chrome: var(--chrome);
+          --color-steel: var(--steel);
+        }
         .pg-toolbar {
           display: flex;
           flex-wrap: wrap;
@@ -203,6 +218,10 @@ export function EditorPlayground() {
           margin: 0 0 1rem;
           padding: 1rem;
           background: var(--frost, #f3f4f6);
+          /* Pin the text to the (forced) ink — otherwise it inherits the page body
+             colour, which tracks the OS, and goes invisible (light text on the now
+             light --frost) when the editor is forced light under a dark OS. */
+          color: var(--ink);
           border: 1px solid var(--chrome);
           font-size: 12px;
           white-space: pre-wrap;


### PR DESCRIPTION
## What

Fixes demo-editor (`sites/paper/`) theming bugs surfaced by the playground's light/dark toggle. All `sites/paper`-only (no `packages/paper` change) → no changeset.

When the editor is **forced** to a scheme that differs from the OS (e.g. Light under a dark OS), several editor overlays leaked the OS scheme:

- slash menu → dark background in light mode
- "Copied" toast → dark-on-dark, unreadable
- table row/column insert handles → dark
- "View markdown" source `<pre>` → text invisible (light-on-light)

## Root cause

`global.css` resolves the porcelain bridge vars (`--color-paper`, `--color-frost`, …) once at `:root` against the OS `prefers-color-scheme`, and that **computed** value inherits down. So overriding only `--paper`/`--frost` on the forced `[data-pg-theme]` wrapper never reaches the editor tokens, which read `--color-paper`/`--color-frost`.

## Fix

- Re-bridge `--color-ink/paper/frost/chrome/steel` to the forced palette (`var(--ink)` etc.) on the `[data-pg-theme="light"|"dark"]` wrapper, so they re-resolve against the forced values and propagate into the editor's overlays.
- Pin the `.pg-source` `<pre>` text to `var(--ink)` — it had no `color` and inherited the OS-tracking page body colour, going invisible on the now-light `--frost`.

## Verified (Light forced, OS dark)

| token / element | before | after |
| --- | --- | --- |
| editor `--paper` | `#16181c` | `#ffffff` |
| editor `--frost` | `#23272e` | `#f3f4f6` |
| slash menu | dark bg | light bg |
| table handle bg | `rgb(35,39,46)` | `rgb(243,244,246)` |
| source view text | invisible | dark, readable |

Dark/system modes verified unaffected (dark wrapper re-bridges to dark; system defers to OS, which stays aligned).

## Follow-ups (editor package, separate)

Root causes that belong in `@beaket/paper` are tracked in #471 (table grip menu clipped by `.cm-scroller` overflow) and #472 (forced `colorScheme` doesn't override consumer-bridged `--color-*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)