### PR TITLE
fix(paper): demo editor fills its card so clicks below content land in it

### DIFF
--- a/sites/paper/src/components/editor-playground.tsx
+++ b/sites/paper/src/components/editor-playground.tsx
@@ -204,6 +204,12 @@ export function EditorPlayground() {
           border: 1px solid var(--chrome);
           box-shadow: var(--shadow-offset, 2px 2px 0 0 var(--chrome));
           padding: 1.25rem 1.5rem;
+        }
+        /* Give the editor (not the card) the tall min-height so it fills the card.
+           Otherwise the card is taller than the editor and the gap below the content
+           is a dead zone — clicking there (e.g. under the table) misses the editor and
+           nothing types. */
+        .pg-paper .cm-content {
           min-height: min(76vh, 680px);
         }
         .pg-footer {
@@ -236,6 +242,8 @@ export function EditorPlayground() {
           }
           .pg-paper {
             padding: 0.9rem 1rem;
+          }
+          .pg-paper .cm-content {
             min-height: min(70vh, 560px);
           }
           /* Bigger tap targets for the swatches on touch screens. */

--- a/sites/paper/src/components/editor-playground.tsx
+++ b/sites/paper/src/components/editor-playground.tsx
@@ -212,6 +212,12 @@ export function EditorPlayground() {
         .pg-paper .cm-content {
           min-height: min(76vh, 680px);
         }
+        /* ...but never the nested cell editor: editing a table cell mounts its own
+           CodeMirror inside the table widget, whose .cm-content would otherwise inherit
+           the rule above and balloon the cell to full height. (0,3,0) beats it. */
+        .pg-paper .cm-table-widget .cm-content {
+          min-height: 0;
+        }
         .pg-footer {
           display: flex;
           align-items: center;


### PR DESCRIPTION
## What

In the docs playground (`sites/paper/`), the editor card `.pg-paper` carried a tall `min-height` while the editor itself sized to its content. The gap below the editor was a **dead zone**: clicking there (e.g. the empty space under the table) missed the editor, so nothing typed — reported as "type below the table and nothing appears."

## Fix

Move the `min-height` from the card onto the editor content (`.pg-paper .cm-content`), so the editor fills the card and the whole surface is editable. One CSS rule (desktop + mobile breakpoint).

## Verified

- Empty document: clicking anywhere in the tall editor places the caret and types normally (previously the lower area was dead).
- With the table: the area below it is now editable (previously inert).

## Not in scope

Clicking directly below a *trailing table widget* still lands the caret on the blank line before the table — a CodeMirror block-widget (`posAtCoords`) behavior, tracked in #474. This PR only removes the dead zone.

`sites/paper`-only, no `packages/paper` change → no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)