### PR TITLE
fix(paper): thin hero typewriter caret to match the real editor cursor

### DIFF
--- a/sites/paper/src/pages/index.astro
+++ b/sites/paper/src/pages/index.astro
@@ -90,7 +90,9 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
 <style is:global>
   .hero h1.type .cr {
     display: inline-block;
-    width: 0.06em;
+    /* Match the real editor caret: a fixed 1.2px bar (CodeMirror's cursor
+       border-left), not an em width that fattens with the big headline. */
+    width: 1.2px;
     height: 0.92em;
     margin-left: 0.04em;
     vertical-align: -0.1em;


### PR DESCRIPTION
## What

The hero typewriter caret on the @beaket/paper docs site looked noticeably thicker than the real editor cursor.

**Cause:** the caret was `width: 0.06em`, an em width that scales with the hero `h1` font size (`clamp(2rem, 5vw, 3rem)` = 32–48px). That renders the caret at ~1.9–2.9px, vs CodeMirror's real cursor which is a fixed **1.2px** `border-left`.

**Fix:** pin the caret to a fixed `1.2px` so it matches the actual editor caret. `height` stays `0.92em` so it still scales to the text height like a normal caret.

## File

- `sites/paper/src/pages/index.astro` — caret `width: 0.06em` → `1.2px`

🤖 Generated with [Claude Code](https://claude.com/claude-code)