### PR TITLE
fix(paper): task-checkbox checkmark invisible under forced colorScheme

### DIFF
--- a/.changeset/fix-checkbox-checkmark-forced-scheme.md
+++ b/.changeset/fix-checkbox-checkmark-forced-scheme.md
@@ -1,0 +1,5 @@
+---
+"@beaket/paper": patch
+---
+
+Fix the task-list checkbox checkmark becoming invisible under a forced `colorScheme`. The checked checkmark image was selected with a bare `@media (prefers-color-scheme: dark)` rule, but forced light/dark schemes are driven by editor scope classes (`.cm-beaket-paper-dark` / `.cm-beaket-paper`), and the OS media query doesn't match a forced scheme. So a checkbox forced opposite the OS (e.g. `colorScheme="dark"` on a light OS) painted a same-color checkmark on its `--ink` fill — invisible. Root cause: it was the only styling rule keyed on `prefers-color-scheme` instead of the scope class. The checkmark image is now the internal `--cm-check-mark` editor token (light default in `tokens`, dark value in `darkTokens`), so it rides the same scoped dark stylesheet as every other dark token and follows the active scheme in both `system` and forced modes.

--- a/packages/paper/src/editor/extensions/list-rendering.test.ts
+++ b/packages/paper/src/editor/extensions/list-rendering.test.ts
@@ -83,6 +83,18 @@ describe("list hanging indent (second-line alignment on wrap)", () => {
   });
 });
 
+describe("task-checkbox checkmark is driven by the --cm-check-mark token (#487)", () => {
+  // The checked checkbox must read its checkmark image from var(--cm-check-mark), so the dark value
+  // shipped in darkTokens can flip it via the scope class (forced colorScheme works regardless of OS).
+  // A bare `@media (prefers-color-scheme: dark)` in this layer would ignore forced schemes — the bug.
+  it("the generated checkbox style references var(--cm-check-mark), not a hard-coded dark @media", () => {
+    makeView("- [x] 완료", 0);
+    const css = [...document.querySelectorAll("style")].map((s) => s.textContent ?? "").join("\n");
+    expect(css).toContain("var(--cm-check-mark");
+    expect(css).not.toMatch(/@media[^{}]*prefers-color-scheme[\s\S]*?cm-task-checkbox/);
+  });
+});
+
 describe("Live Preview: when the cursor is on a structure line the source is exposed (expected behavior)", () => {
   it("when the cursor is on a task line the - [ ] source is visible", () => {
     const v = makeView("- [ ] 미완료", 4);

--- a/packages/paper/src/editor/extensions/list-rendering.ts
+++ b/packages/paper/src/editor/extensions/list-rendering.ts
@@ -126,13 +126,10 @@ function computeDecorations(view: EditorView): DecorationSet {
 }
 
 // A minimal port of the beaket/ui (brutalist) checkbox: sharp square, unchecked is white background +
-// graphite (≈--ink) border, checked fills with ink and a white checkmark. accent only on focus.
-// A native input can't draw ::after, so appearance:none + SVG background stamps the check.
-const CHECK_MARK =
-  "url(\"data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2016%2016'%20fill='none'%20stroke='%23ffffff'%20stroke-width='2.25'%3E%3Cpath%20d='M3.5%208.5l3%203%206-6'/%3E%3C/svg%3E\")";
-// Dark mode stamps onto a light --ink fill, so the white checkmark above would vanish; use a dark stroke instead.
-const CHECK_MARK_DARK =
-  "url(\"data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2016%2016'%20fill='none'%20stroke='%230d1117'%20stroke-width='2.25'%3E%3Cpath%20d='M3.5%208.5l3%203%206-6'/%3E%3C/svg%3E\")";
+// graphite (≈--ink) border, checked fills with --ink and a checkmark. accent only on focus. A native
+// input can't draw ::after, so appearance:none + an SVG background stamps the check. The checkmark
+// image is the editor token --cm-check-mark (theme.ts): light = white stroke, dark = dark stroke — so
+// it follows a forced colorScheme via the scope class, not a bare prefers-color-scheme query (#487).
 
 export function listRendering(): Extension {
   return [
@@ -154,18 +151,12 @@ export function listRendering(): Extension {
       },
       ".cm-task-checkbox:hover": { borderColor: "var(--ink)" },
       ".cm-task-checkbox:checked": {
-        background: `var(--ink) ${CHECK_MARK} center / 11px no-repeat`,
+        background: "var(--ink) var(--cm-check-mark) center / 11px no-repeat",
         borderColor: "var(--ink)",
       },
       ".cm-task-checkbox:focus-visible": {
         outline: "2px solid var(--accent)",
         outlineOffset: "2px",
-      },
-      // Dark mode: --ink fills light, so the white checkmark would disappear — stamp a dark one instead.
-      "@media (prefers-color-scheme: dark)": {
-        ".cm-task-checkbox:checked": {
-          background: `var(--ink) ${CHECK_MARK_DARK} center / 11px no-repeat`,
-        },
       },
     }),
   ];

--- a/packages/paper/src/editor/theme.test.ts
+++ b/packages/paper/src/editor/theme.test.ts
@@ -12,7 +12,9 @@ import { colorSchemeClass, darkThemeCss, darkTokens, tokens } from "./theme";
 // The token names extensions read internally that are NOT a direct public override:
 // - --color-ink is a deliberate local override of porcelain's ink (the default in the chain below).
 // - --accent-sel/--accent-weak are derived from --accent, so they inherit a consumer accent override.
-const NON_PUBLIC = new Set(["--color-ink", "--accent-sel", "--accent-weak"]);
+// - --cm-check-mark is an internal SVG image (the task-checkbox checkmark), not a public theming knob;
+//   it carries a light value here and a dark value in darkTokens so it flips with the scope class (#487).
+const NON_PUBLIC = new Set(["--color-ink", "--accent-sel", "--accent-weak", "--cm-check-mark"]);
 
 describe("theme public override contract", () => {
   it("every theming token is overridable via a --beaket-paper-* public name", () => {
@@ -76,7 +78,8 @@ describe("theme typography is variabilized (CJK-first defaults)", () => {
 // are a browser/manual check, same carve-out as the light tokens above).
 describe("dark theme keeps the override + bridge chains, swapping only the built-in default", () => {
   // Every color/shadow token a consumer can override stays publicly overridable in dark mode too.
-  const NON_PUBLIC = new Set(["--color-ink"]);
+  // --cm-check-mark is the internal checkbox checkmark image (not a public knob), same as in light.
+  const NON_PUBLIC = new Set(["--color-ink", "--cm-check-mark"]);
   it("every dark token still reads a --beaket-paper-* override first", () => {
     for (const [name, value] of Object.entries(darkTokens)) {
       if (NON_PUBLIC.has(name)) continue;
@@ -155,6 +158,20 @@ describe("darkThemeCss emits a scoped prefers-color-scheme block", () => {
     for (const [name, value] of Object.entries(darkTokens)) {
       expect(forced).toContain(`${name}: ${value};`);
     }
+  });
+
+  // #487: the task-checkbox checkmark must follow the active scheme via the scope class, not a bare
+  // `prefers-color-scheme` query (which ignored forced colorScheme — invisible checkmark when forced
+  // opposite the OS). It ships as the editor token `--cm-check-mark`, so it rides BOTH dark blocks
+  // (media-gated + forced) exactly like every other dark token and inherits down to the checkbox.
+  it("ships the dark task-checkbox checkmark as a scope-scoped token in both dark blocks (#487)", () => {
+    expect(darkTokens).toHaveProperty("--cm-check-mark");
+    // the dark variant uses a dark stroke (#0d1117, URL-encoded %230d1117), not the light/white one
+    expect(darkTokens["--cm-check-mark"]).toContain("%230d1117");
+    const media = css.slice(0, css.indexOf("}}") + 2); // the @media (...) { .cm-editor.cm-beaket-paper { ... } } block
+    const forced = css.slice(css.indexOf("}}") + 2); // the unconditional .cm-editor.cm-beaket-paper-dark block
+    expect(media).toContain("--cm-check-mark:");
+    expect(forced).toContain("--cm-check-mark:");
   });
 });
 

--- a/packages/paper/src/editor/theme.ts
+++ b/packages/paper/src/editor/theme.ts
@@ -70,6 +70,12 @@ export const tokens = {
   // ② Editor-owned colors (2-tier; no porcelain equivalent)
   "--canvas": "var(--beaket-paper-canvas, #fbfcfd)", // cool near-white for long-form writing (ADR-0009), not --color-paper (#fff)
   "--surface": "var(--beaket-paper-surface, #eceef2)",
+  // ② Task-checkbox checkmark image. Light = white stroke (stamped on the dark --ink fill). The dark
+  //    variant lives in `darkTokens`, so the checkmark follows a forced `colorScheme` via the scope
+  //    class — not a bare `prefers-color-scheme` query (which ignored forced schemes). Consumed by
+  //    `list-rendering.ts` as `var(--cm-check-mark)`; inherits to the checkbox from the editor root.
+  "--cm-check-mark":
+    "url(\"data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2016%2016'%20fill='none'%20stroke='%23ffffff'%20stroke-width='2.25'%3E%3Cpath%20d='M3.5%208.5l3%203%206-6'/%3E%3C/svg%3E\")",
   // ② Editor-owned code syntax (GitHub Light, ADR-0006); porcelain has none
   "--syn-kw": "var(--beaket-paper-syntax-keyword, #cf222e)",
   "--syn-str": "var(--beaket-paper-syntax-string, #0a3069)",
@@ -122,6 +128,11 @@ export const darkTokens = {
   // ② Editor-owned colors (2-tier; no porcelain equivalent). Cool near-black writing canvas + raised fill.
   "--canvas": "var(--beaket-paper-canvas, #14171c)",
   "--surface": "var(--beaket-paper-surface, #1c1f27)",
+  // ② Dark task-checkbox checkmark: dark stroke, because --ink fills light in dark mode (the white
+  //    light variant would vanish). Rides both dark blocks via darkThemeCss, so it flips with the
+  //    active scope class for forced "dark" and OS-dark "system" alike.
+  "--cm-check-mark":
+    "url(\"data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2016%2016'%20fill='none'%20stroke='%230d1117'%20stroke-width='2.25'%3E%3Cpath%20d='M3.5%208.5l3%203%206-6'/%3E%3C/svg%3E\")",
   // ② Editor-owned code syntax — GitHub Dark Default (mirrors the GitHub Light ramp above)
   "--syn-kw": "var(--beaket-paper-syntax-keyword, #ff7b72)",
   "--syn-str": "var(--beaket-paper-syntax-string, #a5d6ff)",


### PR DESCRIPTION
Closes #487.

> **Agent-contract rehearsal.** I drove this fix exactly as the Phase 4 tactical agent would (per `MAINTENANCE.md`): read `CONTEXT.md` → verified the issue's Definition of Ready → branch → **red test first** → green fix → `pnpm check:adr` + `pnpm test:editor` locally → patch changeset stating the root cause → PR, **no merge**. Posting so we can confirm the contract yields a good PR before automating it.

## Root cause
The checked task-checkbox stamped its checkmark via a bare `@media (prefers-color-scheme: dark)` rule — the *only* styling in `src` keyed on the OS query instead of the editor's scope classes. Forced schemes (`colorScheme="dark"|"light"`, shipped v0.4.0) are driven by `.cm-beaket-paper-dark` / `.cm-beaket-paper` classes, which the OS media query ignores. So a checkbox forced opposite the OS painted a same-color checkmark on its `--ink` fill → invisible.

## Fix
Make the checkmark image the internal `--cm-check-mark` editor token (light value in `tokens`, dark in `darkTokens`). It now rides the same scoped dark stylesheet (`darkThemeCss`) as every other dark token and inherits to the checkbox, so it follows the active scheme in **both `system` and forced** modes. Removes the bare media block from `list-rendering.ts`. `--cm-check-mark` is internal (added to the `NON_PUBLIC` token registry) — no public API change.

## Tests (red→green)
- `theme.test.ts` — the dark checkmark token ships in **both** the media-gated and forced-dark blocks (`#487`).
- `list-rendering.test.ts` — the generated checkbox style reads `var(--cm-check-mark)` and no longer hard-codes a `prefers-color-scheme` rule.
- Pixel-level visibility remains a browser/manual check per `CONTEXT.md` invariant #4.

220 editor tests pass; typecheck + `check:adr` green.