### PR TITLE
fix(release): attach npm provenance via per-package publishConfig

### DIFF
--- a/.changeset/npm-provenance-publishconfig.md
+++ b/.changeset/npm-provenance-publishconfig.md
@@ -1,0 +1,6 @@
+---
+"@beaket/paper": patch
+"@beaket/ui": patch
+---
+
+Attach npm provenance attestations on publish. Root cause of the missing attestations across 0.2.0–0.4.0: the repo-root `.npmrc` carried `provenance=true`, but `changeset publish` runs the publish from each package's own directory, and npm/pnpm only read the `.npmrc` in the current working directory (plus user/global) — they don't walk up to the workspace-root file, so the flag was never seen. The fix moves it to `publishConfig.provenance: true` in each published package's `package.json`, which is read at publish time wherever the command runs (combined with the existing `id-token: write` in the release workflow).

--- a/.npmrc
+++ b/.npmrc
@@ -9,4 +9,11 @@
 # lookup (`if (options.provenance != null) …`) and always emits the sigstore
 # bundle. Applies repo-wide to every changeset-published package (@beaket/ui,
 # @beaket/paper) — both are public, both run with `id-token: write`.
+#
+# NOTE: this root rc did NOT take effect for 0.2.0–0.4.0. `changeset publish`
+# runs the publish from each package's own directory, and npm/pnpm only read the
+# .npmrc in the cwd (+ user/global) — they do not walk up to this repo-root file.
+# The cwd-independent fix is `publishConfig.provenance: true` in each package's
+# package.json (read at publish time wherever it runs). This line is kept as a
+# belt-and-suspenders for any root-cwd publish.
 provenance=true

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -14,6 +14,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "keywords": [
     "react",
     "components",

--- a/packages/paper/package.json
+++ b/packages/paper/package.json
@@ -19,6 +19,9 @@
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
Part of Phase 4. Fixes the npm provenance attestations that have been missing across **0.2.0–0.4.0**.

## Root cause
The repo-root `.npmrc` carried `provenance=true`, but `changeset publish` runs the publish from **each package's own directory**, and npm/pnpm only read the `.npmrc` in the cwd (+ user/global) — they don't walk up to the workspace-root file. So the flag was never applied at publish time.

## Fix
Move it to `publishConfig.provenance: true` in each published package's `package.json` (`@beaket/paper`, `@beaket/ui`) — read at publish time wherever the command runs. The release workflow already grants `id-token: write`, and the repo is public, so the sigstore bundle can be emitted. The root `.npmrc` line is kept as a belt-and-suspenders with a comment explaining why it alone didn't work.

## Verification
Provenance can only be confirmed on a real publish (needs CI + OIDC). The patch changeset bumps both packages, so the **next release will be the test** — check the npm package page shows a "Provenance" section after it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)