### PR TITLE
fix(release): force npm provenance via --provenance flag (patch changesets)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,12 +1,15 @@
-# Attach npm provenance attestations when publishing (OIDC trusted publishing).
+# npm provenance attestations are forced via a patch to @changesets/cli, NOT here.
 #
-# pnpm does NOT read the NPM_CONFIG_PROVENANCE env var — its publish config
-# (@pnpm/config.reader) only ingests URL-scoped `npm_config_//…` env vars, so a
-# bare scalar like NPM_CONFIG_PROVENANCE is dropped. The flag must come from this
-# rc file. This is why @beaket/paper@0.1.0 published over OIDC with no attestation.
+# Empirically (pnpm 11.8.0, the CI version): pnpm only honors provenance via the
+# `--provenance` CLI flag at publish time. It IGNORES `provenance=true` from this
+# .npmrc, from package.json `publishConfig`, and the NPM_CONFIG_PROVENANCE env var
+# (none of them reach `options.provenance`). Releases run `changeset publish`,
+# which gives no hook to add publish flags — so we patch the CLI to push
+# `--provenance` into its publishFlags (see patches/@changesets__cli@*.patch,
+# wired via pnpm-workspace.yaml `patchedDependencies`). Requires `id-token: write`
+# (release.yml) and the package being public; verify post-release with
+# `npm view <pkg>@<ver> dist.attestations`.
 #
-# With `provenance=true`, pnpm's OIDC flow short-circuits the registry visibility
-# lookup (`if (options.provenance != null) …`) and always emits the sigstore
-# bundle. Applies repo-wide to every changeset-published package (@beaket/ui,
-# @beaket/paper) — both are public, both run with `id-token: write`.
+# The line below is INERT for our pnpm-only release flow (kept only because npm
+# CLI — which we don't use to publish — would honor it). Do not rely on it.
 provenance=true

--- a/patches/@changesets__cli@2.31.0.patch
+++ b/patches/@changesets__cli@2.31.0.patch
@@ -1,0 +1,34 @@
+diff --git a/dist/changesets-cli.cjs.js b/dist/changesets-cli.cjs.js
+index 9f0bd6c5f96011be225269a71365a878cb822bb7..c3cdbec2f3e9ef7210729e9584a1d8d80891050a 100644
+--- a/dist/changesets-cli.cjs.js
++++ b/dist/changesets-cli.cjs.js
+@@ -878,6 +878,12 @@ async function internalPublish(packageJson, opts, twoFactorState) {
+   const publishTool = await getPublishTool(opts.cwd);
+   const publishFlags = opts.access ? ["--access", opts.access] : [];
+   publishFlags.push("--tag", opts.tag);
++  // [beaket patch] Force npm provenance attestations. pnpm only honors the
++  // `--provenance` CLI flag at publish time — it ignores `provenance=true` from
++  // .npmrc, package.json `publishConfig`, and NPM_CONFIG_PROVENANCE. `changeset
++  // publish` provides no hook to inject flags, so we patch it here. Requires
++  // `id-token: write` (granted in release.yml) and runs in CI only.
++  publishFlags.push("--provenance");
+   if (publishTool.name === "pnpm" && publishTool.shouldAddNoGitChecks) {
+     publishFlags.push("--no-git-checks");
+   }
+diff --git a/dist/changesets-cli.esm.js b/dist/changesets-cli.esm.js
+index d9582bf53eaf55402a6bf96a39589af7854b8f23..4719573785433a0f24d7ce09bbc6c08a16ff0088 100644
+--- a/dist/changesets-cli.esm.js
++++ b/dist/changesets-cli.esm.js
+@@ -841,6 +841,12 @@ async function internalPublish(packageJson, opts, twoFactorState) {
+   const publishTool = await getPublishTool(opts.cwd);
+   const publishFlags = opts.access ? ["--access", opts.access] : [];
+   publishFlags.push("--tag", opts.tag);
++  // [beaket patch] Force npm provenance attestations. pnpm only honors the
++  // `--provenance` CLI flag at publish time — it ignores `provenance=true` from
++  // .npmrc, package.json `publishConfig`, and NPM_CONFIG_PROVENANCE. `changeset
++  // publish` provides no hook to inject flags, so we patch it here. Requires
++  // `id-token: write` (granted in release.yml) and runs in CI only.
++  publishFlags.push("--provenance");
+   if (publishTool.name === "pnpm" && publishTool.shouldAddNoGitChecks) {
+     publishFlags.push("--no-git-checks");
+   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ overrides:
   yaml: '>=2.8.3'
   fast-uri: '>=3.1.2'
 
+patchedDependencies:
+  '@changesets/cli@2.31.0': e831e43a6a6ccac7e8f42bb617cb3f11212d256f06d9126874ead85747696ff0
+
 importers:
 
   .:
@@ -77,7 +80,7 @@ importers:
         version: 0.7.0
       '@changesets/cli':
         specifier: ^2.30.0
-        version: 2.31.0(@types/node@25.9.4)
+        version: 2.31.0(patch_hash=e831e43a6a6ccac7e8f42bb617cb3f11212d256f06d9126874ead85747696ff0)(@types/node@25.9.4)
       '@chromatic-com/storybook':
         specifier: 5.2.1
         version: 5.2.1(storybook@10.4.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.11.1)(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.8.4)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))
@@ -5756,7 +5759,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.31.0(@types/node@25.9.4)':
+  '@changesets/cli@2.31.0(patch_hash=e831e43a6a6ccac7e8f42bb617cb3f11212d256f06d9126874ead85747696ff0)(@types/node@25.9.4)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,3 +20,6 @@ overrides:
 allowBuilds:
   esbuild: true
   sharp: true
+
+patchedDependencies:
+  "@changesets/cli@2.31.0": patches/@changesets__cli@2.31.0.patch


### PR DESCRIPTION
## Problem

npm **provenance attestations have been missing** across `@beaket/paper` 0.1.0–0.4.0 despite `provenance=true` in the repo-root `.npmrc`. `npm view @beaket/paper@0.4.0 dist` shows only registry signatures, no `attestations`.

## Root cause (proven empirically on pnpm 11.8.0 — the exact CI version)

pnpm **only honors provenance via the `--provenance` CLI flag** at publish time. It silently ignores `provenance=true` from `.npmrc`, from package.json `publishConfig`, and from the `NPM_CONFIG_PROVENANCE` env var — none reach `options.provenance`.

Verified with a dead-registry probe (`pnpm publish` to `http://127.0.0.1:9/`): when provenance is enabled pnpm throws `EUSAGE: Automatic provenance generation not supported for provider` **before** any network call; when not, it goes straight to `ECONNREFUSED`.

| Method | Provenance |
|--------|-----------|
| `--provenance` CLI flag | ✅ enabled (only working method) |
| `.npmrc` `provenance=true` | ❌ ignored |
| `publishConfig.provenance: true` | ❌ ignored |
| `NPM_CONFIG_PROVENANCE` / `npm_config_provenance` env | ❌ ignored |

Source confirms: `createPublishOptions` reads `provenance` only from `options`; the `publishConfig` fallback covers `registry`/`access` only; `PUBLISH_CONFIG_WHITELIST` excludes provenance.

This also **disproves** the earlier hypothesis (branch `fix/npm-provenance-publishconfig`) that `changeset publish` running per-package skips the root `.npmrc`: pnpm's `loadNpmrcFiles` reads `.npmrc` from the **workspace root**, not cwd — the root file was always read; pnpm just drops the provenance key regardless of location. **That branch is a no-op and should be abandoned.**

## Fix

Releases run `changeset publish`, which exposes no hook to add publish flags — so **patch `@changesets/cli`** to push `--provenance` into its `publishFlags` (`internalPublish`, both cjs + esm dist).

- Wired via `pnpm-workspace.yaml` `patchedDependencies` → `patches/@changesets__cli@2.31.0.patch`
- Keeps `changeset publish` and its `published` stdout intact (that output gates the docs deploy job — a naive `pnpm -r publish` replacement would break it)
- `release.yml` already grants `id-token: write`; both published packages are public

Also rewrote the now-inaccurate `.npmrc` comment (the `provenance=true` line is **inert** for our pnpm-only flow; kept only because npm CLI — which we don't use to publish — would honor it).

## Verification

- ✅ `pnpm install --frozen-lockfile` (CI parity) green; patch persists post-install
- ✅ `--provenance` present in the installed `@changesets/cli` dist
- ✅ `pnpm publish --provenance` reaches provenance generation (dead-registry probe)
- ⏳ **Attestation actually landing can only be confirmed post-release** — after the next real `@beaket/paper` release, verify with `npm view @beaket/paper@<next> dist.attestations`

No changeset: release-infra only (no published-package source change; files outside `src/**` / `packages/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)