### PR TITLE
perf(paper): skip tableBoundaryGuard syntax-tree walk on pure-insertion transactions

### DIFF
--- a/.changeset/fix-paper-table-boundary-guard-insertion-skip.md
+++ b/.changeset/fix-paper-table-boundary-guard-insertion-skip.md
@@ -1,0 +1,5 @@
+---
+"@beaket/paper": patch
+---
+
+`tableBoundaryGuard` walked the full syntax tree on every `docChanged` transaction, including pure insertions (normal typing, `fromA === toA`), which can never delete a boundary newline and can never be blocked. Root cause: the guard's `syntaxTree().iterate()` ran unconditionally before the check that actually uses it. Fix: scan `tr.changes` once up-front; if no change has `toA > fromA` (no deletion or replacement), return the transaction immediately without walking the tree — eliminating the tree walk on the common keystroke path.

--- a/packages/paper/src/editor/extensions/table-boundary-guard.test.ts
+++ b/packages/paper/src/editor/extensions/table-boundary-guard.test.ts
@@ -75,4 +75,24 @@ describe("tableBoundaryGuard", () => {
     v.dispatch({ changes: { from: 0, to: v.state.doc.length, insert: "x" } }); // Cmd+A → 'x'
     expect(v.state.doc.toString()).toBe("x");
   });
+
+  // Pure insertion (fromA === toA for every change) can never delete a boundary newline,
+  // so the guard must return early without walking the syntax tree.
+  it("does not block a pure-insertion transaction in a doc with a table+blank-line boundary", async () => {
+    const v = await viewWithParsedTable();
+    const para = v.state.doc.line(5);
+    // Insert a character at the end of the paragraph — no deletion, can't touch the boundary.
+    v.dispatch({ changes: { from: para.to, to: para.to, insert: "x" } });
+    expect(v.state.doc.toString()).toBe(DOC + "x");
+  });
+
+  it("does not block a pure-insertion transaction at the start of the paragraph line", async () => {
+    const v = await viewWithParsedTable();
+    const para = v.state.doc.line(5);
+    // Insert at the start of the paragraph — still a pure insertion, still must pass through.
+    v.dispatch({ changes: { from: para.from, to: para.from, insert: ">" } });
+    expect(v.state.doc.toString()).toBe(
+      ["| a | b |", "| --- | --- |", "| 1 | 2 |", "", ">문단입니다"].join("\n"),
+    );
+  });
 });

--- a/packages/paper/src/editor/extensions/table-widget.ts
+++ b/packages/paper/src/editor/extensions/table-widget.ts
@@ -1146,6 +1146,13 @@ function tableBackspace(view: EditorView): boolean {
  */
 export const tableBoundaryGuard: Extension = EditorState.transactionFilter.of((tr) => {
   if (!tr.docChanged) return tr;
+  // A pure insertion (fromA === toA for every change) can never delete a boundary newline, so the
+  // guard can only ever block deletions/replacements. Skip the whole syntaxTree walk on this path.
+  let hasDeletion = false;
+  tr.changes.iterChanges((fromA, toA) => {
+    if (toA > fromA) hasDeletion = true;
+  });
+  if (!hasDeletion) return tr;
   const doc = tr.startState.doc;
   // Carry each protected newline together with its owning table range. The absorption risk only occurs when
   // "the table stays but only the boundary newline disappears," so changes that delete the whole table (e.g. select-all delete) are not blocked.


### PR DESCRIPTION
## Root cause

`tableBoundaryGuard` is an `EditorState.transactionFilter` that runs on every `docChanged` transaction. It called `syntaxTree(tr.startState).iterate(...)` unconditionally — even on **pure insertions** (normal typing, where `fromA === toA` for every change). A pure insertion can never delete a boundary newline, so it can never be blocked by the guard. The tree walk was entirely wasted on the common keystroke path.

## Change

Before building the `guards` array, scan `tr.changes` once with `iterChanges`. If no change has `toA > fromA` (i.e. no deletion or replacement exists), return `tr` immediately — the tree walk is skipped entirely. This is provably equivalent: the guard's blocking condition (`fromA <= g.pos && g.pos < toA`) requires `toA > fromA`, so a transaction with only insertions could never be blocked regardless.

**Files changed:**
- `packages/paper/src/editor/extensions/table-widget.ts` — the early-out in `tableBoundaryGuard`
- `packages/paper/src/editor/extensions/table-boundary-guard.test.ts` — two new behavioral pin tests confirming pure-insertion transactions pass through unmodified
- `.changeset/fix-paper-table-boundary-guard-insertion-skip.md` — patch changeset

## Test notes

All 7 `tableBoundaryGuard` tests pass (5 existing + 2 new pins). Full suite: 222 tests across 26 files. Typecheck clean. ADR refs clean.

The new tests are behavioral pins for the common path — they document the invariant that pure insertions must never be blocked, guarding against any future regression in this function.

Closes #486

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gz5Les3cB8be9hXv5VX97Z)_