### PR TITLE
docs(paper): ADR-0015 — decline raw CodeMirror extension injection slot (#497)

### DIFF
--- a/.changeset/paper-no-raw-extension-injection-readme.md
+++ b/.changeset/paper-no-raw-extension-injection-readme.md
@@ -1,0 +1,5 @@
+---
+"@beaket/paper": patch
+---
+
+Clarify in the README that `getView()` is the deliberate raw escape hatch with no cross-version guarantee, and that there is intentionally no blessed `extensions` injection slot. This records the consumer-facing outcome of the extensibility decision (#497, ADR-0015): a raw `Extension[]`/`keymap` slot on `EditorOptions` is declined because it would leak CodeMirror into the 1.0-frozen public surface and let a consumer break the core invariants (the composing guard, the permanently-hidden table structure). Concrete extensibility needs route to the declarative APIs instead; raw access stays on the unsafe `getView()` handle.

--- a/packages/paper/README.md
+++ b/packages/paper/README.md
@@ -35,7 +35,9 @@ function Editor() {
 The editor is **uncontrolled**: `defaultValue` seeds the initial document, and you replace it
 programmatically with `ref.current.setValue(...)`. `onChange` fires with the full markdown on user
 edits only — it's IME-guarded, and `setValue` doesn't echo back through it. For anything the handle
-doesn't expose, `ref.current.getView()` returns the underlying CodeMirror `EditorView`.
+doesn't expose, `ref.current.getView()` returns the underlying CodeMirror `EditorView` — the
+deliberate raw escape hatch, with no cross-version guarantee (there is no blessed `extensions` slot;
+that would lock CM6 into the public surface).
 
 See the [API reference](https://beaket.github.io/ui/paper/api) for the full prop and handle surface.
 

--- a/packages/paper/docs/CONTEXT.md
+++ b/packages/paper/docs/CONTEXT.md
@@ -30,12 +30,14 @@ there is no second document model. Everything else follows from this:
    shared Han glyphs render in the Korean font (measured). Lives in `theme.ts`.
    → [ADR-0009](./adr/0009-visual-language-porcelain-tokens-cjk-typography.md)
 3. **Mechanism in editor, policy in consumer.** The editor exposes build-time injection points
-   (`onInsertImage`, `slashItems`, the highlight/selection props) — not a runtime plugin system.
-   Images _render_ in-editor but _ingestion_ is delegated; selection annotations are anchored to the
-   **markdown source**, not rendered HTML.
+   (`onInsertImage`, `slashItems`, the highlight/selection props) — not a runtime plugin system, and
+   **not a raw `extensions[]`/`keymap` slot** (that stays on the unsafe `getView()` hatch, ADR-0015).
+   Curated APIs deliberately do not expose `EditorView`. Images _render_ in-editor but _ingestion_ is
+   delegated; selection annotations are anchored to the **markdown source**, not rendered HTML.
    → [ADR-0011](./adr/0011-images-render-vs-ingest-consumer-delegation.md),
    [ADR-0012](./adr/0012-slash-items-consumer-config.md),
-   [ADR-0014](./adr/0014-selection-annotation-mechanism.md)
+   [ADR-0014](./adr/0014-selection-annotation-mechanism.md),
+   [ADR-0015](./adr/0015-no-raw-codemirror-extension-injection-slot.md)
 4. **Test boundary.** Logic is covered by jsdom **contract + regression tests** (every bug fixed
    red→green). Coordinate/visual concerns are deliberately _carved out_ — jsdom returns zero-size
    rects (polyfills in `test/setup.ts`), so anything geometry-dependent needs real-browser

--- a/packages/paper/docs/DECISIONS.md
+++ b/packages/paper/docs/DECISIONS.md
@@ -23,7 +23,12 @@ change needs an ADR vs. a changeset. Each bullet below links to its ADR.
   ([ADR-0001](./adr/0001-live-preview-on-codemirror6.md))
 - **Consumer config ≠ plugin API.** The editor exposes injection points (`onInsertImage`,
   `slashItems`, the annotation props) as _build-time consumer config_, not a runtime/third-party
-  plugin system. A runtime plugin system is out of scope.
+  plugin system. A runtime plugin system is out of scope. This extends to **build-time raw
+  injection**: there is no blessed `extensions?: Extension[]` (or `keymap`) slot on `EditorOptions` —
+  it would leak CM6 into the 1.0-frozen surface and let a consumer break the core invariants. Raw
+  access stays on the explicitly-_unsafe_ `getView()` escape hatch; concrete needs route to the
+  declarative APIs.
+  ([ADR-0015](./adr/0015-no-raw-codemirror-extension-injection-slot.md))
 
 ## Load-bearing decisions
 

--- a/packages/paper/docs/adr/0015-no-raw-codemirror-extension-injection-slot.md
+++ b/packages/paper/docs/adr/0015-no-raw-codemirror-extension-injection-slot.md
@@ -1,7 +1,7 @@
 # 0015 — No raw CodeMirror `Extension[]` injection slot; keep raw access on the explicitly-unsafe `getView()` escape hatch and route concrete needs to declarative APIs
 
 - **Status:** Accepted
-- **Date:** 2026-06-21
+- **Date:** 2026-06-21 (#506)
 - **Supersedes:** —
 - **Superseded-by:** —
 - **Amends:** —

--- a/packages/paper/docs/adr/0015-no-raw-codemirror-extension-injection-slot.md
+++ b/packages/paper/docs/adr/0015-no-raw-codemirror-extension-injection-slot.md
@@ -1,0 +1,111 @@
+# 0015 — No raw CodeMirror `Extension[]` injection slot; keep raw access on the explicitly-unsafe `getView()` escape hatch and route concrete needs to declarative APIs
+
+- **Status:** Accepted
+- **Date:** 2026-06-21
+- **Supersedes:** —
+- **Superseded-by:** —
+- **Amends:** —
+
+---
+
+# No raw CodeMirror `Extension[]` injection slot; keep raw access on the explicitly-unsafe `getView()` escape hatch and route concrete needs to declarative APIs
+
+## Context
+
+A consumer who needs editor behavior the package does not ship — a custom keymap, a bespoke
+decoration, a third-party CM6 extension — has no _blessed_ entry point today. The only escape is the
+`getView()` handle on the React ref (ADR-0013 decision 3), which is documented as **unsafe** ("Raw
+CM6 `EditorView` — no cross-version guarantees"); from it a power user can reconfigure the live view
+by hand (`view.dispatch({ effects: StateEffect.appendConfig.of(ext) })`, or compartment
+reconfiguration) with no contract from us.
+
+The request is to bless a first-class injection slot — an `extensions?: Extension[]` (or
+`(defaults) => Extension[]`) field on `EditorOptions`. This is a **decision** because it adds public
+API, and the public surface is **slated to freeze at 1.0** (#480, milestone `1.0.0`): breaking
+changes are cheap on `0.x` minors now and expensive deliberate majors after, so what we bless here we
+carry. It is also a **boundary** decision — it lands exactly on the line that `CONTEXT.md` invariant
+#3 and ADR-0012 draw.
+
+The tension. `CONTEXT.md` invariant #3 is explicit: the editor exposes **build-time injection
+points**, _not_ a runtime plugin system, and the curated APIs (`slashItems`, `onInsertImage`)
+**deliberately do not expose `EditorView`** (ADR-0012 decision 2). A raw `extensions?: Extension[]`
+slot is effectively "`getView()` at construction time" — it leaks CM6 internals into the surface that
+freezes at 1.0.
+
+### Options weighed
+
+- **A.** Bless `extensions?: Extension[]` (or `(defaults) => Extension[]`), appended at a defined
+  precedence slot.
+- **B.** Keep raw injection as the explicitly-_unsafe_ `getView()` escape hatch only, and push
+  concrete needs into the declarative APIs (#498–#501).
+- **C.** A narrow, named middle ground — e.g. a `keymap`-only slot.
+
+## Decision — B. Do not add a raw injection slot; defer (do not foreclose)
+
+We add **no** `extensions[]` (option A) and **no** `keymap` slot (option C) to `EditorOptions` for
+1.0. Raw, un-contracted access stays where it already is and is already honestly labeled: the
+`getView()` escape hatch (ADR-0013 decision 3). Concrete extensibility needs are routed to the
+**declarative, `EditorView`-free** sibling APIs in the epic (#505): the trigger API (#498), atomic
+token rendering (#499), grouped/async slash items (#500), and `placeholder`/`readOnly`/autosize
+(#501). This is the outcome the epic itself anticipates ("#497 may bless an injection slot or be
+rejected in favour of the declarative APIs — #498–#501 stand alone either way").
+
+This is a **deferral, not a permanent door-slam**, in the established stance of ADR-0012 decision 1
+("we do not open it speculatively now"). If real demand for a _narrow declarative_ slot appears, a
+future ADR can add it on a cheap `0.x` minor before the freeze.
+
+### Why A is rejected — it reverses ADR-0012 decision 2, on both halves
+
+ADR-0012 decision 2 named the **hardest-to-reverse** lock-in: a public API that exposes
+`EditorView`. A raw `extensions[]` slot reintroduces exactly that, doubly:
+
+1. **CM6 becomes a permanent public dependency.** `Extension` is a CM6 type; blessing it ties the
+   frozen 1.0 surface to CodeMirror's package and version, working directly against the portability
+   that ADR-0012 decision 2 and ADR-0013 protect. The declarative APIs (`SlashItemSpec.insert` is a
+   _markdown string_; highlights anchor to _markdown source_) were shaped precisely so that no public
+   type names a CM6 internal.
+2. **A raw extension can break core invariants.** An injected `ViewPlugin`/decoration source that
+   does not go through `guardedDecorations` violates the composing guard (ADR-0004, invariant #1 —
+   "the most expensive invariant"); an injected widget over a table range can break the permanently-
+   hidden table structure and its atomic ranges (ADR-0002/0003). We would be handing consumers a
+   build-time, _blessed_ way to corrupt the invariants the whole package is built to hold — and then
+   freezing that promise at 1.0.
+
+A is, precisely, "`getView()` at construction time." Its capability already exists on `getView()`;
+the only thing blessing it adds is a **contract we cannot keep across the freeze**.
+
+### Why C is rejected — a keymap slot is not actually more declarative, and has a live precedence hazard
+
+C looks like a safe middle ground but fails on two facts that hold _today_:
+
+1. **It carries the same `EditorView` lock-in.** A CM6 keymap binding's `run` is
+   `(view: EditorView) => boolean` — a keymap slot hands the consumer an `EditorView` just as
+   `extensions[]` does. It is only "more declarative" if we invent our own command vocabulary to
+   replace the handler signature, and there is **no demand** to justify that surface.
+2. **A precedence hazard that is visible in the code.** `blockquoteKeymap` and `slashCommand` are
+   `Prec.highest` _on purpose_ (`create-editor.ts`: blockquote Enter/Tab must beat `markdownKeymap`,
+   and yield to the slash menu). A consumer keymap injected without that precedence reasoning would
+   silently break Enter/Tab behavior — a support burden we would own after the freeze.
+
+If a keymap need turns out to be real, the right shape is a _declarative_ command slot designed then,
+under its own ADR — not a raw CM6 keymap blessed now.
+
+## Consequences
+
+- **The 1.0-frozen `EditorOptions` surface stays declarative and CM6-free.** No public type names a
+  CodeMirror internal; portability and the invariants stay defensible (ADR-0012 decision 2 holds
+  unbroken).
+- **Raw access remains available but explicitly unsafe.** Power users keep `getView()` and
+  post-construction reconfiguration (`StateEffect.appendConfig` / compartments). The cost — no
+  cross-version guarantee, and the consumer owns invariant-breakage — is the deliberate price of the
+  raw door, unchanged by this decision.
+- **The concrete needs move, not vanish.** #498–#501 are the blessed channels for the behaviors a raw
+  slot would have served; none of them is blocked on this decision (#505).
+- **The door is left ajar, narrowly.** A future declarative slot (a command vocabulary, a
+  `theme?: Extension` append — already noted as a deliberate scope-cut in `DECISIONS.md`) can be
+  added on a `0.x` minor before the freeze if demand is observed. What this ADR forecloses for 1.0 is
+  only the _raw_, `EditorView`-exposing form.
+
+This ADR establishes no new code surface, so it does not add a public-API bullet; it **reaffirms and
+extends** the existing "Consumer config ≠ plugin API" constraint in `DECISIONS.md` from _runtime_
+plugins to _build-time raw injection_.


### PR DESCRIPTION
Resolves the **#497** decision (parent epic **#505**): should `@beaket/paper` bless a raw `extensions?: Extension[]` injection slot on `EditorOptions`?

## Decision — B: no raw injection slot

No blessed `extensions[]` (or `keymap`) slot on `EditorOptions`. Raw access stays on the explicitly-**unsafe** `getView()` escape hatch (ADR-0013); concrete extensibility needs route to the declarative sibling APIs (#498–#501).

**Why the alternatives lose:**
- **A (bless `extensions[]`)** reverses ADR-0012 decision 2, on both halves: it makes CM6 a **permanent public dependency** on the surface that *freezes at 1.0* (#480), and a raw extension can **break the core invariants** (composing guard ADR-0004, table atomic ranges ADR-0002/0003). A is "`getView()` at construction time."
- **C (keymap-only slot)** isn't actually more declarative — a CM6 keymap's `run` is `(view: EditorView) => boolean`, so it carries the **same `EditorView` lock-in**, plus a precedence hazard (`blockquoteKeymap`/`slashCommand` are `Prec.highest` deliberately; a consumer keymap silently breaks Enter/Tab).
- **B** adds zero surface, so it's the **reversible, pre-freeze-safe** choice — a *declarative* slot can still be added on a cheap `0.x` minor if real demand appears. Framed as a deferral, not a door-slam (ADR-0012 decision 1's no-speculative-opening stance).

**Mindful of #505:** this is the epic-blessed outcome (#505 anticipates "rejected in favour of the declarative APIs — #498–#501 stand alone either way"); no sibling issues are touched, and #480 (the freeze gate) is cross-referenced.

## Changes
- `docs/adr/0015-no-raw-codemirror-extension-injection-slot.md` — new ADR (`Accepted`)
- `docs/DECISIONS.md` — extend "Consumer config ≠ plugin API" from runtime plugins to build-time raw injection
- `docs/CONTEXT.md` — invariant #3 cites ADR-0015 + states curated APIs don't expose `EditorView`
- `README.md` — mark `getView()` as the deliberate unguaranteed escape hatch (no blessed `extensions` slot)
- `.changeset/*` — patch (`@beaket/paper`); the README ships to npm

## Done-when
- [x] ADR records the decision (invariant #3 / ADR-0012 reaffirmed — not revised, since B adds no surface)
- [x] No surface added → no new public-API entry; constraint folded into existing DECISIONS.md bullet
- [x] Docs: consumer-facing pointer to the `getView()` escape hatch

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)