### PR TITLE
chore(renovate): vulnerabilityAlerts + lockfile maintenance (single-bot security flow)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,8 +8,7 @@
     }
   ],
   "vulnerabilityAlerts": {
-    "labels": ["security"],
-    "automerge": true
+    "labels": ["security"]
   },
   "osvVulnerabilityAlerts": true,
   "lockFileMaintenance": {

--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,14 @@
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     }
-  ]
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "automerge": true
+  },
+  "osvVulnerabilityAlerts": true,
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  }
 }


### PR DESCRIPTION
Extends the autonomous-maintenance cadence to **security/dependencies**, token-cheap (bots do the mechanical part; Claude only judges majors/high-severity in the weekly review). Single-bot by design: **Renovate** is the only bot that opens dependency PRs.

## Change (`renovate.json`)
- **`vulnerabilityAlerts: { labels: ["security"] }`** — Renovate raises security-fix PRs labelled `security`. Auto-merge is governed by the existing `minor`/`patch` rule (configs merge): **patch/minor vuln fixes auto-merge when CI is green; major vuln fixes get labelled but surface as PRs for human / weekly-review judgment** (no breaking change merged unattended).
- **`osvVulnerabilityAlerts`** — widens vuln detection beyond GitHub advisories (OSV DB).
- **`lockFileMaintenance`** (auto-merged) — weekly lockfile refresh so **transitive** vulns resolve without manual work (the 2 currently-open alerts — `js-yaml` medium, `esbuild` low — are transitive).
- Existing minor/patch auto-merge kept; **majors** still surface as PRs.
- Validated with `renovate-config-validator` ✅. No changeset needed — root-level config, outside `src/**` / `packages/**`.

## Repo settings (out of diff)
- **Disabled GitHub Dependabot *automated security fixes*** (the separate auto-PR stream) so it doesn't duel with Renovate. Dependabot vulnerability **alerts/detection stay ON** — the weekly review reads them.

## Accompanying cadence changes (cloud routines + labels, out of diff)
- New labels: `area:ui`, `area:cli`, `security`.
- **`tactical-drain`** (was `paper-tactical-drain`): empty queue → **cheap no-op** (discovery moved to the weekly review); scope extended to drain the top `agent:ready` across `area:paper` ∪ `area:ui`/`area:cli`, rules branched by area.
- **`weekly-review`** (was `paper-strategic-review`): one consolidated Sunday run covering **paper + ui + security**, and it will **auto-draft the @beaket/ui `CONTEXT.md`** map as a docs-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)