### PR TITLE
feat(paper): async and grouped slash menu items (#500)

### DIFF
--- a/.changeset/paper-async-grouped-slash-items.md
+++ b/.changeset/paper-async-grouped-slash-items.md
@@ -1,0 +1,10 @@
+---
+"@beaket/paper": minor
+---
+
+Async and grouped slash menu items — child ④ of the embedding/extensibility epic (#500, ADR-0012 amendment). Two backward-compatible extensions to the existing `slashItems` declarative spec:
+
+- **Async catalog:** the transformer may now return a `Promise` (`(defaults) => SlashItemSpec[] | Promise<SlashItemSpec[]>`). The catalog is resolved **once** on first open and cached, then filtered synchronously per keystroke — preserving the slash menu's "filter a static list locally" identity. A non-interactive **"Loading…"** row shows while pending; a catalog that resolves empty, or a query that filters to zero, closes the menu (unchanged). Per-query async is deliberately left to the `triggers` API (ADR-0016), not duplicated here.
+- **Group section headers:** `SlashItemSpec` gains an optional `group?: string`. A header is rendered at each group boundary — the consumer clusters by ordering items (consistent with "array order = display order"; no `priority`). Headers are woven in after filtering, so a group whose items all filter out shows no empty header, and the selection always lands on a selectable row. The default menu, and any consumer that omits `group`, stays divider-free.
+
+Internally: `resolveSlashItems` stays synchronous (its contract tests unchanged); a thin `resolveSlashConfig` branches on promise-ness and the `SlashMenu` plugin holds the resolved catalog as instance state, re-evaluating through the IME-guarded path on async settle (no DOM rebuild mid-composition, invariant #1). The shared menu engine gained one non-interactive-row type that serves both group headers and the Loading row (keyboard nav skips it, selection indexes selectable rows only); the trigger menu, which emits no headers, is byte-identical. New pure contract-test seam `buildMenuRows(items, query)` (filter + header insertion) alongside the unchanged `resolveSlashItems`; async resolution and loading-row geometry are browser-verified in the `sites/paper` playground.

--- a/packages/paper/docs/CONTEXT.md
+++ b/packages/paper/docs/CONTEXT.md
@@ -104,10 +104,13 @@ there is no second document model. Everything else follows from this:
 **Menus (trigger-activated)**
 
 - `extensions/menu-engine.ts` — the shared popup-menu engine (`PopupMenu`, `menuKeyBindings` /
-  `menuKeymap`, `menuTheme`): menu DOM, selected-index, keyboard nav, porcelain overlay. Both menus
-  below are thin controllers over it (ADR-0016). Coordinate-dependent → browser-verified, not jsdom.
+  `menuKeymap`, `menuTheme`): menu DOM, selected-index, keyboard nav, porcelain overlay, and
+  non-interactive header/loading rows (selection skips them). Both menus below are thin controllers
+  over it (ADR-0016). Coordinate-dependent → browser-verified, not jsdom.
 - `extensions/slash-command.ts` — the `/` insert menu; declarative `slashItems` config + privileged
-  built-ins (table `after`). `resolveSlashItems` is the pure test seam. → ADR-0012.
+  built-ins (table `after`). Catalog resolves sync or **async** (once-cached, Loading row) and items
+  carry an optional `group` rendered as section headers (ADR-0012 + its amendment). `resolveSlashItems`
+  (sync resolve) and `buildMenuRows` (filter + headers) are the pure test seams. → ADR-0012.
 - `extensions/trigger-menu.ts` — declarative consumer triggers (`@` mentions, `[[` wikilinks); the
   `triggers` option, async `onQuery` with stale-response discarding, `onSelect` + `data` passthrough.
   `matchTrigger` / `isResponseCurrent` are the pure test seams. → ADR-0016.

--- a/packages/paper/docs/DECISIONS.md
+++ b/packages/paper/docs/DECISIONS.md
@@ -54,8 +54,12 @@ change needs an ADR vs. a changeset. Each bullet below links to its ADR.
   ([ADR-0009](./adr/0009-visual-language-porcelain-tokens-cjk-typography.md))
 - **Extensibility = mechanism-in-editor / policy-in-consumer.** Images render in the source model;
   _ingestion_ is delegated to the consumer (`onInsertImage`). Slash items are a declarative consumer
-  contract with a transformer override; privileged built-ins are kept separate. **Custom autocomplete
-  triggers** (`@` mentions, `[[` wikilinks) ride the same family: `triggers?: TriggerSpec[]`, an
+  contract with a transformer override; privileged built-ins are kept separate. The `slashItems`
+  transformer may resolve **asynchronously** (once-cached on first open, then filtered locally — a
+  Loading row meanwhile) and items carry an optional `group` rendered as section headers; per-query
+  async is left to `triggers`, not the slash menu ([ADR-0012 amendment](./adr/0012-slash-items-consumer-config.md)).
+  **Custom autocomplete triggers** (`@` mentions, `[[` wikilinks) ride the same family:
+  `triggers?: TriggerSpec[]`, an
   async `onQuery` source whose items insert a **markdown string** (no `EditorView` exposed), with an
   `onSelect`/`data` passthrough to recover the picked entity. One shared menu engine
   (`menu-engine.ts`) backs both the slash menu and the trigger menu; only one is ever open. **Inserted

--- a/packages/paper/docs/adr/0012-slash-items-consumer-config.md
+++ b/packages/paper/docs/adr/0012-slash-items-consumer-config.md
@@ -1,11 +1,12 @@
 # 0012 — Slash items are opened through consumer config — a declarative contract, transformer override, and a separation of privileged built-ins
 
-- **Status:** Accepted
+- **Status:** Amended
 - **Date:** 2026-06-16
 - **Provenance:** Imported & translated from the `sandbox-beaket-editor` prototype on 2026-06-21.
 - **Supersedes:** —
 - **Superseded-by:** —
 - **Amends:** —
+- **Amended-by:** Amendment 2026-06-21 (#500) — async catalog + group section headers (see foot of file).
 
 ---
 
@@ -91,3 +92,59 @@ Even as items grow, the visual language stays as it is today (label-centric, por
 - Item injection does not change the decoration or DOM-recompute path — the composing guard contract (ADR-0004) is maintained by the existing `SlashMenu` unchanged (open/close/filter deferred while composing).
 - **Deterministic contract test (ADR-0005):** spec → internal-item resolution, transformer application, `id` → behavior reattachment, order preservation, and filter matching are unit-tested under jsdom (coordinate-independent) through the pure function `resolveSlashItems`. red → green.
 - Coordinate-dependent concerns (menu position, scroll overflow) cannot run under jsdom → verified in the 5173 browser.
+
+---
+
+## Amendment (2026-06-21, #500) — async catalog resolution and group section headers
+
+The decision above stands; this extends the **declarative spec** in two backward-compatible ways for
+richer menus (#500, child ④ of the embedding epic #505). Both ride the existing channel — they add to
+`SlashItemSpec` / `SlashItemsConfig`, not a new API — so decisions 1–5 above hold unchanged.
+
+### Async catalog — once-cached, not per-query
+
+The transformer may now return a `Promise`:
+
+```ts
+type SlashItemsConfig =
+  | SlashItemSpec[]
+  | ((defaults: SlashItemSpec[]) => SlashItemSpec[] | Promise<SlashItemSpec[]>);
+```
+
+The catalog is resolved **once** on the menu's first open and **cached**, then filtered synchronously
+on every keystroke. This preserves the slash menu's identity — _filter a static list internally_ — the
+asymmetry ADR-0016 drew against the trigger menu (whose `onQuery` filters per query). **Per-query async
+is deliberately not added here:** that is exactly what the `triggers` API (ADR-0016) already provides; a
+per-keystroke refetch on the slash menu would duplicate it and lose the local-filter snappiness.
+
+States are concrete: while the promise is pending the menu shows a single non-interactive **"Loading…"**
+row; a catalog that resolves **empty** closes the menu; a query that filters to **zero** items closes the
+menu — the _existing_ behavior, kept byte-stable (no new "no results" row).
+
+### Group section headers — boundary-emitted, consumer-clustered
+
+`SlashItemSpec` gains an optional `group?: string`. A non-interactive header is emitted whenever a
+**surviving** item's `group` differs from the previous survivor's. This **revises decision 5** ("we add
+no section dividers"): dividers are now possible, but **only when the consumer opts in** by setting
+`group` — the default menu, and any consumer that omits `group`, stays divider-free, so the lightness
+that decision 5 protected holds for the common case. Consequences, chosen to stay consistent with
+decision 4 (_array order = display order_; no `priority`):
+
+- The **consumer clusters** by ordering items; the editor does not reorder. Non-contiguous same-group
+  items therefore repeat the header — accepted, since order is the consumer's to state.
+- Headers are woven in **after** filtering, over the survivors — so a group whose items all filter out
+  shows **no empty header**, and the preserved selection index always lands on a selectable row.
+- Ungrouped items render with no header.
+
+### Mechanism (reversible, internal)
+
+- `resolveSlashItems` stays **synchronous** (its contract tests are unchanged); a thin
+  `resolveSlashConfig` branches on promise-ness and only the async branch defers. The `SlashMenu` plugin
+  holds the resolved catalog as instance state, fires the promise once, and on resolve re-evaluates
+  **through the IME-guarded path** (never rebuilding DOM mid-composition — invariant #1).
+- The shared menu engine (`menu-engine.ts`, ADR-0016) gained one **non-interactive row** type that
+  serves both group headers and the "Loading…" row; keyboard navigation skips it, selection indexes
+  selectable rows only. The trigger menu, which emits no headers, is byte-identical.
+- New pure contract-test seam (ADR-0005): `buildMenuRows(items, query)` — filter + header insertion —
+  alongside the unchanged `resolveSlashItems`. Async resolution and the loading-row geometry are
+  browser-verified (invariant #4).

--- a/packages/paper/src/editor/create-editor.ts
+++ b/packages/paper/src/editor/create-editor.ts
@@ -53,6 +53,9 @@ export interface EditorOptions {
   /**
    * Extends/replaces the slash menu items (consumer config, ADR-0012). Default items if unspecified.
    * - flat array → full replacement  - function `(defaults) => items` → derive from defaults (recommended)
+   * The transformer may return a `Promise` to load the catalog **asynchronously** (resolved once on
+   * first open, then filtered locally; a "Loading…" row shows meanwhile), and each item may carry an
+   * optional `group` to render section headers (ADR-0012 amendment).
    */
   slashItems?: SlashItemsConfig;
   /**

--- a/packages/paper/src/editor/extensions/menu-engine.ts
+++ b/packages/paper/src/editor/extensions/menu-engine.ts
@@ -12,6 +12,11 @@ import { EditorView, keymap } from "@codemirror/view";
 /** Minimal shape the engine needs to render one menu row. Controllers extend it with their own fields. */
 export interface MenuRow {
   label: string;
+  /**
+   * A non-interactive row — a group section header or a "Loading…" placeholder (ADR-0012 amendment).
+   * Rendered as plain text, never a button: not clickable, and keyboard navigation skips it.
+   */
+  header?: boolean;
 }
 
 /** Per-menu class names — kept distinct so the stable `.cm-slash-menu` consumer hook is preserved. */
@@ -20,6 +25,8 @@ export interface MenuClasses {
   menu: string;
   /** Class on the selected row button (e.g. `cm-slash-selected`). */
   selected: string;
+  /** Class on a non-interactive header/loading row (e.g. `cm-slash-header`). */
+  header: string;
 }
 
 /**
@@ -29,7 +36,8 @@ export interface MenuClasses {
  */
 export class PopupMenu<T extends MenuRow> {
   private el: HTMLElement | null = null;
-  private rows: T[] = [];
+  /** The selectable (non-header) rows, in display order — `selected` indexes into this, never headers. */
+  private items: T[] = [];
   private selected = 0;
 
   constructor(
@@ -42,17 +50,33 @@ export class PopupMenu<T extends MenuRow> {
     return this.el !== null;
   }
 
-  /** (Re)open at the given source position. The selected index is preserved across re-filtering. */
+  /**
+   * (Re)open at the given source position. `rows` may interleave non-interactive header rows
+   * (`row.header`) with selectable items; headers render as plain text and are skipped by selection.
+   * The selected index is preserved across re-filtering (clamped to the selectable rows).
+   */
   open(anchorPos: number, rows: T[]): void {
-    this.rows = rows;
     const coords = this.view.coordsAtPos(anchorPos);
     this.closeDOM();
     if (!coords) return;
 
+    const items = rows.filter((row) => !row.header);
+    this.items = items;
+    this.selected =
+      items.length === 0 ? -1 : Math.max(0, Math.min(this.selected, items.length - 1));
+
     const menu = document.createElement("div");
     menu.className = this.classes.menu;
-    this.selected = Math.max(0, Math.min(this.selected, rows.length - 1));
-    rows.forEach((row, i) => {
+    let itemIndex = 0;
+    for (const row of rows) {
+      if (row.header) {
+        const head = document.createElement("div");
+        head.className = this.classes.header;
+        head.textContent = row.label;
+        menu.appendChild(head);
+        continue;
+      }
+      const i = itemIndex++;
       const btn = document.createElement("button");
       btn.type = "button";
       btn.textContent = row.label;
@@ -60,7 +84,7 @@ export class PopupMenu<T extends MenuRow> {
       btn.addEventListener("mousedown", (e) => e.preventDefault());
       btn.addEventListener("click", () => this.onApply(row));
       menu.appendChild(btn);
-    });
+    }
     menu.style.left = `${coords.left}px`;
     menu.style.top = `${coords.bottom + 4}px`;
     // Attach to view.dom so the EditorView.theme scope (under .cm-editor) applies.
@@ -69,8 +93,9 @@ export class PopupMenu<T extends MenuRow> {
   }
 
   moveSelection(delta: -1 | 1): void {
-    if (!this.el || this.rows.length === 0) return;
-    this.selected = (this.selected + delta + this.rows.length) % this.rows.length;
+    if (!this.el || this.items.length === 0) return;
+    this.selected = (this.selected + delta + this.items.length) % this.items.length;
+    // Only selectable rows are <button>s, so the button list aligns 1:1 with `this.items`.
     this.el.querySelectorAll("button").forEach((btn, i) => {
       const on = i === this.selected;
       btn.classList.toggle(this.classes.selected, on);
@@ -79,14 +104,14 @@ export class PopupMenu<T extends MenuRow> {
   }
 
   applySelected(): void {
-    const row = this.rows[this.selected];
+    const row = this.items[this.selected];
     if (row) this.onApply(row);
   }
 
   close(): void {
     this.closeDOM();
     this.selected = 0;
-    this.rows = [];
+    this.items = [];
   }
 
   private closeDOM(): void {
@@ -169,5 +194,16 @@ export const menuTheme = EditorView.theme({
   ".cm-slash-menu button.cm-slash-selected, .cm-trigger-menu button.cm-trigger-selected": {
     backgroundColor: "var(--accent-sel)",
     color: "var(--accent)",
+  },
+  // Non-interactive header / "Loading…" row (ADR-0012 amendment): a muted, uppercased label, set
+  // apart from the items. No hover/selection — it is never a button.
+  ".cm-slash-header, .cm-trigger-header": {
+    padding: "6px 10px 2px",
+    fontSize: "11px",
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: "0.04em",
+    color: "var(--steel)",
+    userSelect: "none",
   },
 });

--- a/packages/paper/src/editor/extensions/slash-command.test.ts
+++ b/packages/paper/src/editor/extensions/slash-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { defaultSlashItems, resolveSlashItems } from "./slash-command";
+import { buildMenuRows, defaultSlashItems, resolveSlashItems } from "./slash-command";
 
 // Slash item consumer config contract (ADR-0012). resolveSlashItems is a coordinate-independent
 // pure function, so it is a deterministic unit-test target (ADR-0005). Menu position/scroll are
@@ -72,5 +72,81 @@ describe("resolveSlashItems — transformer (derived)", () => {
 
   it("returning an empty array yields no items (menu closes, same as a filter result of 0)", () => {
     expect(resolveSlashItems(() => [])).toEqual([]);
+  });
+});
+
+describe("resolveSlashItems — group is carried through (ADR-0012 amendment)", () => {
+  it("carries the spec's group onto the internal item; absent group stays undefined", () => {
+    const items = resolveSlashItems([
+      { label: "A", insert: "a", group: "Blocks" },
+      { label: "B", insert: "b" },
+    ]);
+    expect(items.map((i) => i.group)).toEqual(["Blocks", undefined]);
+  });
+
+  it("an async transformer (returns a Promise) yields an empty sync list — async rides the plugin", () => {
+    expect(resolveSlashItems(() => Promise.resolve([{ label: "X", insert: "x" }]))).toEqual([]);
+  });
+});
+
+// buildMenuRows: filter + group section headers (ADR-0012 amendment). Pure → jsdom contract test;
+// the rendered DOM / keyboard nav is browser-verified (invariant #4). A header row has `header: true`.
+const rows = (config: Parameters<typeof resolveSlashItems>[0], query: string) =>
+  buildMenuRows(resolveSlashItems(config), query).map((r) => (r.header ? `# ${r.label}` : r.label));
+
+describe("buildMenuRows — filtering", () => {
+  const items: { label: string; insert: string; keywords?: string }[] = [
+    { label: "Table", insert: "t", keywords: "grid" },
+    { label: "Heading 1", insert: "h" },
+  ];
+
+  it("matches on label or keywords, case-insensitively", () => {
+    expect(rows(items, "grid")).toEqual(["Table"]);
+    expect(rows(items, "HEAD")).toEqual(["Heading 1"]);
+  });
+
+  it("an empty query keeps every item, in order", () => {
+    expect(rows(items, "")).toEqual(["Table", "Heading 1"]);
+  });
+});
+
+describe("buildMenuRows — group section headers (boundary semantics)", () => {
+  const grouped = [
+    { label: "Table", insert: "t", group: "Blocks" },
+    { label: "Quote", insert: "q", group: "Blocks" },
+    { label: "Image", insert: "i", group: "Media" },
+  ];
+
+  it("emits a header at each group boundary, not per item", () => {
+    expect(rows(grouped, "")).toEqual(["# Blocks", "Table", "Quote", "# Media", "Image"]);
+  });
+
+  it("shows no header for a group whose items all filter out", () => {
+    // Only the Media item survives → its header shows, the (now-empty) Blocks header does not.
+    expect(rows(grouped, "image")).toEqual(["# Media", "Image"]);
+  });
+
+  it("repeats the header when the same group is non-contiguous (consumer owns clustering)", () => {
+    const interleaved = [
+      { label: "Table", insert: "t", group: "Blocks" },
+      { label: "Image", insert: "i", group: "Media" },
+      { label: "Quote", insert: "q", group: "Blocks" },
+    ];
+    expect(rows(interleaved, "")).toEqual([
+      "# Blocks",
+      "Table",
+      "# Media",
+      "Image",
+      "# Blocks",
+      "Quote",
+    ]);
+  });
+
+  it("renders ungrouped items with no header, then grouped sections", () => {
+    const mixed = [
+      { label: "Plain", insert: "p" },
+      { label: "Table", insert: "t", group: "Blocks" },
+    ];
+    expect(rows(mixed, "")).toEqual(["Plain", "# Blocks", "Table"]);
   });
 });

--- a/packages/paper/src/editor/extensions/slash-command.ts
+++ b/packages/paper/src/editor/extensions/slash-command.ts
@@ -29,14 +29,26 @@ export interface SlashItemSpec {
   insert: string;
   /** Cursor position after insertion (offset from insertion start). Defaults to end of insertion. */
   cursorOffset?: number;
+  /**
+   * Optional section header this item sits under (ADR-0012 amendment). A header is rendered whenever
+   * `group` changes from the previous item's, so the consumer clusters items by ordering them — the
+   * same "array order = display order" rule as the rest of the spec. Items without a `group` render
+   * with no header.
+   */
+  group?: string;
 }
 
 /**
  * How a consumer treats the default items (ADR-0012):
  * - flat array → complete replacement (only their own items)
- * - function → derive from defaults (recommended). Returned array order = display order.
+ * - function → derive from defaults (recommended). Returned array order = display order. May return a
+ *   `Promise` to load the catalog **asynchronously** (ADR-0012 amendment): the catalog is resolved
+ *   once on first open and cached, then filtered synchronously per keystroke. Per-query async sources
+ *   are deliberately not offered here — that is what the `triggers` API (ADR-0016) is for.
  */
-export type SlashItemsConfig = SlashItemSpec[] | ((defaults: SlashItemSpec[]) => SlashItemSpec[]);
+export type SlashItemsConfig =
+  | SlashItemSpec[]
+  | ((defaults: SlashItemSpec[]) => SlashItemSpec[] | Promise<SlashItemSpec[]>);
 
 /** Internal item — includes the privileged action (after). Not exposed. */
 interface SlashItem {
@@ -44,6 +56,7 @@ interface SlashItem {
   keywords: string;
   insert: string;
   cursorOffset?: number;
+  group?: string;
   /** Post-processing after insertion (activating a table cell, etc.). from = insertion start position */
   after?: (view: EditorView, from: number) => void;
 }
@@ -86,29 +99,68 @@ function specToItem(spec: SlashItemSpec): SlashItem {
     keywords: spec.keywords ?? "",
     insert: spec.insert,
     cursorOffset: spec.cursorOffset,
+    group: spec.group,
     // The privileged action is reattached internally via the built-in ID, not via the public spec (ADR-0012 decision 3)
     after: spec.id ? BUILTIN_BEHAVIORS[spec.id] : undefined,
   };
 }
 
-/**
- * consumer config → internal item list. A pure function (coordinate-independent), so it is a
- * unit-test target (ADR-0005).
- * - unspecified → default items
- * - flat array → complete replacement
- * - function → derive by passing a copy of defaults (prevents mutating the original)
- */
-export function resolveSlashItems(config?: SlashItemsConfig): SlashItem[] {
-  const specs =
-    typeof config === "function"
-      ? config(defaultSlashItems.map((s) => ({ ...s })))
-      : (config ?? defaultSlashItems);
+/** The pure, synchronous spec→item mapper. Async resolution rides this once the specs have settled. */
+function specsToItems(specs: SlashItemSpec[]): SlashItem[] {
   return specs.map(specToItem);
 }
 
-/** **Internal** facet that carries the resolved items to the plugin (not public). */
-const slashItemsFacet = Facet.define<SlashItem[], SlashItem[]>({
-  combine: (values) => values[0] ?? resolveSlashItems(),
+/**
+ * consumer config → specs. May be async (the transformer returned a `Promise`, ADR-0012 amendment),
+ * so it returns `specs | Promise<specs>`; the sync path is untouched and immediate.
+ * - unspecified → default items  - flat array → complete replacement  - function → derive from a copy
+ */
+function resolveSlashConfig(config?: SlashItemsConfig): SlashItemSpec[] | Promise<SlashItemSpec[]> {
+  if (typeof config === "function") return config(defaultSlashItems.map((s) => ({ ...s })));
+  return config ?? defaultSlashItems;
+}
+
+/**
+ * consumer config → internal item list, **synchronously** (ADR-0005 unit-test target). Unchanged for
+ * sync configs; an async transformer is resolved through the plugin's cached catalog, not here, so a
+ * Promise result yields an empty list rather than slipping into the sync map.
+ */
+export function resolveSlashItems(config?: SlashItemsConfig): SlashItem[] {
+  const specs = resolveSlashConfig(config);
+  return specs instanceof Promise ? [] : specsToItems(specs);
+}
+
+/** A rendered slash row: a selectable item, or a non-interactive group header / "Loading…" row. */
+export type SlashMenuRow = (SlashItem & { header?: false }) | { header: true; label: string };
+
+/**
+ * Filter the catalog by `query` and weave in group section headers (ADR-0012 amendment). Pure and
+ * coordinate-independent → the jsdom contract-test seam (ADR-0005). A header is emitted whenever a
+ * surviving item's `group` differs from the previous survivor's, so: a group whose items all filter
+ * out shows **no** header; non-contiguous same-group runs repeat the header (the consumer owns
+ * clustering); ungrouped items render with no header.
+ */
+export function buildMenuRows(items: SlashItem[], query: string): SlashMenuRow[] {
+  const q = query.toLowerCase();
+  const rows: SlashMenuRow[] = [];
+  let lastGroup: string | undefined;
+  for (const item of items) {
+    if (!item.label.toLowerCase().includes(q) && !item.keywords.toLowerCase().includes(q)) continue;
+    if (item.group !== undefined && item.group !== lastGroup) {
+      rows.push({ header: true, label: item.group });
+    }
+    rows.push(item);
+    lastGroup = item.group;
+  }
+  return rows;
+}
+
+/** The non-interactive row shown while an async catalog is still resolving (ADR-0012 amendment). */
+const LOADING_ROW: SlashMenuRow = { header: true, label: "Loading…" };
+
+/** **Internal** facet that carries the raw consumer config to the plugin (resolved there; not public). */
+const slashConfigFacet = Facet.define<SlashItemsConfig | undefined, SlashItemsConfig | undefined>({
+  combine: (values) => values[0],
 });
 
 const TRIGGER_RE = /(?:^|\s)([/、；／])(\S*)$/;
@@ -120,19 +172,57 @@ const TRIGGER_RE = /(?:^|\s)([/、；／])(\S*)$/;
  * unlike the consumer trigger menu, whose source (`onQuery`) does its own filtering.
  */
 class SlashMenu implements MenuController {
-  private readonly popup: PopupMenu<SlashItem>;
+  private readonly popup: PopupMenu<SlashMenuRow>;
   private triggerPos = -1;
+  /** The resolved catalog, filtered synchronously per keystroke. `null` until first resolved. */
+  private catalog: SlashItem[] | null = null;
+  private loading = false;
 
   constructor(private readonly view: EditorView) {
     this.popup = new PopupMenu(
       view,
-      { menu: "cm-slash-menu", selected: "cm-slash-selected" },
-      (item) => this.apply(item),
+      { menu: "cm-slash-menu", selected: "cm-slash-selected", header: "cm-slash-header" },
+      (row) => {
+        if (!row.header) this.apply(row);
+      },
     );
   }
 
   get isOpen(): boolean {
     return this.popup.isOpen;
+  }
+
+  /**
+   * Resolve the catalog **lazily on first open** and cache it (ADR-0012 amendment): a consumer who
+   * never opens the menu pays no fetch. Sync configs resolve immediately; an async transformer flips
+   * `loading` (so the next render shows a Loading row) and, once settled, re-evaluates through the
+   * IME-guarded path — never rebuilding DOM mid-composition (invariant #1).
+   */
+  private ensureCatalog(): void {
+    if (this.catalog !== null || this.loading) return;
+    const resolved = resolveSlashConfig(this.view.state.facet(slashConfigFacet));
+    if (resolved instanceof Promise) {
+      this.loading = true;
+      // Re-evaluate only if the menu is still open (and not composing): if the user pressed Escape, or
+      // the editor was destroyed, while the catalog was loading, the resolved fetch must not reopen the
+      // dismissed menu (close() leaves the trigger text in place, so evaluate would re-match) nor act on
+      // a dead view. The `.catch` re-evaluates too, so a rejected fetch clears the Loading row at once.
+      const settle = () => {
+        this.loading = false;
+        if (!this.view.composing && this.popup.isOpen) setTimeout(() => this.evaluate());
+      };
+      resolved
+        .then((specs) => {
+          this.catalog = specsToItems(specs);
+          settle();
+        })
+        .catch(() => {
+          this.catalog = [];
+          settle();
+        });
+    } else {
+      this.catalog = specsToItems(resolved);
+    }
   }
 
   update(update: ViewUpdate): void {
@@ -159,13 +249,16 @@ class SlashMenu implements MenuController {
     if (trigger !== "/" && query.length < 1) return this.close();
 
     this.triggerPos = sel.head - query.length - 1;
-    const q = query.toLowerCase();
-    const items = state.facet(slashItemsFacet);
-    const filtered = items.filter(
-      (item) => item.label.toLowerCase().includes(q) || item.keywords.toLowerCase().includes(q),
-    );
-    if (filtered.length === 0) return this.close();
-    this.popup.open(this.triggerPos, filtered);
+    this.ensureCatalog();
+    // Async catalog still loading → a single non-interactive Loading row (ADR-0012 amendment).
+    if (this.loading) {
+      this.popup.open(this.triggerPos, [LOADING_ROW]);
+      return;
+    }
+    const rows = buildMenuRows(this.catalog ?? [], query);
+    // No selectable item survived the filter (or the catalog resolved empty) → close, as before.
+    if (!rows.some((row) => !row.header)) return this.close();
+    this.popup.open(this.triggerPos, rows);
   }
 
   moveSelection(delta: -1 | 1): void {
@@ -212,11 +305,5 @@ const slashPlugin = ViewPlugin.fromClass(SlashMenu);
 const slashKeymap = menuKeymap((view) => view.plugin(slashPlugin));
 
 export function slashCommand(config?: SlashItemsConfig): Extension {
-  return [
-    composingWake,
-    slashItemsFacet.of(resolveSlashItems(config)),
-    slashPlugin,
-    slashKeymap,
-    menuTheme,
-  ];
+  return [composingWake, slashConfigFacet.of(config), slashPlugin, slashKeymap, menuTheme];
 }

--- a/packages/paper/src/editor/extensions/trigger-menu.ts
+++ b/packages/paper/src/editor/extensions/trigger-menu.ts
@@ -119,7 +119,7 @@ class TriggerMenu implements MenuController {
   constructor(private readonly view: EditorView) {
     this.popup = new PopupMenu(
       view,
-      { menu: "cm-trigger-menu", selected: "cm-trigger-selected" },
+      { menu: "cm-trigger-menu", selected: "cm-trigger-selected", header: "cm-trigger-header" },
       (item) => this.apply(item),
     );
   }

--- a/sites/paper/src/components/editor-playground.tsx
+++ b/sites/paper/src/components/editor-playground.tsx
@@ -2,10 +2,39 @@ import {
   type ColorScheme,
   Paper,
   type PaperHandle,
+  type SlashItemsConfig,
   type TokenSpec,
   type TriggerSpec,
 } from "@beaket/paper/react";
 import { useEffect, useRef, useState } from "react";
+
+// Async + grouped slash items (ADR-0012 amendment). The transformer returns a Promise — modelling a
+// catalog fetched on first open, with a short delay so the non-interactive "Loading…" row is visible —
+// and tags items with `group`, so the menu renders "Blocks" / "Templates" section headers. Built-ins
+// keep their order; the consumer clusters by ordering. Resolution is lazy + cached: only the first `/`
+// open waits; subsequent opens are instant.
+const slashItems: SlashItemsConfig = (defaults) =>
+  new Promise((resolve) =>
+    setTimeout(
+      () =>
+        resolve([
+          ...defaults.map((item) => ({ ...item, group: "Blocks" })),
+          {
+            label: "Meeting notes",
+            keywords: "template meeting",
+            insert: "## Meeting notes\n\n- ",
+            group: "Templates",
+          },
+          {
+            label: "Daily log",
+            keywords: "template daily",
+            insert: "## Daily log\n\n- [ ] ",
+            group: "Templates",
+          },
+        ]),
+      500,
+    ),
+  );
 
 // A declarative `@`-mention trigger (ADR-0016). `onQuery` filters a directory — async here, to model a
 // real fetch — and returns declarative items: each inserts a markdown link (single source of truth), and
@@ -49,7 +78,7 @@ A markdown-first, CJK-first **Live Preview** editor built on CodeMirror 6.
 
 Try it:
 
-- Type \`/\` to open the slash menu
+- Type \`/\` to open the slash menu — items load async and are grouped (Blocks · Templates)
 - Type \`@\` to mention someone — it renders as an atomic chip (Backspace removes it whole)
 - Drop an image, paste a table, write some \`code\`
 
@@ -168,6 +197,7 @@ export function EditorPlayground() {
           defaultValue={INITIAL}
           onChange={setMarkdown}
           colorScheme={scheme}
+          slashItems={slashItems}
           triggers={[mentionTrigger]}
           tokens={[mentionToken]}
         />


### PR DESCRIPTION
Closes #500. Child ④ of the embedding/extensibility epic #505. With this merged, the **interface-core children #497–#500 are all done**.

## What

Two backward-compatible extensions to the existing `slashItems` declarative spec (an **ADR-0012 amendment**, not a new ADR — per the issue):

- **Async catalog.** The transformer may now return a `Promise`:
  ```ts
  type SlashItemsConfig =
    | SlashItemSpec[]
    | ((defaults: SlashItemSpec[]) => SlashItemSpec[] | Promise<SlashItemSpec[]>);
  ```
  Resolved **lazily on first open** and cached, then filtered synchronously per keystroke — preserving the slash menu's "filter a static list locally" identity (the asymmetry ADR-0016 drew against `triggers`). A non-interactive **"Loading…"** row shows while pending; a catalog that resolves empty, or a query that filters to zero, closes the menu (unchanged). Per-query async is deliberately left to `triggers` (ADR-0016), not duplicated here.
- **Group section headers.** `SlashItemSpec` gains an optional `group?: string`. A header is emitted at each group boundary — the consumer clusters by ordering (consistent with "array order = display order"; no `priority`). Woven in *after* filtering, so a group whose items all filter out shows no empty header, and selection always lands on a selectable row. The default menu, and any consumer omitting `group`, stays divider-free.

## How

- `resolveSlashItems` stays **synchronous** (its contract tests unchanged); a thin `resolveSlashConfig` branches on promise-ness, and the `SlashMenu` plugin holds the catalog as instance state, re-evaluating through the **IME-guarded** path on async settle (no DOM rebuild mid-composition, invariant #1). The settle re-eval is guarded on `popup.isOpen`, so a fetch that resolves after **Escape** (or editor destroy) doesn't reopen the dismissed menu.
- The shared **menu engine** gained one non-interactive-row type serving both group headers and the Loading row (keyboard nav skips it; selection indexes selectable rows only). The trigger menu, which emits no headers, is **byte-identical** (`items === rows` path).

## Tests / verification

- New pure contract seam `buildMenuRows(items, query)` (filter + boundary headers): emits headers per boundary not per item, no empty header after filter, repeats headers for non-contiguous groups, ungrouped-then-grouped; plus `group` carry-through and the async-transformer→empty-sync-list guard. `resolveSlashItems` + `trigger-menu` tests unchanged (regression gate). Full suite **255 passing**.
- **Browser-verified** in the `sites/paper` playground (async + grouped Blocks/Templates example): `/` loads the async catalog and renders the **BLOCKS** header; filtering to `template` drops the empty BLOCKS header and shows **TEMPLATES** + its items; **ArrowUp skips the header** (wraps to the last item); Enter inserts a grouped async item; no console errors. The transient "Loading…" row renders via the same non-interactive-row path as the headers (geometry carved out, invariant #4).

## Docs

ADR-0012 amendment (async once-cached + boundary headers; per-query rejected → `triggers`; revises decision 5's "no section dividers" for the opt-in case), `CONTEXT.md` + `DECISIONS.md`, and the playground async + grouped `slashItems` example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)