### PR TITLE
docs(paper): controlled-value bridge recipe — keep core uncontrolled (#503)

### DIFF
--- a/packages/paper/docs/DECISIONS.md
+++ b/packages/paper/docs/DECISIONS.md
@@ -85,8 +85,12 @@ change needs an ADR vs. a changeset. Each bullet below links to its ADR.
   `onChange` emits full markdown on user edits only (IME-guarded; `setValue` does not echo). A
   curated `ref` handle with a `getView()` escape hatch. Shipped as a **standalone npm package**, not
   a copy-paste registry component — so it is exempt from the monorepo's component checklist (no
-  Storybook story, no `registry.json`, no `cn` util, no Tailwind).
-  ([ADR-0013](./adr/0013-react-shell-and-distribution.md))
+  Storybook story, no `registry.json`, no `cn` util, no Tailwind). **Controlled-value** consumers are
+  served by a documented **controlled-bridge recipe** (a thin `setValue` + `onChange` + `value !==
+getValue()` echo-guard wrapper), _not_ a `value` prop — the core stays uncontrolled; a first-class
+  `value` prop is deferred as an additive future minor.
+  ([ADR-0013](./adr/0013-react-shell-and-distribution.md),
+  [ADR-0019](./adr/0019-controlled-value-bridge-recipe.md))
 - **Selection annotation = mechanism only, policy to consumer.** The anchor is a `quote` (a source
   substring) plus an `offset`; resolution is 3-state (`exact` / `approximate` / `orphaned`),
   anchored to the **markdown source**, not rendered HTML. Surface: `highlights`,

--- a/packages/paper/docs/adr/0019-controlled-value-bridge-recipe.md
+++ b/packages/paper/docs/adr/0019-controlled-value-bridge-recipe.md
@@ -1,0 +1,108 @@
+# 0019 — Controlled-value mode: keep the core uncontrolled, ship a controlled-bridge recipe (not a `value` prop)
+
+- **Status:** Accepted
+- **Date:** 2026-06-21
+- **Supersedes:** —
+- **Superseded-by:** —
+- **Amends:** —
+
+---
+
+# Controlled-value mode: keep the core uncontrolled, ship a controlled-bridge recipe
+
+## Context
+
+`<Paper>` is deliberately **uncontrolled** (ADR-0013 decision 2): `defaultValue` seeds the initial
+document, `ref.setValue()` commands a wholesale replacement, and `onChange` emits the full markdown on
+user edits only. The markdown owned by the editor is the single source of truth at the API boundary
+(`CONTEXT.md`'s mental model).
+
+Some consumers want the React-idiomatic **controlled** story — `<Paper value={md} onChange={setMd} />`,
+where a parent holds the value in state and feeds it back every render. This is child ⑦ of the
+embedding/extensibility epic (#505, issue #503), formally a **decision** (`type:arch`): a real `value`
+prop would revise the load-bearing ADR-0013 and add a contract to the surface that **freezes at 1.0**
+(#480).
+
+**The tension a live `value` prop reintroduces** — the two exact problems the uncontrolled design
+exists to prevent (ADR-0013 decision 2):
+
+1. **It fights IME.** A controlled form swaps the document whenever `value` changes. If an external
+   value arrives mid-composition (`view.composing`), the result is a cursor jump and a broken
+   composition — breaking, at the React-contract level, the invariant ADR-0004 paid the most to
+   protect.
+2. **It is a second source of truth.** React state and the editor document both claim to own the
+   text; keeping them in lockstep per keystroke is the very coupling the uncontrolled boundary
+   removes.
+
+## Decision — Option A: keep the core uncontrolled; ship a documented controlled-bridge recipe
+
+Two options were weighed (issue #503):
+
+- **A. A controlled-bridge recipe** — a thin consumer-side wrapper over the uncontrolled `<Paper>`,
+  shipped as documentation + a runnable example. **No API change**; the core stays uncontrolled.
+- **B. A real `value` prop** — first-class on `PaperProps`, revising ADR-0013 decision 2 and defining
+  an IME/echo contract.
+
+**We choose A.** The recipe is the official controlled story; ADR-0013 decision 2 stands unchanged.
+
+The bridge is the standard "controlled-over-uncontrolled" pattern, and it works because the uncontrolled
+surface already provides both halves: `setValue` is IME-deferred (ADR-0004 / value-controller), and
+`onChange` fires on **user edits only** (`setValue` does not echo, ADR-0013 step B). So an
+`value !== getValue()` guard is all that is needed:
+
+```tsx
+function ControlledPaper({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+  const ref = useRef<PaperHandle>(null);
+  useEffect(() => {
+    // Sync EXTERNAL value changes into the editor. Skip the echo of the user's own edit:
+    // after onChange, `value` already equals what the editor holds, so this is a no-op then —
+    // no cursor jump. A real external change (load/reset/sync) differs, so setValue applies
+    // (IME-deferred internally).
+    if (ref.current && value !== ref.current.getValue()) ref.current.setValue(value);
+  }, [value]);
+  return <Paper ref={ref} defaultValue={value} onChange={onChange} />;
+}
+```
+
+- **Echo-guard.** The user types → `onChange(v)` → parent state becomes `v` → the effect runs but
+  `v === getValue()`, so `setValue` is skipped. No re-application of the user's own keystroke, no
+  cursor jump.
+- **IME.** External changes route through `setValue`, which already defers during composition and
+  applies on `compositionend` — the IME tension of a raw `value` prop never arises.
+- **Caveat (documented).** The parent must store **exactly** what `onChange` emits. A per-keystroke
+  transform (uppercasing, normalization) makes `value !== getValue()` mid-type and re-triggers
+  `setValue` → a cursor jump. The recipe is for **wholesale / external** value changes (server load,
+  reset-to-template, cross-tab sync), not per-keystroke control of a rich Live-Preview editor — that
+  is what the uncontrolled boundary is for.
+
+## Why A, and why it forecloses nothing
+
+- **Principle.** A keeps the single-source-of-truth boundary and the IME guarantee intact; B trades
+  them away for an idiom the bridge already delivers.
+- **Restraint (lightness).** A adds zero public surface to freeze at 1.0.
+- **Low-regret / reversible.** A `value` prop is **additive and optional**. If real demand for a
+  first-class controlled prop appears, B can be added later as a **non-breaking minor** (with the IME
+  echo contract designed then). There is no now-or-never pressure: choosing A closes no door.
+
+## Alternatives and rejections
+
+- **B — a real `value` prop (revise ADR-0013).** Reintroduces the IME-composition break and the
+  double source of truth (ADR-0013 decision 2's two rationales), and locks a new contract onto the
+  1.0-frozen surface for a capability the bridge already covers. Rejected for v1; revisitable as a
+  non-breaking minor on demand.
+- **A pull-only story (no recipe, "just use `getValue()`/`setValue()`").** Already possible, but it
+  leaves the most-asked React-controlled question unanswered. The recipe is the small, honest
+  answer — the same "mechanism in editor, policy/example in consumer" stance as the rest of the epic.
+
+## Consequences
+
+- **No code change to `@beaket/paper`.** ADR-0013 decision 2 (uncontrolled) stands. This ships as docs
+  (`sites/paper` usage page + a runnable example) and this ADR — no published tarball change, so no
+  changeset/version bump (the docs-only path, per `changeset-check.yml`).
+- **The controlled story is now official and bounded:** a copy-pasteable bridge with an explicit
+  echo-guard and a documented "wholesale-not-per-keystroke" caveat.
+- **`DECISIONS.md`** gains a one-line pointer that the uncontrolled boundary now has a sanctioned
+  controlled-bridge recipe (it does not change a constraint — uncontrolled is unchanged — so the
+  existing ADR-0013 bullet is annotated rather than rewritten).
+- **Deferred, not foreclosed:** a first-class `value` prop (Option B) as a future non-breaking minor
+  if demand materializes.

--- a/sites/paper/src/components/controlled-demo.tsx
+++ b/sites/paper/src/components/controlled-demo.tsx
@@ -1,0 +1,161 @@
+import { Paper, type PaperHandle } from "@beaket/paper/react";
+import { useEffect, useRef, useState } from "react";
+
+// The recipe itself, running live (ADR-0019). A thin wrapper turns the uncontrolled <Paper> into a
+// controlled value/onChange component. It works because the uncontrolled surface already provides
+// both halves: setValue is IME-deferred, and onChange fires on user edits only (setValue does not
+// echo). The `value !== getValue()` guard is the whole trick — see the comment below.
+function ControlledPaper({
+  value,
+  onChange,
+  paperRef,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+  paperRef?: React.Ref<PaperHandle>;
+}) {
+  const ref = useRef<PaperHandle>(null);
+  useEffect(() => {
+    // Sync EXTERNAL value changes into the editor. Skip the echo of the user's own edit: after
+    // onChange fires, `value` already equals what the editor holds, so this is a no-op then — no
+    // cursor jump. A real external change (the buttons / the textarea below) differs, so setValue
+    // applies (IME-deferred internally).
+    if (ref.current && value !== ref.current.getValue()) ref.current.setValue(value);
+  }, [value]);
+  return (
+    <Paper
+      ref={(v) => {
+        ref.current = v;
+        if (typeof paperRef === "function") paperRef(v);
+        else if (paperRef) (paperRef as React.RefObject<PaperHandle | null>).current = v;
+      }}
+      defaultValue={value}
+      onChange={onChange}
+      minHeight="180px"
+    />
+  );
+}
+
+const DOC_A = `# Release notes
+
+- Controlled **value** lives in React state.
+- Type here → the state (and the textarea) update.
+`;
+
+const DOC_B = `# Meeting agenda
+
+1. Roadmap review
+2. Open questions
+3. Next steps
+`;
+
+export function ControlledDemo() {
+  // The single source the parent controls. Both <Paper> and the <textarea> read and write it.
+  const [value, setValue] = useState(DOC_A);
+
+  return (
+    <div className="cd-root">
+      <div className="cd-bar">
+        <span className="cd-label">Set value externally</span>
+        <button type="button" className="cd-btn" onClick={() => setValue(DOC_A)}>
+          Doc A
+        </button>
+        <button type="button" className="cd-btn" onClick={() => setValue(DOC_B)}>
+          Doc B
+        </button>
+        <button type="button" className="cd-btn" onClick={() => setValue("")}>
+          Clear
+        </button>
+        <span className="cd-count">{value.length} chars</span>
+      </div>
+
+      <div className="cd-panes">
+        <div className="cd-pane">
+          <div className="cd-pane-label">&lt;ControlledPaper value onChange /&gt;</div>
+          <div className="cd-paper">
+            <ControlledPaper value={value} onChange={setValue} />
+          </div>
+        </div>
+        <div className="cd-pane">
+          <div className="cd-pane-label">&lt;textarea value onChange /&gt; — same state</div>
+          <textarea
+            className="cd-textarea"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            spellCheck={false}
+          />
+        </div>
+      </div>
+
+      <style>{`
+        .cd-root { position: relative; }
+        .cd-bar {
+          display: flex;
+          flex-wrap: wrap;
+          align-items: center;
+          gap: 0.5rem;
+          padding: 0.5rem 0 0.85rem;
+        }
+        .cd-label {
+          font-size: 12px;
+          text-transform: uppercase;
+          letter-spacing: 0.05em;
+          color: var(--steel, #686b6f);
+          margin-right: 0.25rem;
+        }
+        .cd-btn {
+          font: inherit;
+          font-size: 13px;
+          padding: 0.25rem 0.6rem;
+          background: var(--paper);
+          color: var(--ink);
+          border: 1px solid var(--chrome);
+          cursor: pointer;
+        }
+        .cd-count {
+          margin-left: auto;
+          font-size: 12px;
+          color: var(--steel, #686b6f);
+        }
+        .cd-panes {
+          display: grid;
+          grid-template-columns: 1fr 1fr;
+          gap: 1rem;
+        }
+        .cd-pane { min-width: 0; }
+        .cd-pane-label {
+          font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, monospace;
+          font-size: 11px;
+          color: var(--steel, #686b6f);
+          margin-bottom: 0.4rem;
+        }
+        .cd-paper {
+          background: var(--beaket-paper-paper, var(--paper, #fff));
+          border: 1px solid var(--chrome);
+          box-shadow: var(--shadow-offset, 2px 2px 0 0 var(--chrome));
+          padding: 0.9rem 1.1rem;
+        }
+        .cd-textarea {
+          width: 100%;
+          min-height: 212px;
+          box-sizing: border-box;
+          padding: 0.9rem 1.1rem;
+          background: var(--frost, #f3f4f6);
+          color: var(--ink);
+          border: 1px solid var(--chrome);
+          font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, monospace;
+          font-size: 13px;
+          line-height: 1.6;
+          resize: vertical;
+        }
+        .cd-textarea:focus-visible {
+          outline: 2px solid var(--beaket-paper-accent, #0c6bae);
+          outline-offset: 2px;
+        }
+        @media (max-width: 640px) {
+          .cd-panes { grid-template-columns: 1fr; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/sites/paper/src/pages/usage.astro
+++ b/sites/paper/src/pages/usage.astro
@@ -2,6 +2,7 @@
 import Base from '../layouts/base.astro';
 import CodeBlock from '../components/code-block.astro';
 import { HighlightsDemo } from '../components/highlights-demo';
+import { ControlledDemo } from '../components/controlled-demo';
 const base = import.meta.env.BASE_URL;
 const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p);
 
@@ -32,6 +33,32 @@ const editor = createEditor(document.querySelector("#editor")!, {
   doc: "# Hello",
   onChange: (markdown) => console.log(markdown),
 });`;
+
+const controlledCode = `import { Paper, type PaperHandle } from "@beaket/paper/react";
+import { useEffect, useRef } from "react";
+
+// A thin bridge: controlled value/onChange over the uncontrolled <Paper>.
+function ControlledPaper({ value, onChange }: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const ref = useRef<PaperHandle>(null);
+
+  useEffect(() => {
+    // Sync EXTERNAL value changes into the editor. Skip the echo of the user's
+    // own edit: after onChange, value already equals what the editor holds, so
+    // this is a no-op then — no cursor jump. A real external change (load, reset,
+    // cross-tab sync) differs, so setValue applies (IME-deferred internally).
+    if (ref.current && value !== ref.current.getValue()) {
+      ref.current.setValue(value);
+    }
+  }, [value]);
+
+  return <Paper ref={ref} defaultValue={value} onChange={onChange} />;
+}
+
+// Now use it like any controlled input:
+// <ControlledPaper value={md} onChange={setMd} />`;
 
 const highlightsCode = `import { Paper, type SelectionInfo, type HighlightInput } from "@beaket/paper/react";
 import { useState } from "react";
@@ -83,6 +110,41 @@ function Annotator() {
     underlying CodeMirror <code>EditorView</code> as an escape hatch. See the
     <a href={withBase('api')}>API Reference</a> for the full prop and handle surface.
   </p>
+
+  <h2 id="controlled">Controlled value (a bridge)</h2>
+  <p>
+    Paper is uncontrolled by design — a live <code>value</code> prop would fight IME composition and
+    make React state a second source of truth (see <a href="https://github.com/beaket/ui/blob/main/packages/paper/docs/adr/0019-controlled-value-bridge-recipe.md">ADR-0019</a>).
+    When you want the React-idiomatic <code>value</code>/<code>onChange</code> shape anyway, wrap it in
+    a thin bridge — the uncontrolled surface already gives you both halves:
+  </p>
+  <CodeBlock code={controlledCode} lang="tsx" />
+  <p>
+    The one line that matters is the <code>value !== ref.current.getValue()</code> guard. When the user
+    types, <code>onChange</code> updates your state, the effect re-runs, but the value already matches
+    what the editor holds — so <code>setValue</code> is skipped and the cursor never jumps. Only a
+    genuinely <em>external</em> change differs, and that routes through the IME-deferred
+    <code>setValue</code>.
+  </p>
+  <p class="callout callout-tip">
+    <svg class="callout-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863.5 8 .5s5.5 1.81 5.5 4.75c0 1.516-.701 2.5-1.318 3.282-.095.115-.184.22-.268.32-.207.245-.383.453-.541.68-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z" />
+    </svg>
+    <span><strong>Caveat</strong> — store <em>exactly</em> what <code>onChange</code> emits. The bridge
+    is for wholesale/external value changes (server load, reset-to-template, cross-tab sync), not
+    per-keystroke transforms (uppercasing, normalization) — those make the value differ mid-type and
+    re-trigger <code>setValue</code>, jumping the cursor.</span>
+  </p>
+  <p class="callout callout-tip">
+    <svg class="callout-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863.5 8 .5s5.5 1.81 5.5 4.75c0 1.516-.701 2.5-1.318 3.282-.095.115-.184.22-.268.32-.207.245-.383.453-.541.68-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z" />
+    </svg>
+    <span><strong>Try it</strong> — both panes below share one React <code>value</code>. Type in the
+    editor and the textarea follows; edit the textarea (or hit a button) and the editor syncs.</span>
+  </p>
+  <div class="demo">
+    <ControlledDemo client:only="react" />
+  </div>
 
   <h2 id="highlights">Selections &amp; highlights</h2>
   <p>


### PR DESCRIPTION
Child ⑦ of the embedding/extensibility epic (#505) — a formally-typed **decision** issue. Resolves the controlled-value question by recording **Option A** in **ADR-0019**: keep `<Paper>` uncontrolled (ADR-0013 decision 2 stands) and serve controlled-value consumers with a documented **controlled-bridge recipe**, not a `value` prop.

Closes #503.

## The decision (A vs B)

A live `value` prop (Option B) would reintroduce the exact two problems the uncontrolled design exists to prevent (ADR-0013 decision 2):
1. **It fights IME** — echoing `value` mid-composition jumps the cursor / breaks composition (the ADR-0004 invariant).
2. **It is a second source of truth** — React state and the editor document both claim to own the text.

**Option A** (chosen) avoids both: the uncontrolled surface already provides both halves — `setValue` is IME-deferred and `onChange` fires on user edits only (no echo) — so a thin bridge with a `value !== ref.getValue()` echo-guard is all it takes. A first-class `value` prop stays available as an **additive future minor**, so choosing A forecloses nothing.

> The A-vs-B fork was confirmed with the maintainer before implementing (it revises a load-bearing ADR if B).

## What ships (docs only — no `@beaket/paper` code change, no changeset)

- **ADR-0019** — records A/B weighed, affirms uncontrolled, sanctions the bridge, defers B.
- **DECISIONS.md** — one-line pointer on the package-shape bullet.
- **`sites/paper` usage page** — a "Controlled value (a bridge)" section with the copy-pasteable `ControlledPaper` recipe, the echo-guard explanation, the wholesale-not-per-keystroke caveat, and a **live two-pane demo** (`ControlledPaper` + a textarea sharing one React `value`).

The diff is confined to `packages/paper/docs/**` (changeset-excluded) and `sites/paper/**` (outside `packages/**`), so no version bump / changeset is needed.

## Verification

Browser-verified the live demo: external value changes (Doc A / Doc B / Clear) sync into the editor; typing in the editor syncs back out to the textarea; and the echo-guard keeps the cursor — char count moved exactly +3 for a 3-char insert with no reset/duplication. IME-safe via the deferred `setValue`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)