### PR TITLE
fix(paper): click below a bare trailing table places the caret after it (#474)

### DIFF
--- a/.changeset/paper-click-below-bare-trailing-table.md
+++ b/.changeset/paper-click-below-bare-trailing-table.md
@@ -1,0 +1,11 @@
+---
+"@beaket/paper": patch
+---
+
+Fix (#474): clicking in the empty space below a table that is the **literal last block** no longer parks the caret before the table.
+
+**Root cause.** The user-visible symptom in the docs demo was a dead zone (the demo card was taller than the editor), already fixed docs-side in #475 by letting the editor content fill its card. The hypothesized editor-internal `posAtCoords` bug does not exist — for a table followed by a trailing blank line (the state `tableBoundaryGuard` always enforces during editing) a below-content click resolves to that trailing line and renders correctly after the table.
+
+The one remaining case is an **initial `doc` passed straight in that ends with a table and no trailing line**: the table's block-widget replace range ends exactly at doc end, and CM6 renders a caret at that end-boundary _before_ the widget (there is no following text line for it to attach to). State position is correct (doc end), only the rendered caret is wrong.
+
+**Fix.** The body `mousedown` handler now detects this case (`docEndsWithBareTable`) and, when the click lands below the last block, heals the doc with a trailing line and places the caret there — mirroring `escapeTable("below")`'s keyboard behavior. Read-only never mutates. The geometry gate ("below the last block") is browser-verified per invariant #4; `docEndsWithBareTable` and the doc-mutation path are covered by jsdom regression tests.

--- a/packages/paper/src/editor/extensions/table-trailing-click.test.ts
+++ b/packages/paper/src/editor/extensions/table-trailing-click.test.ts
@@ -1,0 +1,98 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vitest";
+import { editorExtensions } from "../create-editor";
+import { docEndsWithBareTable } from "./table-widget";
+
+// Regression (#474): clicking in the empty space below a table that is the *literal last block*
+// (an initial doc ending in a table with no trailing line) lands the caret at doc end, which CM
+// renders visually *before* the widget. The mousedown handler heals the doc with a trailing line
+// and places the caret there. Edit paths can't reach this state (tableBoundaryGuard guarantees a
+// trailing blank line), but an initial `doc` passed straight in can.
+//
+// Geometry is carved out under jsdom (invariant #4): documentTop / lineBlockAt return 0, so the
+// "below the last block" gate reduces to clientY > 0 — enough to exercise the full handler path.
+
+let view: EditorView | null = null;
+
+function makeView(doc: string, readOnly = false): EditorView {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  view = new EditorView({
+    state: EditorState.create({ doc, extensions: editorExtensions({ readOnly }) }),
+    parent,
+  });
+  return view;
+}
+
+async function until(cond: () => boolean, timeout = 5000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeout) throw new Error("until(): timeout");
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+async function viewWithTable(doc: string, readOnly = false): Promise<EditorView> {
+  const v = makeView(doc, readOnly);
+  await until(() => v.dom.querySelector(".cm-table-widget") !== null);
+  return v;
+}
+
+function clickBelow(v: EditorView): void {
+  v.contentDOM.dispatchEvent(
+    new MouseEvent("mousedown", { bubbles: true, clientX: 10, clientY: 100 }),
+  );
+}
+
+afterEach(() => {
+  view?.destroy();
+  view = null;
+});
+
+describe("docEndsWithBareTable", () => {
+  it("is true when the doc ends with a table and no trailing line", () => {
+    const v = makeView("| a | b |\n| --- | --- |\n| 1 | 2 |");
+    expect(docEndsWithBareTable(v.state)).toBe(true);
+  });
+
+  it("is false when a trailing blank line follows the table", () => {
+    const v = makeView("| a | b |\n| --- | --- |\n| 1 | 2 |\n");
+    expect(docEndsWithBareTable(v.state)).toBe(false);
+  });
+
+  it("is false when content follows the table", () => {
+    const v = makeView("| a | b |\n| --- | --- |\n| 1 | 2 |\n\ntail");
+    expect(docEndsWithBareTable(v.state)).toBe(false);
+  });
+
+  it("is false for a doc without a table", () => {
+    const v = makeView("just a paragraph");
+    expect(docEndsWithBareTable(v.state)).toBe(false);
+  });
+});
+
+describe("click below a bare trailing table (#474)", () => {
+  it("inserts a trailing line and places the caret after the table", async () => {
+    const v = await viewWithTable("| a | b |\n| --- | --- |\n| 1 | 2 |");
+    const before = v.state.doc.length;
+    clickBelow(v);
+    expect(v.state.doc.length).toBe(before + 1);
+    expect(v.state.sliceDoc(before)).toBe("\n");
+    expect(v.state.selection.main.head).toBe(before + 1); // the fresh trailing line, after the table
+  });
+
+  it("does nothing when a trailing blank line already exists", async () => {
+    const v = await viewWithTable("| a | b |\n| --- | --- |\n| 1 | 2 |\n");
+    const before = v.state.doc.toString();
+    clickBelow(v);
+    expect(v.state.doc.toString()).toBe(before); // CM's default (correct) handling is left alone
+  });
+
+  it("never mutates a read-only doc", async () => {
+    const v = await viewWithTable("| a | b |\n| --- | --- |\n| 1 | 2 |", true);
+    const before = v.state.doc.toString();
+    clickBelow(v);
+    expect(v.state.doc.toString()).toBe(before);
+  });
+});

--- a/packages/paper/src/editor/extensions/table-widget.ts
+++ b/packages/paper/src/editor/extensions/table-widget.ts
@@ -1116,6 +1116,18 @@ function findTableRange(
   return found;
 }
 
+/**
+ * Whether the document ends with a table that has no trailing line — its block widget range ends
+ * exactly at doc end. CM6 renders a caret at that end-boundary *before* the widget (there is no
+ * following text line for it to attach to), so clicking in the empty space below such a table would
+ * visually land the caret above it even though the state position (doc end) is correct. (Pure — a
+ * unit-test target.) Edit paths can't reach this state (tableBoundaryGuard guarantees a trailing
+ * blank line after every table), but an initial doc passed straight in can — hence the click heal below.
+ */
+export function docEndsWithBareTable(state: EditorState): boolean {
+  return findTableRange(state, (_from, to) => to === state.doc.length) !== null;
+}
+
 // Obsidian 1.5.8 policy: backspace right after a table = (1) select the whole table, (2) once more = delete.
 // We must intercept atomicRanges' default behavior (one backspace deletes the whole table).
 function tableBackspace(view: EditorView): boolean {
@@ -1398,8 +1410,27 @@ export function tableWidget(): Extension {
     tableSelectionRing,
     // Clicking outside the widget (in the body) clears the active cell — events inside the widget are ignored by CM, so this doesn't reach them
     EditorView.domEventHandlers({
-      mousedown(_event, view) {
+      mousedown(event, view) {
         clearActiveCell(view);
+        // Bare table at EOF (no trailing line): a click in the empty space below it lands the caret at
+        // doc end, which CM renders *before* the widget. Heal the doc with a trailing line and place the
+        // caret there — mirroring escapeTable("below"). Geometry-gated (only fires below the last block,
+        // browser-verified, invariant #4); read-only never mutates (ADR-0018 matrix).
+        if (!view.state.readOnly && docEndsWithBareTable(view.state)) {
+          const docLen = view.state.doc.length;
+          const lastBottom = view.documentTop + view.lineBlockAt(docLen).bottom;
+          if (event.clientY > lastBottom) {
+            view.focus();
+            view.dispatch({
+              changes: { from: docLen, insert: "\n" },
+              selection: { anchor: docLen + 1 },
+              scrollIntoView: true,
+              userEvent: "input",
+            });
+            event.preventDefault();
+            return true;
+          }
+        }
         return false;
       },
     }),


### PR DESCRIPTION
## Summary

Closes #474.

Clicking in the empty space below a table that is the **literal last block** (an initial `doc` ending in a table with no trailing line) parked the caret *before* the table. This hardens that edge case.

## Root cause (verified empirically in the browser)

- The user-visible symptom in the docs demo was a **dead zone** — the demo card was taller than the editor — already fixed docs-side in #475 by letting the editor content fill its card.
- The hypothesized editor-internal `posAtCoords` bug **does not exist**: a below-content click resolves to the trailing line *after* the table (measured `posAtCoords` returns doc end in both precise and non-precise modes), and the direct selection dispatch is **not** bounced by `atomicRanges` (doc end is the atomic range's valid `to` boundary).
- The one remaining case: an **initial `doc` that ends with a table and no trailing line**. The block-widget replace range ends exactly at doc end, and CM6 renders a caret at that end-boundary *before* the widget (there's no following text line to attach to). State is correct (doc end); only the render is wrong. Edit paths can't reach this — `tableBoundaryGuard` always keeps a trailing blank line after a table.

## Fix

The body `mousedown` handler now detects this case (`docEndsWithBareTable`) and, when the click lands below the last block, heals the doc with a trailing line and places the caret there — mirroring `escapeTable("below")`'s keyboard behavior.

- Read-only never mutates (ADR-0018 matrix).
- The geometry gate (`clientY > lastBottom`) keeps clicks **above** the table untouched.
- Note: the heal dispatches `userEvent: "input"`, so a plain click now fires `onChange` with a trailing blank line the user didn't type — a defensible tradeoff that mirrors `escapeTable` and heals toward the "tables are isolated by blank lines" invariant.

## Verification

- **Browser, end-to-end** (bare-table-at-EOF doc):
  - Click below the table → caret renders *below* the table; typing inserts after it (`| x | y |\nZ`).
  - Click *above* the table (intro text) → doc unchanged, caret lands at the click point (gate does not false-fire).
- **Tests**: 7 new jsdom regression tests (`table-trailing-click.test.ts`); full suite **274/274** green. Geometry is carved out under jsdom per invariant #4, so the "below the last block" gate is browser-verified rather than unit-tested.
- Typecheck clean; prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)