### PR TITLE
fix(paper): table grip menu is clipped by the editor scroller (#471)

### DIFF
--- a/.changeset/paper-table-menu-overflow-clip.md
+++ b/.changeset/paper-table-menu-overflow-clip.md
@@ -1,0 +1,9 @@
+---
+"@beaket/paper": patch
+---
+
+Fix (#471): the table grip context menu (column/row: insert, move, delete) is no longer clipped near the editor's scroll viewport edge.
+
+**Root cause.** `openMenu()` appended the menu to the table widget wrapper (`this.wrap`) — which lives inside `.cm-content` → `.cm-scroller` — and positioned it `absolute` relative to that wrapper. `.cm-scroller` is `overflow: auto`, so any descendant menu extending past the scroller box was clipped (worse when the editor was tall or scrolled).
+
+**Fix.** Mirror the slash menu: the menu now attaches to `view.dom` (`.cm-editor`, `overflow: visible`) with `position: fixed`, positioned from the anchor grip's `getBoundingClientRect()` (viewport coords). This takes it out of the scroller's overflow context so it can never be clipped. The outside-click close and IME guard are unchanged. The clip geometry is browser-verified per invariant #4; a jsdom regression test locks the structural fact that the open menu attaches under `.cm-editor` and outside `.cm-scroller`.

--- a/packages/paper/src/editor/extensions/table-menu-overflow.test.ts
+++ b/packages/paper/src/editor/extensions/table-menu-overflow.test.ts
@@ -1,0 +1,51 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vitest";
+import { editorExtensions } from "../create-editor";
+
+// #471: the grip menu must escape the .cm-scroller overflow box so it is never clipped. We assert
+// the structural fact (jsdom carries no real geometry, invariant #4): the open menu is a child of
+// view.dom (.cm-editor, overflow:visible) and lives OUTSIDE .cm-scroller (overflow:auto).
+
+let view: EditorView | null = null;
+
+function makeView(doc: string): EditorView {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  view = new EditorView({
+    state: EditorState.create({ doc, extensions: editorExtensions() }),
+    parent,
+  });
+  return view;
+}
+
+async function until(cond: () => boolean, timeout = 5000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeout) throw new Error("until(): timeout");
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+afterEach(() => {
+  view?.destroy();
+  view = null;
+});
+
+const DOC = ["| a | b |", "| --- | --- |", "| 1 | 2 |"].join("\n");
+
+describe("table grip menu overflow (#471)", () => {
+  it("attaches the opened menu under .cm-editor and outside .cm-scroller", async () => {
+    const v = makeView(DOC);
+    await until(() => v.dom.querySelector(".cm-col-grip") !== null);
+    const grip = v.dom.querySelector(".cm-col-grip") as HTMLElement;
+
+    grip.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    await until(() => v.dom.querySelector(".cm-table-menu") !== null);
+
+    const menu = v.dom.querySelector(".cm-table-menu") as HTMLElement;
+    // Direct child of the editor root, not nested in the scroller that clips overflow.
+    expect(menu.parentElement).toBe(v.dom);
+    expect(v.dom.querySelector(".cm-scroller")?.contains(menu)).toBe(false);
+  });
+});

--- a/packages/paper/src/editor/extensions/table-widget.ts
+++ b/packages/paper/src/editor/extensions/table-widget.ts
@@ -805,11 +805,13 @@ class TableController {
       menu.appendChild(btn);
     }
 
-    const wrapRect = this.wrap.getBoundingClientRect();
+    // Position from the grip's viewport rect and attach to view.dom (.cm-editor, overflow:visible)
+    // with position:fixed, mirroring the slash menu — this escapes the .cm-scroller overflow box so
+    // the menu is never clipped near the scroller's right/bottom edge (#471).
     const anchorRect = anchor.getBoundingClientRect();
-    menu.style.left = `${anchorRect.left - wrapRect.left}px`;
-    menu.style.top = `${anchorRect.bottom - wrapRect.top + 4}px`;
-    this.wrap.appendChild(menu);
+    menu.style.left = `${anchorRect.left}px`;
+    menu.style.top = `${anchorRect.bottom + 4}px`;
+    (this.mainView?.dom ?? this.wrap).appendChild(menu);
     this.menu = menu;
 
     this.menuCloseListener = (event) => {
@@ -1323,7 +1325,7 @@ const tableTheme = EditorView.theme({
   },
   // Overlay = porcelain hard offset, radius 0
   ".cm-table-menu": {
-    position: "absolute",
+    position: "fixed",
     zIndex: "10",
     backgroundColor: "var(--paper)",
     border: "1px solid var(--silver)",


### PR DESCRIPTION
Closes #471.

## Problem

The table **grip context menu** (column/row: insert, move, delete, align) was clipped when it extended past the editor's scroll viewport — cut off near the right/bottom edge, worse when the editor was tall or scrolled.

## Root cause

`openMenu()` appended the menu to the table widget wrapper (`this.wrap`), which lives inside `.cm-content` → `.cm-scroller`, and positioned it `absolute` relative to that wrapper. `.cm-scroller` is `overflow: auto`, so any descendant menu extending past the scroller box was clipped.

## Fix

Mirror the slash menu (`menu-engine.ts`): attach the menu to `view.dom` (`.cm-editor`, `overflow: visible`) with `position: fixed`, positioned from the anchor grip's `getBoundingClientRect()` (viewport coords). This takes it out of the scroller's overflow context so it can never be clipped. The outside-click close and IME guard are unchanged.

## Verification

Real-browser checked on the docs demo:
- **Not clipped** — the rightmost column menu renders **41px past** the scroller's right edge, fully visible (outside `.cm-scroller`, `position: fixed`).
- **Position correct** — menu glued just below the grip, no transform offset.
- **Functions** — clicking "Insert column after" added a column (2→3) and the menu closed.
- **Styling intact** — border/shadow/dividers render (theme scope under `.cm-editor` preserved).

Per invariant #4 (jsdom has no geometry), clip geometry is browser-verified; a jsdom regression test (`table-menu-overflow.test.ts`) locks the structural fact that the open menu attaches under `.cm-editor` and outside `.cm-scroller`. Full paper suite (275 tests), typecheck, and prettier all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)