### PR TITLE
fix(paper): forced colorScheme overrides consumer --color-* bridge (#472)

### DIFF
--- a/.changeset/paper-forced-colorscheme-authoritative.md
+++ b/.changeset/paper-forced-colorscheme-authoritative.md
@@ -1,0 +1,9 @@
+---
+"@beaket/paper": patch
+---
+
+Fix (#472): a forced `colorScheme` ("light"/"dark") now overrides a consumer's porcelain `--color-*` bridge, so overlays (slash menu, "Copied" toast, table row/col insert handles) follow the forced scheme instead of leaking the OS scheme.
+
+**Root cause.** Surface tokens resolve through the 3-tier bridge `var(--beaket-paper-X, var(--color-Y, default))`. Forcing only swapped the tier-3 built-in _default_ — it never beat a consumer-provided tier-2 `--color-*`. So when a consumer bridges `--color-paper`/`--color-frost`/… to a palette that tracks the OS, a forced-light editor under a dark OS still painted those surfaces dark (and CSS custom-property resolution makes it sticky: `--color-paper: var(--paper)` declared at `:root` is computed once against the OS scheme, and that value inherits down). Only `--color-ink`, which was already pinned per scheme, didn't leak.
+
+**Fix.** When a scheme is forced, pin the full set of bridged surface `--color-*` (and `--shadow-offset`) per scheme on `.cm-editor` — the same mechanism `--color-ink` already used, so the editor's own declaration beats the inherited bridge and reaches every overlay (they are `.cm-editor` descendants). `colorScheme="light"` now wears its own scope class (`cm-beaket-paper-light`) carrying the light pins; `"dark"` adds dark pins to its existing block; `"system"` stays unpinned so it keeps deferring to the bridge. The tier-1 `--beaket-paper-*` override still wins inside a forced scheme. Pins are derived off the var() chains in `theme.ts` (single source of truth), forced-block-only — never merged into the token maps. See ADR-0020. The docs playground's consumer-side `--color-*` re-bridge workaround was removed (the package fix makes forcing authoritative on its own). jsdom tests lock the derived pins + placement; the rendered colors are browser-verified (ADR-0005 carve-out).

--- a/packages/paper/docs/DECISIONS.md
+++ b/packages/paper/docs/DECISIONS.md
@@ -133,6 +133,13 @@ Deliberate, documented local divergences (each now carries a dark-aware value; d
 - `--canvas` is `#fbfcfd`, a cool near-white writing surface — not porcelain's `--color-paper`
   (`#ffffff`).
 
+**A forced `colorScheme` is authoritative over the bridge** ([ADR-0020](./adr/0020-forced-colorscheme-authoritative-over-bridge.md)).
+`"light"`/`"dark"` pin the bridged surface `--color-*` per scheme on `.cm-editor` (the same mechanism
+`--color-ink` uses), so a forced scheme beats a consumer `--color-*` bridge that tracks the OS — otherwise
+overlays leaked the OS scheme (#472). `"system"` stays unpinned, keeping the porcelain match-for-free;
+tier-1 `--beaket-paper-*` is the escape hatch within a forced scheme. The pins are derived off the var()
+chains (single source of truth), forced-block-only — never merged into the token maps.
+
 Not yet exposed (deliberate scope cut, revisit on demand): a `theme?: Extension` option to append a
 consumer CodeMirror theme.
 

--- a/packages/paper/docs/adr/0020-forced-colorscheme-authoritative-over-bridge.md
+++ b/packages/paper/docs/adr/0020-forced-colorscheme-authoritative-over-bridge.md
@@ -1,0 +1,84 @@
+# 0020 — A forced `colorScheme` is authoritative over the consumer's porcelain bridge
+
+- **Status:** Accepted
+- **Date:** 2026-06-21
+- **Supersedes:** —
+- **Superseded-by:** —
+- **Amends:** —
+
+---
+
+# A forced `colorScheme` is authoritative over the consumer's porcelain bridge
+
+## Context
+
+`colorScheme` (added with OS-driven dark mode, ADR-0009's amendment) takes `"system" | "light" | "dark"`.
+`"system"` follows the OS via `prefers-color-scheme`; `"light"`/`"dark"` are meant to **force** a scheme
+regardless of the OS.
+
+The surface tokens resolve through the 3-tier porcelain bridge `var(--beaket-paper-X, var(--color-Y, default))`
+(ADR-0009 / token reconciliation). Forcing was implemented by swapping which scope class the editor root
+wears, and the scoped stylesheet only swapped the **tier-3 built-in defaults**. It never beat a
+consumer-provided **tier-2** `--color-*`.
+
+So when a consumer bridges the porcelain vars (`--color-paper`, `--color-frost`, …) to a palette that
+tracks the OS, forcing `"light"` on a dark OS (or vice-versa) left those surfaces on the OS scheme. The
+visible symptom (#472): a forced-light editor under a dark OS rendered **dark overlays** — the slash menu,
+the "Copied" toast (dark-on-dark, unreadable), the table row/col insert handles — because those overlays
+paint `--paper`/`--frost`/`--ink` directly and inherited the consumer's dark `--color-*`.
+
+CSS custom-property resolution makes the leak sticky: a consumer's `--color-paper: var(--paper)` declared
+at `:root` is computed once against the OS scheme, and that computed value inherits down. Overriding the
+short `--paper` deeper in the tree does not re-resolve it — only redeclaring `--color-paper` itself in the
+editor's own scope does. (`--color-ink` was already pinned this way per scheme, which is exactly why ink —
+alone among the surfaces — did _not_ leak.)
+
+## Decision
+
+**When a scheme is forced (`"light"`/`"dark"`, not `"system"`), forcing wins over the bridge.** Each
+forced block pins the full set of bridged surface `--color-*` (and `--shadow-offset`) to its scheme's
+value on `.cm-editor`, the same mechanism `--color-ink` already used. A concrete `--color-*` declared on
+the editor root overrides the value inherited from the consumer's `:root`, so the forced scheme reaches
+every overlay (they are `.cm-editor` descendants and inherit it).
+
+Concretely:
+
+- `colorScheme="light"` now wears its own scope class (`cm-beaket-paper-light`) — previously it wore
+  **none**, which is why even the OS media block couldn't be the problem but the bridge still leaked. The
+  class carries the light surface pins.
+- `colorScheme="dark"` keeps `cm-beaket-paper-dark` and additionally carries the dark surface pins.
+- `"system"` is left **unpinned** — it keeps deferring to the bridge, preserving the porcelain
+  match-for-free contract (inside `@beaket/ui`'s porcelain, system mode inherits porcelain's dark block).
+
+The tier-1 public `--beaket-paper-*` override still wins **inside** a forced scheme — it is the escape
+hatch for a consumer who wants a forced scheme but a custom surface.
+
+The pins are **derived off the var() chains** in `tokens`/`darkTokens` (the tier-3 default of each 3-tier
+token), not authored as a second list and not merged into `tokens`/`darkTokens` themselves. Keeping them
+forced-block-only is load-bearing: merging them into the token maps would (a) break the "every token reads
+a `--beaket-paper-*` override first" contract, (b) re-break `system` mode (the maps apply unconditionally
+via `baseTheme`, which would kill the bridge), and (c) duplicate the source of truth. Deriving them means a
+future 3-tier token auto-pins under forcing for free, which is the correct semantics.
+
+## Alternatives considered
+
+- **Option 2 — document that consumers who force a scheme must override the tier-1 `--beaket-paper-*`
+  names.** Rejected: it pushes the editor's own correctness onto every consumer and makes "force a scheme"
+  a leaky abstraction. Forcing should be authoritative without the consumer knowing the bridge exists.
+- **Pin the surfaces in all modes (including `system`).** Rejected: it would defeat the porcelain bridge —
+  the whole point of tier-2 is that the editor matches a consumer's porcelain customization for free. Only
+  `--color-ink` is an _always_ divergence (ADR-0009); the other surfaces must keep deferring under
+  `system`.
+
+## Consequences
+
+- Forcing a scheme now trades the porcelain-bridge match (tier-2) for **scheme authority**: under a forced
+  scheme the editor paints its own per-scheme surfaces, ignoring a consumer `--color-*` bridge. `system`
+  keeps the bridge; tier-1 `--beaket-paper-*` is the escape hatch within a forced scheme.
+- The docs playground's consumer-side workaround (re-bridging `--color-*` to the forced palette on its
+  themed wrapper) is no longer needed and was removed — the package fix makes forcing authoritative on its
+  own.
+- The fix is verified at two levels: jsdom wiring tests lock the derived pin set and its placement (forced
+  blocks pin, `system`/media block does not); a browser check confirmed that under a simulated dark-OS
+  bridge (`:root --color-paper: #0d1117`) a forced-light editor resolves `.cm-editor --color-paper:
+#ffffff` and the `cm-slash-menu` overlay renders light — the rendered-color carve-out of ADR-0005.

--- a/packages/paper/src/editor/theme.test.ts
+++ b/packages/paper/src/editor/theme.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { colorSchemeClass, darkThemeCss, darkTokens, sizeRules, tokens } from "./theme";
+import {
+  colorSchemeClass,
+  colorSchemeCss,
+  darkTokens,
+  sizeRules,
+  surfacePins,
+  tokens,
+} from "./theme";
 
 // Token reconciliation + public theming contract (ADR-0013 decision 6).
 //
@@ -130,8 +137,8 @@ describe("dark theme keeps the override + bridge chains, swapping only the built
 // nested `&` produces bare declarations under the at-rule), so it ships as a scoped stylesheet. This
 // locks the structure that makes it apply: an @media wrapper + a two-class root selector that outranks
 // baseTheme's single generated class without disturbing the var() override/bridge chains.
-describe("darkThemeCss emits a scoped prefers-color-scheme block", () => {
-  const css = darkThemeCss();
+describe("colorSchemeCss emits a scoped prefers-color-scheme block", () => {
+  const css = colorSchemeCss();
 
   it("wraps the tokens in a prefers-color-scheme: dark media query", () => {
     expect(css).toMatch(/^@media \(prefers-color-scheme: dark\)\{/);
@@ -208,9 +215,65 @@ describe("sizeRules maps height/minHeight to the CM6 recipes", () => {
 // stylesheet above is static). "system" follows the OS (media-gated class), "dark" forces the
 // unconditional block, "light" wears no class so even the OS media block can't darken it.
 describe("colorSchemeClass selects the editor-root class per scheme", () => {
-  it("maps system → OS-follow class, dark → forced class, light → none", () => {
+  it("maps system → OS-follow class, dark → forced-dark class, light → forced-light class", () => {
     expect(colorSchemeClass("system")).toBe("cm-beaket-paper");
     expect(colorSchemeClass("dark")).toBe("cm-beaket-paper-dark");
-    expect(colorSchemeClass("light")).toBe("");
+    // #472: forced light now wears its own class (was none) so it can pin the bridged surfaces light.
+    expect(colorSchemeClass("light")).toBe("cm-beaket-paper-light");
+  });
+});
+
+// #472: forcing a scheme must be authoritative over a consumer's porcelain `--color-*` bridge (ADR-0020).
+// The forced blocks pin the bridged tier-2 surface names to their scheme value so the editor wins over a
+// bridge that tracks the OS; `system` stays unpinned so it keeps deferring to the bridge. The pins are
+// derived off the var() chains (single source of truth), so these lock the derivation + placement.
+describe("surfacePins derives the bridged tier-2 surfaces from the token chains", () => {
+  it("pins the 3-tier porcelain surfaces to their tier-3 default, per scheme", () => {
+    const light = surfacePins(tokens);
+    expect(light["--color-paper"]).toBe("#ffffff");
+    expect(light["--color-frost"]).toBe("#f3f4f6");
+    expect(light["--color-signal-blue"]).toBe("#0c6bae"); // the accent bridges --color-signal-blue
+    expect(light["--color-ink"]).toBe("#232a35");
+    expect(light["--shadow-offset"]).toBe("1px 1px 0 0 #c0c4ca"); // the shadow bridges --shadow-offset
+
+    const dark = surfacePins(darkTokens);
+    expect(dark["--color-paper"]).toBe("#0d1117");
+    expect(dark["--color-frost"]).toBe("#0e1016");
+    expect(dark["--color-signal-blue"]).toBe("#1a8ed8");
+  });
+
+  it("excludes 2-tier editor-owned tokens (no porcelain bridge to override)", () => {
+    const light = surfacePins(tokens);
+    expect(light).not.toHaveProperty("--canvas"); // editor-owned: var(--beaket-paper-canvas, #fbfcfd)
+    expect(light).not.toHaveProperty("--surface");
+    expect(light).not.toHaveProperty("--font");
+  });
+});
+
+describe("colorSchemeCss makes forcing authoritative over the consumer bridge (#472)", () => {
+  const css = colorSchemeCss();
+  const forced = css.slice(css.indexOf("}}") + 2); // everything after the media block closes
+  const media = css.slice(0, css.indexOf("}}") + 2); // the @media (...) { .cm-editor.cm-beaket-paper { … } }
+
+  it("emits an unconditional forced-light block keyed on the forced-light class", () => {
+    expect(forced).toContain(".cm-editor.cm-beaket-paper-light{");
+  });
+
+  it("pins the bridged surfaces light in the forced-light block (was leaking the OS scheme)", () => {
+    const light = forced.slice(forced.indexOf(".cm-editor.cm-beaket-paper-light{"));
+    expect(light).toContain("--color-paper: #ffffff;");
+    expect(light).toContain("--color-frost: #f3f4f6;");
+  });
+
+  it("pins the bridged surfaces dark in the forced-dark block", () => {
+    expect(forced).toContain("--color-paper: #0d1117;");
+    expect(forced).toContain("--color-frost: #0e1016;");
+  });
+
+  // The OS-follow block must NOT pin the surfaces — it defers to the consumer bridge. The `:` (vs the
+  // `,` in the `--paper`/`--frost` var() chains) makes this a precise pin assertion, no false positive.
+  it("leaves the system/media block deferring to the bridge (no surface pins)", () => {
+    expect(media).not.toContain("--color-paper:");
+    expect(media).not.toContain("--color-frost:");
   });
 });

--- a/packages/paper/src/editor/theme.ts
+++ b/packages/paper/src/editor/theme.ts
@@ -129,7 +129,7 @@ export const darkTokens = {
   "--canvas": "var(--beaket-paper-canvas, #14171c)",
   "--surface": "var(--beaket-paper-surface, #1c1f27)",
   // ② Dark task-checkbox checkmark: dark stroke, because --ink fills light in dark mode (the white
-  //    light variant would vanish). Rides both dark blocks via darkThemeCss, so it flips with the
+  //    light variant would vanish). Rides both dark blocks via colorSchemeCss, so it flips with the
   //    active scope class for forced "dark" and OS-dark "system" alike.
   "--cm-check-mark":
     "url(\"data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2016%2016'%20fill='none'%20stroke='%230d1117'%20stroke-width='2.25'%3E%3Cpath%20d='M3.5%208.5l3%203%206-6'/%3E%3C/svg%3E\")",
@@ -203,34 +203,76 @@ export const baseTheme = EditorView.theme({
 // - "system" (default) → follow the OS via `prefers-color-scheme` (the original behavior).
 // - "dark"            → force dark regardless of OS.
 // - "light"           → force light regardless of OS (suppress the OS dark block).
-// The injected stylesheet carries BOTH a media-gated block (keyed on DARK_SCOPE_CLASS) and an
-// unconditional forced-dark block (keyed on DARK_FORCE_CLASS). The scheme only decides which scope
-// class the editor root wears — so flipping it is a single live class swap (`setColorScheme`), no
-// recreation. "light" wears neither class, so even the OS media block can't match it.
+// The injected stylesheet carries a media-gated block (keyed on DARK_SCOPE_CLASS) plus an
+// unconditional forced-dark and forced-light block (keyed on DARK_FORCE_CLASS / LIGHT_FORCE_CLASS).
+// The scheme only decides which scope class the editor root wears — so flipping it is a single live
+// class swap (`setColorScheme`), no recreation.
+//
+// Forcing is AUTHORITATIVE over the porcelain bridge (#472, ADR-0020). A consumer who bridges
+// `--color-paper`/`--color-frost`/… to a palette that tracks the OS would otherwise leak the OS scheme
+// into the editor's surfaces when a scheme is forced: the forced block only swaps the tier-3 *defaults*
+// inside each var() chain, never beating a consumer-provided tier-2 `--color-*`. So each forced block
+// also PINS the bridged surface `--color-*` to its scheme's value (the same mechanism `--color-ink`
+// already uses — a concrete `--color-*` declared on `.cm-editor` overrides the value inherited from the
+// consumer's `:root`, sidestepping the once-resolved-against-the-OS stickiness). "system" is left
+// unpinned, so it keeps deferring to the bridge (the porcelain-match-for-free contract). The tier-1
+// public `--beaket-paper-*` override still wins within a forced scheme — it is the escape hatch.
 export type ColorScheme = "light" | "dark" | "system";
 
 const DARK_SCOPE_CLASS = "cm-beaket-paper"; // OS-follow: only goes dark inside the media query
 const DARK_FORCE_CLASS = "cm-beaket-paper-dark"; // forced dark: unconditional
+const LIGHT_FORCE_CLASS = "cm-beaket-paper-light"; // forced light: unconditional (pins surfaces light)
 const DARK_STYLE_ID = "beaket-paper-dark-tokens";
 
-/** Maps a color scheme to the editor-root class that selects its token block (empty = forced light). */
+/** Maps a color scheme to the editor-root class that selects its token block. */
 export function colorSchemeClass(scheme: ColorScheme): string {
   if (scheme === "dark") return DARK_FORCE_CLASS;
-  if (scheme === "light") return "";
+  if (scheme === "light") return LIGHT_FORCE_CLASS;
   return DARK_SCOPE_CLASS;
 }
 
+// A 3-tier porcelain bridge: `var(--beaket-paper-X, var(--color-Y, DEFAULT))`. Captures the tier-2
+// porcelain name (`--color-Y`, or `--shadow-offset` for the shadow) and its tier-3 DEFAULT. 2-tier
+// editor-owned tokens (canvas/surface/syntax/typography) have no inner `var(` and never match, so they
+// are correctly excluded from the surface pins.
+const BRIDGE_CHAIN = /^var\(--beaket-paper-[\w-]+, var\((--[\w-]+), (.+)\)\)$/;
+
 /**
- * Serializes `darkTokens` into the dark-mode stylesheet text. Exported for the wiring test.
- * Emits the OS-follow block (media-gated) and the forced-dark block (unconditional) from one source.
+ * Derives the bridged surface pins for a token set — the tier-2 `--color-*`/`--shadow-offset` names
+ * mapped to their scheme-specific tier-3 default. Single source of truth: read straight off the var()
+ * chains in `tokens`/`darkTokens`, so a new 3-tier token auto-pins under forcing for free. Exported for
+ * the wiring test. NOT merged into `tokens`/`darkTokens` themselves — those stay pure var() chains so
+ * the public-override contract holds and `system` keeps deferring to the bridge; the pins exist ONLY in
+ * the forced blocks emitted by `colorSchemeCss()`.
  */
-export function darkThemeCss(): string {
-  const decls = Object.entries(darkTokens)
+export function surfacePins(tokenSet: Record<string, string>): Record<string, string> {
+  const pins: Record<string, string> = {};
+  for (const value of Object.values(tokenSet)) {
+    const match = BRIDGE_CHAIN.exec(value);
+    if (match) pins[match[1]] = match[2];
+  }
+  return pins;
+}
+
+/**
+ * Serializes the scheme stylesheet text. Exported for the wiring test. Emits three blocks from one
+ * source: the OS-follow dark block (media-gated), the forced-dark block, and the forced-light block.
+ * The forced blocks additionally carry the per-scheme surface pins (#472) so forcing beats the bridge.
+ */
+export function colorSchemeCss(): string {
+  const darkDecls = Object.entries(darkTokens)
     .map(([name, value]) => `${name}: ${value};`)
     .join(" ");
+  const pinDecls = (pins: Record<string, string>) =>
+    Object.entries(pins)
+      .map(([name, value]) => `${name}: ${value};`)
+      .join(" ");
+  const lightPins = pinDecls(surfacePins(tokens));
+  const darkPins = pinDecls(surfacePins(darkTokens));
   return (
-    `@media (prefers-color-scheme: dark){.cm-editor.${DARK_SCOPE_CLASS}{${decls}}}` +
-    `.cm-editor.${DARK_FORCE_CLASS}{${decls}}`
+    `@media (prefers-color-scheme: dark){.cm-editor.${DARK_SCOPE_CLASS}{${darkDecls}}}` +
+    `.cm-editor.${DARK_FORCE_CLASS}{${darkDecls} ${darkPins}}` +
+    `.cm-editor.${LIGHT_FORCE_CLASS}{${lightPins}}`
   );
 }
 
@@ -265,7 +307,7 @@ export function darkThemeStyle(scheme: ColorScheme = "system"): Extension {
       if (!host.querySelector(`#${DARK_STYLE_ID}`)) {
         const style = (root.ownerDocument ?? document).createElement("style");
         style.id = DARK_STYLE_ID;
-        style.textContent = darkThemeCss();
+        style.textContent = colorSchemeCss();
         host.appendChild(style);
       }
       return {};

--- a/sites/paper/src/components/editor-playground.tsx
+++ b/sites/paper/src/components/editor-playground.tsx
@@ -230,21 +230,11 @@ export function EditorPlayground() {
         [data-pg-theme="dark"] {
           --ink: #e8eaec; --paper: #16181c; --frost: #23272e; --chrome: #3e4145; --steel: #9aa0a6;
         }
-        /* Re-bridge the editor's porcelain vars to the *forced* palette. global.css resolves
-           --color-* at :root against the OS scheme and that computed value inherits down — so
-           overriding only --paper/--frost above doesn't reach the editor's tokens, which read
-           --color-paper/--color-frost. Without this, a forced-light editor under a dark OS leaks
-           dark into overlays that paint those tokens directly: the slash menu, the "Copied" toast
-           and the table row/col insert handles. Re-declaring --color-* here re-resolves them
-           against the forced --paper/--ink/etc. on this element. */
-        [data-pg-theme="light"],
-        [data-pg-theme="dark"] {
-          --color-ink: var(--ink);
-          --color-paper: var(--paper);
-          --color-frost: var(--frost);
-          --color-chrome: var(--chrome);
-          --color-steel: var(--steel);
-        }
+        /* No --color-* re-bridge needed here: as of @beaket/paper ≥ the #472 fix (ADR-0020), a forced
+           colorScheme is authoritative — the editor pins its own bridged --color-* per scheme on
+           .cm-editor, so overlays (slash menu, "Copied" toast, table handles) follow the forced scheme
+           regardless of the docs site's OS-tracking bridge in global.css. The chrome overrides above
+           only dress the card/toolbar/footer around the editor. */
         .pg-toolbar {
           display: flex;
           flex-wrap: wrap;


### PR DESCRIPTION
Fixes #472.

## Problem

A forced `colorScheme` (`"light"`/`"dark"`) didn't override a consumer's porcelain `--color-*` bridge. When a consumer bridges `--color-paper`/`--color-frost`/… to a palette that tracks the OS, a forced-light editor under a **dark** OS leaked the OS scheme into overlays — the slash menu, the "Copied" toast (dark-on-dark, unreadable) and the table row/col insert handles.

**Root cause.** Surface tokens resolve through the 3-tier bridge `var(--beaket-paper-X, var(--color-Y, default))`. Forcing only swapped the **tier-3** built-in default — it never beat a consumer-provided **tier-2** `--color-*`. CSS custom-property resolution makes it sticky: `--color-paper: var(--paper)` declared at `:root` is computed once against the OS scheme and that value inherits down. Only `--color-ink`, already pinned per scheme, didn't leak — the discriminating clue.

## Fix

When a scheme is **forced**, pin the full set of bridged surface `--color-*` (and `--shadow-offset`) per scheme on `.cm-editor` — the same mechanism `--color-ink` already used, so the editor's own declaration beats the inherited bridge and reaches every `.cm-editor`-attached overlay.

- `colorScheme="light"` now wears its own scope class (`cm-beaket-paper-light`) carrying the light pins (previously it wore **none**).
- `colorScheme="dark"` adds dark pins to its existing block.
- `"system"` stays **unpinned** — keeps deferring to the bridge (porcelain match-for-free preserved).
- Tier-1 `--beaket-paper-*` override still wins inside a forced scheme (the escape hatch).

Pins are **derived off the var() chains** in `theme.ts` (single source of truth), **forced-block-only** — never merged into the token maps (merging would break the public-override contract and re-break `system` mode). Removed the now-redundant docs-playground `--color-*` re-bridge workaround.

See **ADR-0020** for the decision (option 1 over option 2) and the load-bearing constraint.

## Verification

- **Browser (decisive).** Under a simulated dark-OS bridge (`:root --color-paper: #0d1117`), a forced-light editor resolves `.cm-editor --color-paper: #ffffff`, and the `cm-slash-menu` overlay — a confirmed `.cm-editor` descendant — renders `rgb(255,255,255)` bg with ink text. The comprehensive pin set + proven inheritance path covers the whole class of `.cm-editor`-attached overlays (toast, table handles), not just the slash menu.
- **Tests.** Full paper suite **281 passing**, typecheck clean, ADR-ref CI check passes. jsdom tests lock the derived pin set and placement (forced blocks pin; `system`/media block does not — rendered colors are the ADR-0005 browser carve-out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)