### PR TITLE
feat(paper): GitHub-style footnotes — in-place render + collected section

### DIFF
--- a/.changeset/paper-footnotes.md
+++ b/.changeset/paper-footnotes.md
@@ -1,0 +1,12 @@
+---
+"@beaket/paper": minor
+---
+
+Add GitHub-style footnotes (ADR-0021). Type a `[^label]` reference in a sentence and a `[^label]: text` definition anywhere — off the cursor they "become footnotes," all derived from the markdown source (no second model; round-trips for free).
+
+- **Parser.** GFM in `@lezer/markdown` ships no footnote node, so a custom `MarkdownConfig` adds real `FootnoteReference` (inline) and `FootnoteDefinition` (block) nodes — driving marker hiding, definition detection, and round-trip without fragile regex. A definition may interrupt a paragraph with no blank line above it (`endLeaf`), and a `[^x]` inside inline code stays literal.
+- **Reference → superscript, reveal-on-cursor.** `[^1]` renders as a superscript ordinal off-cursor and reveals its raw form on-cursor (the Live-Preview contract, not an atomic token). Numbering follows GitHub: by **first-reference order**, computed over the whole document; an undefined `[^x]` stays literal and an unreferenced definition is excluded from the numbering.
+- **Definition rendered in place + collected at the end.** Off-cursor, a referenced definition renders as a real footnote (number + body) where it is authored — locatable and clickable, not hidden — and on-cursor reveals raw for editing. Every referenced definition is also gathered into a section after the last line (the package's first StateField-provided block decoration; IME-safe via the widget's `eq()` and `docChanged`-only recompute). Both renderings share markup so they stay consistent.
+- **Re-edit model.** Editing always happens at the source: cursor-on-line reveals raw like any other block, and clicking a collected item moves the cursor to its source definition. The cursor moves; content never teleports.
+
+Always-on (like tables) — no `EditorOptions` change. Known v1 cuts: footnote bodies are plain text (inline markdown inside a footnote not yet rendered), single-line definitions only, and numbering rescans the whole document per edit. A publish-oriented `footnoteLayout: "inline" | "collected"` toggle (collected = clean body, definitions only at the bottom) is a planned follow-up.

--- a/packages/paper/docs/CONTEXT.md
+++ b/packages/paper/docs/CONTEXT.md
@@ -73,7 +73,7 @@ there is no second document model. Everything else follows from this:
   `EditorView.editable` in one compartment; `setReadOnly` flips it live (ADR-0018). The doc-mutating
   entry points guard on `view.state.readOnly` themselves (the matrix lives in the ADR).
 - `editor/extensions/markdown.ts` — the dialect: CommonMark + GFM core (Table, TaskList,
-  Strikethrough, Autolink) and the heading/code style ramp.
+  Strikethrough, Autolink), the **footnotes** parser config (below), and the heading/code style ramp.
 
 **Live Preview rendering** (hide syntax off-cursor, render on)
 
@@ -83,6 +83,20 @@ there is no second document model. Everything else follows from this:
 - `extensions/list-rendering.ts` — bullets `- * +` → •, task markers → checkboxes, off-cursor.
 - `extensions/image-widget.ts` — a line that is a lone `![alt](url)` renders as the image (render
   side of images).
+
+**Footnotes** (GitHub-style; ADR-0021. Always-on, no consumer config)
+
+- `extensions/footnotes-syntax.ts` — the `@beaket/paper` `MarkdownConfig` adding real
+  `FootnoteReference` (inline) + `FootnoteDefinition` (block) nodes, since GFM ships none. Wired into
+  `markdown.ts`. `endLeaf` lets a definition interrupt a paragraph (no blank line needed).
+- `extensions/footnote-render.ts` — `computeFootnotes(state)` (the one pure model: numbering by
+  first-reference order; the pure test seam) + the ViewPlugin rendering: a `[^1]` reference → superscript
+  reveal-on-cursor, and a referenced definition rendered **in place** off-cursor (number + body),
+  locatable and clickable, raw on-cursor.
+- `extensions/footnote-section.ts` — the collected "footnotes at the end" list. The package's **first
+  StateField-provided block decoration** (CM6 forbids block decorations from a ViewPlugin); IME-safe via
+  the widget's `eq()` + `docChanged`-only recompute. `mousedown` on an item jumps the cursor to its
+  source definition (the collected list is a read-only preview — editing is always at the source).
 
 **Tables** (structure permanently hidden; cell edited in a subview)
 

--- a/packages/paper/docs/adr/0021-footnotes-in-place-render-plus-collected-section.md
+++ b/packages/paper/docs/adr/0021-footnotes-in-place-render-plus-collected-section.md
@@ -1,0 +1,98 @@
+# 0021 — Footnotes: in-place definition render + a collected section
+
+- **Status:** Accepted
+- **Date:** 2026-06-23
+- **Supersedes:** —
+- **Superseded-by:** —
+- **Amends:** —
+
+---
+
+# Footnotes: GitHub-style markers, definitions rendered in place _and_ collected at the end
+
+## Context
+
+GitHub-flavored footnotes are two constructs: an inline **reference** `[^label]` that lives in a
+sentence, and a block **definition** `[^label]: text` authored anywhere. The ask: type them anywhere
+and have them "magically become footnotes," with a re-editing model thought through deliberately.
+
+Two facts shaped the design:
+
+1. **GFM in `@lezer/markdown` ships no footnote node.** The dialect is CommonMark + GFM (Table,
+   TaskList, Strikethrough, Autolink) — `[^1]` / `[^1]: …` are not parser-recognized. So footnotes need
+   either a custom parser extension or syntax-independent regex detection.
+2. **The editor's one model is "markdown is the only source of truth; the view is derived by
+   decorations" (ADR-0001), and Live Preview reveals raw only on the cursor's line.** A reference is a
+   natural fit. A definition is the hard part: "collected at the bottom" means rendering content away
+   from its source position, which fights render-in-place.
+
+The re-editing model was the genuinely hard question (an earlier, never-committed footnote epic cycled
+here). Two approaches were tried in the browser and **rejected**:
+
+- **Collapse the off-cursor definition to an invisible hairline** (content shown only in the collected
+  section). This produced a real editing bug: editing a definition then pressing Enter moved the cursor
+  off the line, so the definition _vanished_ — and because it was zero-height and invisible, it could
+  not be relocated or clicked to bring back. Confirmed in the playground with a body-interleaved
+  definition.
+- **A dual-mode `inline | collected` layout toggle, built up front.** Deferred — it front-loaded
+  complexity (and was the rock the prior epic split on). In-place rendering turned out to be the simple,
+  no-teleport base, which makes the toggle cheap to add _later_ rather than a prerequisite.
+
+## Decision
+
+**Parse footnotes as real nodes; render the reference inline (Live Preview) and the definition _in
+place_; also collect every definition into a section at the document's end. Everything derives from the
+markdown source — no second model, round-trips for free.**
+
+Concretely:
+
+- **Parser (`footnotes-syntax.ts`).** A custom `@lezer/markdown` `MarkdownConfig` adds
+  `FootnoteReference` (inline, installed `before: "Link"`) and `FootnoteDefinition` (block, installed
+  `before: "LinkReference"` so it isn't mis-claimed as a link-reference definition). `endLeaf` lets a
+  definition interrupt a running paragraph, so it works with no blank line above ("write anywhere"). Real
+  nodes — not regex — drive marker hiding, definition detection, and a clean round-trip; matches inside
+  inline code are never treated as footnotes (the InlineCode parser claims them first).
+- **Numbering = GitHub's: by first-_reference_ order**, computed over the whole document (stable, not
+  viewport-dependent). A reference with no matching definition stays literal `[^x]`; an unreferenced
+  definition is parsed but excluded from the numbering. `computeFootnotes(state)` is the one pure model,
+  shared by both renderers (the jsdom contract-test seam, ADR-0005).
+- **Reference rendering (`footnote-render.ts`, ViewPlugin via `guardedDecorations`).** Off-cursor, a
+  `[^label]` reference becomes a superscript ordinal; on-cursor it reveals raw — the same
+  reveal-on-cursor contract as inline-syntax-hiding, **not** the permanently-atomic token path.
+- **Definition rendering = in place, locatable.** Off-cursor, a referenced definition line renders as a
+  real footnote (its number + body) where it is authored — **not** collapsed to nothing. On-cursor it
+  reveals raw for editing. This is what fixes the vanish/relocate bug: the definition's position is
+  always visible and clickable.
+- **Collected section (`footnote-section.ts`, a StateField).** Every referenced definition is also
+  gathered into a list rendered after the last line. This is a **block** decoration, which CM6 requires
+  from a StateField, not a ViewPlugin ("Block decorations may not be specified via plugins") — the
+  package's first block decoration. IME safety without the composing-guard plugin (a StateField can't use
+  it): the field recomputes only on `docChanged` (its content never depends on the cursor) and the
+  widget's `eq()` compares the full model, so composing CJK into a paragraph leaves the definition set
+  unchanged → `eq` true → CM6 keeps the DOM, no rebuild near the composition target. The collected items
+  reuse the in-place definition's markup/classes so the two are consistent by construction.
+- **Re-edit model.** You never edit at the bottom — it is a derived preview. Editing happens at the
+  source: cursor-on-line reveals raw (like every other block), and **clicking a collected item moves the
+  cursor to its source definition** (revealing it raw). The cursor moves; content never teleports.
+- **Default presentation shows both** the in-place render and the collected section. The redundancy is
+  accepted for now; a publish-oriented `footnoteLayout: "inline" | "collected"` (collected = clean body,
+  definitions only at the bottom) is **deferred** to a follow-up, modeled on the existing
+  `colorScheme`/`readOnly` compartment+setter shape. Collected mode's mouse re-edit path is the
+  click-to-source jump, already built.
+
+## Consequences
+
+- Footnotes are always-on (like tables) — zero consumer config; nothing added to the 1.0-frozen
+  `EditorOptions` surface. The follow-up toggle is an additive `0.x` minor when it lands.
+- The package gains its **first StateField-provided block decoration**; future block-level rendering has
+  a precedent (and its IME story) to follow.
+- **v1 cuts (deliberate, revisit on demand):**
+  - Footnote bodies render as **plain text** — inline markdown inside a footnote is not rendered.
+  - **Single-line definitions only** — no indented continuation lines.
+  - `computeFootnotes` scans the **whole document** per `docChanged` (numbering is global). Fine for
+    normal documents; a very large document is a perf follow-up.
+  - The StateField's IME deferral rests on `eq()` only; a **physical-key CJK IME** spot-check of the
+    block-section path is deferred (consistent with the existing deferred IME spot-checks).
+- Coordinate/DOM behavior (superscript placement, the in-place and collected renders, reveal-on-cursor,
+  click-to-source) is carved out for browser verification (invariant #4) — done in the playground; the
+  parser and `computeFootnotes` model are covered by jsdom contract tests.

--- a/packages/paper/src/editor/create-editor.ts
+++ b/packages/paper/src/editor/create-editor.ts
@@ -8,6 +8,8 @@ import { blockquoteKeymap } from "./extensions/blockquote-keys";
 import { changeNotifier } from "./extensions/change-notifier";
 import { codeBlockCopy } from "./extensions/code-block-copy";
 import { codeBlockEnter } from "./extensions/code-block-enter";
+import { footnoteRender } from "./extensions/footnote-render";
+import { footnoteSection } from "./extensions/footnote-section";
 import { highlightLayer } from "./extensions/highlight-layer";
 import type { ImageResolver } from "./extensions/image-drop";
 import { imageDrop } from "./extensions/image-drop";
@@ -133,6 +135,11 @@ export function editorExtensions(opts: EditorOptions = {}): Extension[] {
     tokenRender(opts.tokens),
     inlineSyntaxHiding(),
     blockSyntaxHiding(),
+    // Footnotes: `[^1]` references render as superscript ordinals (numbered by first-reference order),
+    // raw-on-cursor. Placed after the syntax-hiders so its replace widget owns the reference range.
+    footnoteRender(),
+    // The collected "Footnotes" section at the document's end (a StateField-provided block widget).
+    footnoteSection(),
     imageWidget(),
     imageDrop(opts.onInsertImage),
     codeBlockCopy(),

--- a/packages/paper/src/editor/extensions/footnote-render.ts
+++ b/packages/paper/src/editor/extensions/footnote-render.ts
@@ -1,0 +1,235 @@
+import { syntaxTree } from "@codemirror/language";
+import { type EditorState, type Extension, StateField } from "@codemirror/state";
+import type { DecorationSet } from "@codemirror/view";
+import { Decoration, EditorView, WidgetType } from "@codemirror/view";
+import { guardedDecorations } from "./composing-guard";
+
+// Live-Preview rendering for footnotes. A `[^label]` reference renders as a superscript ordinal
+// off-cursor and reveals its raw `[^label]` when the cursor touches it — the same reveal-on-cursor
+// contract as inline-syntax-hiding, not the permanently-atomic token path. Numbering is GitHub's: by
+// first-reference order in the body, and only references that have a matching definition become a number
+// (an undefined `[^x]` stays literal text). The collected section (footnote-section.ts) reads the same
+// model.
+
+/** A footnote definition resolved from the source: its source range, label, and raw body text. */
+export interface FootnoteDef {
+  label: string;
+  from: number;
+  to: number;
+  /** Body text after `[^label]:` (leading space trimmed). Plain text in v1 — inline md is not rendered. */
+  body: string;
+}
+
+/** The whole-document footnote model, shared by the reference renderer and the collected section. */
+export interface FootnoteModel {
+  /** label → 1-based ordinal, by first-reference order; only labels that have a definition. */
+  numberOf: Map<string, number>;
+  /** Labels in numbered order (i.e. the order the collected section lists them). */
+  order: string[];
+  /** label → definition (last wins if a label is defined twice). */
+  defs: Map<string, FootnoteDef>;
+}
+
+const REF_RE = /^\[\^([^\]]+)\]$/;
+const DEF_RE = /^\[\^([^\]]+)\]:\s?/;
+
+/**
+ * Build the footnote model for the whole document. Pure + coordinate-independent → the jsdom
+ * contract-test seam (ADR-0005). Scans the full doc (not just the viewport) because numbering is global
+ * and stable: a reference's number can't depend on what happens to be scrolled into view.
+ */
+export function computeFootnotes(state: EditorState): FootnoteModel {
+  const defs = new Map<string, FootnoteDef>();
+  const refLabelsInOrder: string[] = [];
+
+  syntaxTree(state).iterate({
+    from: 0,
+    to: state.doc.length,
+    enter(node) {
+      if (node.name === "FootnoteDefinition") {
+        const text = state.doc.sliceString(node.from, node.to);
+        const m = DEF_RE.exec(text);
+        if (m) {
+          const label = m[1];
+          defs.set(label, {
+            label,
+            from: node.from,
+            to: node.to,
+            body: text.slice(m[0].length),
+          });
+        }
+        return false; // don't descend into the definition's marks
+      }
+      if (node.name === "FootnoteReference") {
+        const m = REF_RE.exec(state.doc.sliceString(node.from, node.to));
+        if (m) refLabelsInOrder.push(m[1]);
+      }
+    },
+  });
+
+  const numberOf = new Map<string, number>();
+  const order: string[] = [];
+  for (const label of refLabelsInOrder) {
+    if (numberOf.has(label) || !defs.has(label)) continue;
+    order.push(label);
+    numberOf.set(label, order.length);
+  }
+
+  return { numberOf, order, defs };
+}
+
+/**
+ * The footnote model, recomputed once per document change and shared by the reference renderer, the
+ * collected section, and the jump-to-source handler. Numbering is global, so the model is a whole-doc
+ * scan — caching it here keeps cursor moves (which re-run the reference renderer) from rescanning.
+ */
+export const footnoteModelField = StateField.define<FootnoteModel>({
+  create: computeFootnotes,
+  update: (value, tr) => (tr.docChanged ? computeFootnotes(tr.state) : value),
+});
+
+/** Superscript ordinal shown in place of a `[^label]` reference off-cursor. */
+class FootnoteRefWidget extends WidgetType {
+  constructor(readonly num: number) {
+    super();
+  }
+
+  eq(other: FootnoteRefWidget): boolean {
+    return other.num === this.num;
+  }
+
+  toDOM(): HTMLElement {
+    const sup = document.createElement("sup");
+    sup.className = "cm-footnote-ref";
+    sup.textContent = String(this.num);
+    return sup;
+  }
+
+  // Let clicks reach the editor so clicking the superscript places the caret there (revealing raw),
+  // rather than being swallowed by the widget.
+  ignoreEvent(): boolean {
+    return false;
+  }
+}
+
+/**
+ * The off-cursor rendering of a definition line: its number plus the rendered body, shown in place
+ * where the `[^x]: …` is authored — a real, locatable footnote, not an invisible strip. Clicking or
+ * cursoring it reveals the raw line for editing; the same text is also gathered in the collected
+ * section, and both derive from the one source so an edit updates them together. (Body is plain text
+ * in v1 — inline markdown inside a footnote is not yet rendered.)
+ */
+class FootnoteDefWidget extends WidgetType {
+  constructor(
+    readonly num: number,
+    readonly body: string,
+  ) {
+    super();
+  }
+
+  eq(other: FootnoteDefWidget): boolean {
+    return other.num === this.num && other.body === this.body;
+  }
+
+  toDOM(): HTMLElement {
+    const wrap = document.createElement("span");
+    wrap.className = "cm-footnote-def";
+
+    const num = document.createElement("sup");
+    num.className = "cm-footnote-def-num";
+    num.textContent = String(this.num);
+
+    const body = document.createElement("span");
+    body.className = "cm-footnote-def-body";
+    body.textContent = this.body || " ";
+
+    wrap.append(num, body);
+    return wrap;
+  }
+
+  ignoreEvent(): boolean {
+    return false;
+  }
+}
+
+function selectionTouches(state: EditorState, from: number, to: number): boolean {
+  return state.selection.ranges.some((range) => range.from <= to && range.to >= from);
+}
+
+function computeRefDecorations(view: EditorView): DecorationSet {
+  const { state } = view;
+  const { numberOf } = state.field(footnoteModelField);
+  if (numberOf.size === 0) return Decoration.none;
+
+  const ranges: ReturnType<Decoration["range"]>[] = [];
+  for (const { from, to } of view.visibleRanges) {
+    syntaxTree(state).iterate({
+      from,
+      to,
+      enter(node) {
+        if (node.name === "FootnoteReference") {
+          const m = REF_RE.exec(state.doc.sliceString(node.from, node.to));
+          if (!m) return;
+          const num = numberOf.get(m[1]);
+          if (num === undefined) return; // undefined label → stays literal `[^x]`
+          if (selectionTouches(state, node.from, node.to)) return; // reveal raw on cursor
+          ranges.push(
+            Decoration.replace({ widget: new FootnoteRefWidget(num) }).range(node.from, node.to),
+          );
+          return;
+        }
+        if (node.name === "FootnoteDefinition") {
+          const text = state.doc.sliceString(node.from, node.to);
+          const m = DEF_RE.exec(text);
+          if (!m) return false;
+          const num = numberOf.get(m[1]);
+          if (num === undefined) return false; // unreferenced def → stays raw
+          const line = state.doc.lineAt(node.from);
+          if (selectionTouches(state, line.from, line.to)) return false; // editing → raw
+          // Off-cursor: render the raw `[^x]: …` in place as a real footnote (number + body).
+          ranges.push(
+            Decoration.replace({
+              widget: new FootnoteDefWidget(num, text.slice(m[0].length)),
+            }).range(node.from, node.to),
+          );
+          return false; // don't descend into the definition's marks
+        }
+      },
+    });
+  }
+  return Decoration.set(ranges, true);
+}
+
+const footnoteTheme = EditorView.theme({
+  ".cm-footnote-ref": {
+    color: "var(--accent)",
+    fontWeight: "600",
+    cursor: "pointer",
+    // Sit the number tight against the preceding word, like a printed footnote mark.
+    padding: "0 0.1em",
+  },
+  // The off-cursor definition rendered in place: an accent number + muted body; the hover tint signals
+  // it is clickable (cursor → reveals raw for editing).
+  ".cm-footnote-def": {
+    cursor: "pointer",
+    color: "var(--steel)",
+    fontSize: "0.9em",
+  },
+  ".cm-footnote-def-num": {
+    color: "var(--accent)",
+    fontWeight: "600",
+    marginRight: "0.35em",
+  },
+  ".cm-footnote-def:hover": {
+    backgroundColor: "var(--accent-sel)",
+  },
+});
+
+/** Wire footnote reference + in-place definition rendering, and the shared model field both halves read. */
+export function footnoteRender(): Extension {
+  return [
+    footnoteModelField,
+    guardedDecorations("footnote-render", computeRefDecorations),
+    footnoteTheme,
+  ];
+}

--- a/packages/paper/src/editor/extensions/footnote-render.ts
+++ b/packages/paper/src/editor/extensions/footnote-render.ts
@@ -213,7 +213,7 @@ const footnoteTheme = EditorView.theme({
   ".cm-footnote-def": {
     cursor: "pointer",
     color: "var(--steel)",
-    fontSize: "0.9em",
+    fontSize: "0.8em",
   },
   ".cm-footnote-def-num": {
     color: "var(--accent)",

--- a/packages/paper/src/editor/extensions/footnote-section.ts
+++ b/packages/paper/src/editor/extensions/footnote-section.ts
@@ -120,7 +120,7 @@ const footnoteSectionTheme = EditorView.theme({
     margin: "0",
     paddingLeft: "1.4em",
     color: "var(--steel)",
-    fontSize: "0.9em",
+    fontSize: "0.8em",
     lineHeight: "1.6",
   },
   ".cm-footnotes-item": {

--- a/packages/paper/src/editor/extensions/footnote-section.ts
+++ b/packages/paper/src/editor/extensions/footnote-section.ts
@@ -1,0 +1,139 @@
+import type { EditorState, Extension } from "@codemirror/state";
+import { StateField } from "@codemirror/state";
+import type { DecorationSet } from "@codemirror/view";
+import { Decoration, EditorView, WidgetType } from "@codemirror/view";
+import { type FootnoteModel, footnoteModelField } from "./footnote-render";
+
+// The collected "Footnotes" section — definitions authored anywhere in the source are gathered into a
+// numbered list rendered after the last line (GitHub's presentation). This is a **block** decoration,
+// which CM6 requires to come from a StateField, not a ViewPlugin ("Block decorations may not be
+// specified via plugins") — so it lives here, separate from the plugin-based reference rendering.
+//
+// IME safety without the composing-guard plugin (which a StateField can't use): the field recomputes
+// only on `docChanged` (the section content depends on the doc, never on the cursor), and the widget's
+// `eq()` compares the full rendered model — so composing CJK into a paragraph leaves the definition set
+// unchanged → `eq` true → CM6 keeps the existing DOM, no rebuild near the composition target.
+
+interface SectionItem {
+  num: number;
+  label: string;
+  /** Plain body text. v1 does not render inline markdown inside a footnote body (a deliberate cut). */
+  body: string;
+}
+
+function buildItems(model: FootnoteModel): SectionItem[] {
+  return model.order.map((label) => ({
+    num: model.numberOf.get(label) as number,
+    label,
+    body: model.defs.get(label)?.body ?? "",
+  }));
+}
+
+class FootnoteSectionWidget extends WidgetType {
+  constructor(readonly items: SectionItem[]) {
+    super();
+  }
+
+  eq(other: FootnoteSectionWidget): boolean {
+    if (other.items.length !== this.items.length) return false;
+    return this.items.every((it, i) => {
+      const o = other.items[i];
+      return it.num === o.num && it.label === o.label && it.body === o.body;
+    });
+  }
+
+  toDOM(): HTMLElement {
+    const section = document.createElement("div");
+    section.className = "cm-footnotes-section";
+    section.setAttribute("contenteditable", "false");
+
+    // No heading label — the top border alone marks the collected zone.
+    const ol = document.createElement("ol");
+    ol.className = "cm-footnotes-list";
+    for (const item of this.items) {
+      const li = document.createElement("li");
+      li.className = "cm-footnotes-item";
+      li.value = item.num; // <li value> drives the displayed ordinal
+      li.setAttribute("data-footnote-label", item.label);
+      li.textContent = item.body || " ";
+      ol.appendChild(li);
+    }
+    section.appendChild(ol);
+    return section;
+  }
+
+  ignoreEvent(): boolean {
+    return false; // let clicks through so the section can offer jump-to-source
+  }
+}
+
+function sectionDecorations(state: EditorState): DecorationSet {
+  const model = state.field(footnoteModelField);
+  if (model.order.length === 0) return Decoration.none;
+  const widget = Decoration.widget({
+    widget: new FootnoteSectionWidget(buildItems(model)),
+    block: true,
+    side: 1,
+  });
+  return Decoration.set([widget.range(state.doc.length)]);
+}
+
+const footnoteSectionField = StateField.define<DecorationSet>({
+  create: (state) => sectionDecorations(state),
+  update(value, tr) {
+    // The section content depends only on the document. Skip recompute on pure selection/viewport
+    // transactions; just map the end-anchored widget to the new coordinates.
+    if (!tr.docChanged) return value.map(tr.changes);
+    return sectionDecorations(tr.state);
+  },
+  provide: (f) => EditorView.decorations.from(f),
+});
+
+// Click a collected item → move the cursor to its source definition line. The cursor landing there is
+// what reveals the raw `[^x]: …` inline (via footnote-render's reveal-on-cursor) — so editing always
+// happens at the source, and the section stays a read-only publish preview. mousedown (not click) so
+// we beat CM's own selection handling; preventDefault keeps focus/caret where we put it.
+const footnoteSectionClick = EditorView.domEventHandlers({
+  mousedown(event, view) {
+    const target = event.target as HTMLElement | null;
+    const item = target?.closest?.(".cm-footnotes-item") as HTMLElement | null;
+    if (!item) return false;
+    const label = item.getAttribute("data-footnote-label");
+    if (!label) return false;
+    const def = view.state.field(footnoteModelField).defs.get(label);
+    if (!def) return false;
+    event.preventDefault();
+    view.focus();
+    // Land at the end of the definition body so the writer is positioned to keep typing.
+    view.dispatch({ selection: { anchor: def.to }, scrollIntoView: true });
+    return true;
+  },
+});
+
+const footnoteSectionTheme = EditorView.theme({
+  ".cm-footnotes-section": {
+    marginTop: "2em",
+    paddingTop: "1em",
+    borderTop: "1px solid var(--silver)",
+  },
+  ".cm-footnotes-list": {
+    margin: "0",
+    paddingLeft: "1.4em",
+    color: "var(--steel)",
+    fontSize: "0.9em",
+    lineHeight: "1.6",
+  },
+  ".cm-footnotes-item": {
+    paddingLeft: "0.2em",
+    cursor: "pointer",
+  },
+  ".cm-footnotes-item::marker": {
+    color: "var(--accent)",
+    fontWeight: "600",
+  },
+});
+
+/** Wire the collected footnotes section (block widget at the end of the document). */
+export function footnoteSection(): Extension {
+  return [footnoteSectionField, footnoteSectionClick, footnoteSectionTheme];
+}

--- a/packages/paper/src/editor/extensions/footnotes-syntax.ts
+++ b/packages/paper/src/editor/extensions/footnotes-syntax.ts
@@ -1,0 +1,89 @@
+import { tags as t } from "@lezer/highlight";
+import type { BlockContext, InlineContext, Line, MarkdownConfig } from "@lezer/markdown";
+
+// Footnote syntax (GitHub-flavored). GFM in @lezer/markdown ships Table/TaskList/Strikethrough/Autolink
+// but *not* footnotes, so we add real parser nodes here rather than detect with regex — real nodes drive
+// marker hiding, definition detection, and a clean round-trip to plain markdown (single source of truth).
+//
+//   reference  : `[^label]`         — inline, lives in the sentence (rendered as a superscript number)
+//   definition : `[^label]: text`   — block, authored anywhere (collected into a footnotes section)
+//
+// v1 scope: single-line definitions only (no indented continuation lines); labels carry no whitespace
+// or nested bracket. Both cuts are intentional — see footnote-render.ts for where they surface.
+
+const BRACKET_OPEN = 91; // [
+const CARET = 94; // ^
+const BRACKET_CLOSE = 93; // ]
+const COLON = 58; // :
+const SPACE = 32;
+const TAB = 9;
+const NEWLINE = 10;
+
+/**
+ * Scan a footnote label starting just past `[^`. Returns the index of the closing `]`, or -1 when the
+ * run isn't a valid label (empty, or contains whitespace / a nested `[`) so the text stays literal.
+ */
+function scanLabelEnd(charAt: (i: number) => number, start: number, end: number): number {
+  for (let i = start; i < end; i++) {
+    const ch = charAt(i);
+    if (ch === BRACKET_CLOSE) return i === start ? -1 : i;
+    if (ch === BRACKET_OPEN || ch === SPACE || ch === TAB || ch === NEWLINE) return -1;
+  }
+  return -1;
+}
+
+// Inline: `[^label]` → a FootnoteReference element. Installed before the standard Link parser so the
+// opening `[` is claimed here (a footnote ref is never a link). Definition lines never reach inline
+// parsing — the block parser below consumes them whole first.
+const footnoteReferenceParser = {
+  name: "FootnoteReference",
+  before: "Link",
+  parse(cx: InlineContext, next: number, pos: number): number {
+    if (next !== BRACKET_OPEN || cx.char(pos + 1) !== CARET) return -1;
+    const close = scanLabelEnd((i) => cx.char(i), pos + 2, cx.end);
+    if (close < 0) return -1;
+    return cx.addElement(cx.elt("FootnoteReference", pos, close + 1));
+  },
+};
+
+/** True when a line (from its first non-marker char) opens a `[^label]:` definition. */
+function definitionLabelClose(text: string, start: number): number {
+  if (text.charCodeAt(start) !== BRACKET_OPEN || text.charCodeAt(start + 1) !== CARET) return -1;
+  const close = scanLabelEnd((i) => text.charCodeAt(i), start + 2, text.length);
+  if (close < 0 || text.charCodeAt(close + 1) !== COLON) return -1;
+  return close;
+}
+
+// Block: `[^label]: text` → a FootnoteDefinition (single line). Installed before LinkReference, which
+// would otherwise mis-claim `[^label]: ...` as a link reference definition. `endLeaf` lets a definition
+// interrupt a running paragraph, so it works even with no blank line above it ("write anywhere").
+const footnoteDefinitionParser = {
+  name: "FootnoteDefinition",
+  before: "LinkReference",
+  parse(cx: BlockContext, line: Line): boolean {
+    const close = definitionLabelClose(line.text, line.pos);
+    if (close < 0) return false;
+    const from = cx.lineStart + line.pos;
+    const markEnd = cx.lineStart + close + 2; // through the `]:`
+    const lineEnd = cx.lineStart + line.text.length;
+    cx.addElement(
+      cx.elt("FootnoteDefinition", from, lineEnd, [cx.elt("FootnoteMark", from, markEnd)]),
+    );
+    cx.nextLine();
+    return true;
+  },
+  endLeaf(_cx: BlockContext, line: Line): boolean {
+    return definitionLabelClose(line.text, line.pos) >= 0;
+  },
+};
+
+/** The lezer-markdown extension adding footnote reference + definition nodes. Wired in `markdown.ts`. */
+export const footnotesMarkdown: MarkdownConfig = {
+  defineNodes: [
+    { name: "FootnoteReference", style: t.labelName },
+    { name: "FootnoteDefinition", block: true },
+    { name: "FootnoteMark", style: t.processingInstruction },
+  ],
+  parseInline: [footnoteReferenceParser],
+  parseBlock: [footnoteDefinitionParser],
+};

--- a/packages/paper/src/editor/extensions/footnotes.test.ts
+++ b/packages/paper/src/editor/extensions/footnotes.test.ts
@@ -1,0 +1,96 @@
+import { syntaxTree } from "@codemirror/language";
+import { EditorState } from "@codemirror/state";
+import { describe, expect, it } from "vitest";
+import { computeFootnotes } from "./footnote-render";
+import { markdownExtension } from "./markdown";
+
+// Footnote contract tests (ADR-0005). The parser nodes (FootnoteReference / FootnoteDefinition) and the
+// pure `computeFootnotes` model are deterministic and coordinate-independent → jsdom contract targets.
+// The rendering — superscript widgets, the in-place definition render, the collected block section, the
+// reveal-on-cursor and click-to-source behaviors — is geometry/DOM and is carved out for the browser
+// (invariant #4), verified in the playground.
+
+const stateOf = (doc: string) => EditorState.create({ doc, extensions: [markdownExtension()] });
+
+const modelOf = (doc: string) => computeFootnotes(stateOf(doc));
+
+describe("footnote parser", () => {
+  it("parses `[^1]` as a FootnoteReference and `[^1]: …` as a FootnoteDefinition", () => {
+    const names = new Set<string>();
+    syntaxTree(stateOf("ref[^1]\n\n[^1]: def")).iterate({
+      enter: (n) => {
+        names.add(n.name);
+      },
+    });
+    expect(names.has("FootnoteReference")).toBe(true);
+    expect(names.has("FootnoteDefinition")).toBe(true);
+  });
+
+  it("recognizes a definition that directly follows a paragraph line (no blank line above)", () => {
+    // The block parser's `endLeaf` lets a definition interrupt a running paragraph ("write anywhere").
+    const m = modelOf("ref[^1]\ntext\n[^1]: def");
+    expect(m.numberOf.get("1")).toBe(1);
+    expect(m.defs.get("1")?.body).toBe("def");
+  });
+
+  it("does not treat `[^x]` inside inline code as a reference", () => {
+    // The code span is claimed by the InlineCode parser first, so its `[^x]` stays literal — leaving the
+    // real definition unreferenced (and therefore unnumbered).
+    const m = modelOf("use `[^x]` literally\n\n[^x]: real");
+    expect(m.numberOf.has("x")).toBe(false);
+    expect(m.defs.has("x")).toBe(true);
+  });
+});
+
+describe("computeFootnotes — numbering", () => {
+  it("numbers by first-reference order, not definition order", () => {
+    const m = modelOf("A[^x] B[^y]\n\n[^y]: why\n[^x]: ex");
+    expect(m.order).toEqual(["x", "y"]); // x is referenced first → 1
+    expect(m.numberOf.get("x")).toBe(1);
+    expect(m.numberOf.get("y")).toBe(2);
+  });
+
+  it("numbers a label referenced more than once only once", () => {
+    const m = modelOf("A[^x] B[^x] C[^y]\n\n[^x]: ex\n[^y]: why");
+    expect(m.order).toEqual(["x", "y"]);
+    expect(m.numberOf.get("x")).toBe(1);
+    expect(m.numberOf.get("y")).toBe(2);
+  });
+
+  it("excludes a reference that has no matching definition (stays literal)", () => {
+    const m = modelOf("A[^ghost] B[^real]\n\n[^real]: here");
+    expect(m.numberOf.has("ghost")).toBe(false);
+    expect(m.numberOf.get("real")).toBe(1);
+    expect(m.order).toEqual(["real"]);
+  });
+
+  it("excludes an unreferenced definition from the numbering, but still parses it", () => {
+    const m = modelOf("A[^x]\n\n[^x]: ex\n[^orphan]: lonely");
+    expect(m.order).toEqual(["x"]);
+    expect(m.numberOf.has("orphan")).toBe(false);
+    expect(m.defs.has("orphan")).toBe(true);
+  });
+
+  it("returns an empty model when there are no footnotes", () => {
+    const m = modelOf("just a paragraph with no footnotes");
+    expect(m.order).toEqual([]);
+    expect(m.numberOf.size).toBe(0);
+  });
+});
+
+describe("computeFootnotes — definitions", () => {
+  it("captures the definition body with the single leading space trimmed", () => {
+    expect(modelOf("A[^x]\n\n[^x]: the body text").defs.get("x")?.body).toBe("the body text");
+  });
+
+  it("lets a later definition for the same label win", () => {
+    expect(modelOf("A[^x]\n\n[^x]: first\n[^x]: second").defs.get("x")?.body).toBe("second");
+  });
+
+  it("records the definition's source range", () => {
+    const doc = "A[^x]\n\n[^x]: body";
+    const def = modelOf(doc).defs.get("x");
+    expect(def?.from).toBe(doc.indexOf("[^x]:"));
+    expect(def?.to).toBe(doc.length);
+  });
+});

--- a/packages/paper/src/editor/extensions/markdown.ts
+++ b/packages/paper/src/editor/extensions/markdown.ts
@@ -4,6 +4,7 @@ import { languages } from "@codemirror/language-data";
 import type { Extension } from "@codemirror/state";
 import { tags } from "@lezer/highlight";
 import { GFM } from "@lezer/markdown";
+import { footnotesMarkdown } from "./footnotes-syntax";
 
 // Dialect (CONTEXT.md): CommonMark + GFM core extensions only — Table, TaskList, Strikethrough, Autolink.
 // markdownLanguage (the default) includes out-of-scope syntax like subscript/emoji, so we restrict to commonmark + GFM.
@@ -63,7 +64,7 @@ const sourceHighlight = HighlightStyle.define([
 
 const support = markdown({
   base: commonmarkLanguage,
-  extensions: [GFM],
+  extensions: [GFM, footnotesMarkdown],
   codeLanguages: languages,
 });
 


### PR DESCRIPTION
## What

GitHub-style footnotes for `@beaket/paper`. Type a `[^label]` reference in a sentence and a `[^label]: text` definition anywhere — off the cursor they "become footnotes," all derived from the markdown source (no second model; round-trips for free).

Closes #521.

## How

- **Parser** (`footnotes-syntax.ts`): a custom `@lezer/markdown` `MarkdownConfig` adds real `FootnoteReference` (inline) + `FootnoteDefinition` (block) nodes, since GFM ships none. `endLeaf` lets a definition interrupt a paragraph (no blank line needed); a `[^x]` inside inline code stays literal.
- **Reference** (`footnote-render.ts`): superscript ordinal off-cursor, raw on-cursor (Live Preview, not an atomic token). Numbering by **first-reference order**; an undefined `[^x]` stays literal, an unreferenced definition is excluded.
- **Definition**: rendered **in place** off-cursor (number + body — locatable and clickable), raw on-cursor — and also **collected** into a section at the document end (`footnote-section.ts`, the package's first StateField-provided block decoration; IME-safe via the widget's `eq()` + `docChanged`-only recompute). The whole-doc model is computed once per doc change and shared by both renderers (cursor moves don't rescan).
- **Re-edit**: always at the source — cursor-on-line reveals raw like any block, and clicking a collected item moves the cursor to its source definition. The cursor moves; content never teleports.

Always-on (like tables) — no `EditorOptions` change. **ADR-0021** records the decision, including the rejected *collapse-to-invisible* approach (it produced a vanish/relocate bug, caught by dogfooding) and the v1 cuts.

## Tests / verification

- 11 new jsdom contract tests (`footnotes.test.ts`) for the parser + the pure `computeFootnotes` model; full suite **298 green**.
- Browser-verified in the playground: reference superscripts, in-place + collected rendering, reveal-on-cursor, click-to-source, live update, and keyboard navigation onto a folded definition. (Geometry/DOM is carved out of jsdom per ADR-0005.)

## Follow-up

#525 — a `footnoteLayout: "inline" | "collected"` toggle for a publish/clean-body view (definitions only at the bottom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)