### PR TITLE
chore(paper): hot-reload Paper dev via source condition + turbo

### DIFF
--- a/.changeset/paper-dev-source-condition.md
+++ b/.changeset/paper-dev-source-condition.md
@@ -1,0 +1,9 @@
+---
+"@beaket/paper": patch
+---
+
+Add a `source` export condition so monorepo consumers can resolve the package to its TypeScript source during local dev.
+
+`exports[".".|"./react"].source` now points at `src/index.ts` / `src/react/index.ts`, ordered before `types`/`import`. Default resolvers (npm, Node, a normal Vite/webpack install) never request `source`, so installs are unchanged — they keep resolving `import → dist`, and the published tarball still ships `dist` only. A dev server that opts into the condition (`resolve.conditions: ["source"]`) instead compiles the package from source via the workspace symlink, enabling Fast Refresh on `@beaket/paper` edits with no rebuild.
+
+No runtime or API change for consumers.

--- a/README.md
+++ b/README.md
@@ -1,28 +1,45 @@
 # Beaket UI
 
-Brutalist component library for React + Tailwind CSS.
+A brutalist design system. Two things live in this repo:
 
-## Development
+- **`@beaket/ui`** — copy-paste React + Tailwind components (shadcn-style: the CLI copies source into your project, you own it).
+- **`@beaket/paper`** — a standalone, markdown-first / CJK-first Live Preview editor, published to npm.
+
+## Start here
 
 ```bash
-pnpm install
-pnpm dev        # Storybook at localhost:6006
+pnpm install   # first time only
 ```
+
+| Working on…      | Run                                  | Opens                                     |
+| ---------------- | ------------------------------------ | ----------------------------------------- |
+| Components       | `pnpm dev`                           | Storybook — localhost:6006                |
+| The Paper editor | `pnpm turbo dev --filter=paper-site` | Live playground — localhost:4321/ui/paper |
+| The docs site    | `pnpm docs:dev`                      | Docs — localhost:4321/ui                  |
+
+Editing component or editor source hot-reloads the open page — no rebuild.
 
 ## Structure
 
 ```
-src/components/     # Component source files
-registry/           # Component registry for CLI
-packages/cli/       # @beaket/ui CLI
-docs/               # Documentation site
+src/components/   # @beaket/ui components (copy-paste registry)
+registry/         # manifest the CLI reads to copy components
+packages/cli/     # @beaket/ui — the CLI (published to npm)
+packages/paper/   # @beaket/paper — the editor (published to npm)
+sites/paper/      # Paper's docs + live playground (Astro)
+docs/             # @beaket/ui docs site (Astro)
 ```
 
-## Contributing
+## Commands
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md)
+| Command          | Does                                          |
+| ---------------- | --------------------------------------------- |
+| `pnpm typecheck` | Type-check the whole monorepo                 |
+| `pnpm test`      | Run component tests (`test:editor` for Paper) |
+| `pnpm build`     | Build the component docs (Storybook)          |
 
-## Links
+## Docs & links
 
-- [Documentation](https://beaket.github.io/ui/)
-- [npm](https://www.npmjs.com/package/@beaket/ui)
+- Deeper: [CONTRIBUTING.md](./CONTRIBUTING.md) (components) · [packages/paper/docs/CONTEXT.md](./packages/paper/docs/CONTEXT.md) (editor map) · [CLAUDE.md](./CLAUDE.md) (conventions)
+- Sites: [Docs](https://beaket.github.io/ui/) · [Paper](https://beaket.github.io/ui/paper/)
+- npm: [@beaket/ui](https://www.npmjs.com/package/@beaket/ui) · [@beaket/paper](https://www.npmjs.com/package/@beaket/paper)

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-dom": "19.2.7",
     "storybook": "10.4.6",
     "tailwindcss": "4.3.1",
+    "turbo": "^2.9.18",
     "typescript": "6.0.3",
     "vite": "8.0.16",
     "vitest": "4.1.9"

--- a/packages/paper/package.json
+++ b/packages/paper/package.json
@@ -5,10 +5,12 @@
   "type": "module",
   "exports": {
     ".": {
+      "source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./react": {
+      "source": "./src/react/index.ts",
       "types": "./dist/react/index.d.ts",
       "import": "./dist/react/index.js"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,9 @@ importers:
       tailwindcss:
         specifier: 4.3.1
         version: 4.3.1
+      turbo:
+        specifier: ^2.9.18
+        version: 2.9.18
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -2537,6 +2540,36 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@turbo/darwin-64@2.9.18':
+    resolution: {integrity: sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.18':
+    resolution: {integrity: sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.18':
+    resolution: {integrity: sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.18':
+    resolution: {integrity: sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.18':
+    resolution: {integrity: sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.18':
+    resolution: {integrity: sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA==}
+    cpu: [arm64]
+    os: [win32]
+
   '@tybys/wasm-util@0.10.2':
     resolution: {integrity: sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==}
 
@@ -4605,6 +4638,10 @@ packages:
   tsx@4.22.4:
     resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
     engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  turbo@2.9.18:
+    resolution: {integrity: sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==}
     hasBin: true
 
   typesafe-path@0.2.2:
@@ -7342,6 +7379,24 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@turbo/darwin-64@2.9.18':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.18':
+    optional: true
+
+  '@turbo/linux-64@2.9.18':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.18':
+    optional: true
+
+  '@turbo/windows-64@2.9.18':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.18':
+    optional: true
+
   '@tybys/wasm-util@0.10.2':
     dependencies:
       tslib: 2.8.1
@@ -9769,6 +9824,15 @@ snapshots:
       esbuild: 0.28.1
     optionalDependencies:
       fsevents: 2.3.3
+
+  turbo@2.9.18:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.9.18
+      '@turbo/darwin-arm64': 2.9.18
+      '@turbo/linux-64': 2.9.18
+      '@turbo/linux-arm64': 2.9.18
+      '@turbo/windows-64': 2.9.18
+      '@turbo/windows-arm64': 2.9.18
 
   typesafe-path@0.2.2: {}
 

--- a/sites/paper/astro.config.mjs
+++ b/sites/paper/astro.config.mjs
@@ -2,6 +2,23 @@
 import react from "@astrojs/react";
 import { defineConfig } from "astro/config";
 
+// Dev-only: resolve every `@beaket/*` workspace package to its TypeScript `source`
+// (its package.json `exports[*].source` → `src/…`) instead of the built `dist/`.
+// This puts the packages inside Vite's module graph, so editing e.g.
+// `packages/paper/src/**` Fast-Refreshes the live demo with no rebuild.
+//
+// Why a `source` condition and not a hardcoded alias: it scales to the whole
+// monorepo. Any present or future `@beaket/*` package that declares a `source`
+// export is picked up automatically — this site config never changes as packages
+// are added. `apply: "serve"` gates it to `astro dev`; the deploy build (docs.yml)
+// omits the condition and falls through to `import` → `dist`, so the published
+// site still exercises the real built artifact.
+const beaketDevSource = {
+  name: "beaket:dev-source-condition",
+  apply: /** @type {const} */ ("serve"),
+  config: () => ({ resolve: { conditions: ["source"] } }),
+};
+
 // Standalone Paper docs site, deployed as a sub-path of the existing beaket/ui
 // GitHub Pages site → https://beaket.github.io/ui/paper. The Pages workflow builds
 // this into docs/dist/paper (see .github/workflows/docs.yml). To move it later:
@@ -13,6 +30,7 @@ export default defineConfig({
   output: "static",
   integrations: [react()],
   vite: {
+    plugins: [beaketDevSource],
     esbuild: { jsx: "automatic" },
     optimizeDeps: { include: ["react/jsx-runtime", "react/jsx-dev-runtime"] },
   },

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://turborepo.dev/schema.json",
+  "ui": "stream",
+  "tasks": {
+    "dev": {
+      "persistent": true,
+      "cache": false
+    },
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"]
+    },
+    "test": {
+      "dependsOn": ["^build"]
+    },
+    "lint": {}
+  }
+}


### PR DESCRIPTION
## What

Make local Paper development hot-reload from source, and adopt **turbo** as the parallel/args task runner for the monorepo.

```bash
pnpm turbo dev --filter=paper-site   # live playground, edits Fast-Refresh, no rebuild
```

## How

- **`@beaket/paper`** — add a `source` export condition (`src/index.ts` / `src/react/index.ts`), ordered before `types`/`import`. Default resolvers (npm, Node, a normal install) never request it, so installs keep resolving `import → dist`, and the published tarball stays **dist-only** (`files` unchanged). A dev server that opts into `resolve.conditions: ["source"]` instead compiles Paper from source via the workspace symlink → React Fast Refresh on `packages/paper/src` edits, zero rebuild.
- **`sites/paper`** — a dev-only Vite plugin (`apply: "serve"`) turns that condition on. The deploy build (`docs.yml`) omits it, so production still builds the **published `dist` artifact** (smoke-tests the real exports map).
- **turbo** — add `turbo.json` (`dev` persistent + cache:false; build/typecheck/test/lint) and the `turbo` devDep; remove the hardcoded `paper:dev` root script. `pnpm turbo dev --filter=…` scales to any future package with a `dev` script — no per-package root scripts.
- **README** — rewrite as a tight "start here" map (Components → Storybook, Paper → turbo dev, Docs), with an accurate structure block (was missing `packages/paper` and `sites/paper`).

## Verified (probes, not reasoning)

- dev resolves Paper to **src**: playground imports `@beaket/paper/react` → `packages/paper/src/react/index.ts`; editing a `src` label is served live.
- Works from a **fresh clone** (dist deleted) — `pnpm turbo dev --filter=paper-site` boots and serves from src.
- gating holds: with dist deleted, `pnpm --filter paper-site build` **fails** to resolve Paper → the deploy build uses `dist`, not src.

## Notes

- `@beaket/paper` gets a **patch** changeset (adds the `source` condition; no runtime/API change).
- IDE / `astro check` still read types from `dist/*.d.ts`, so keep one Paper build around (already built).
- Pre-existing `vite@8` vs Astro's `vite@7` warning is unrelated and left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)