### PR TITLE
docs(paper): refresh intro/installation/usage copy

### DIFF
--- a/sites/paper/src/components/controlled-demo.tsx
+++ b/sites/paper/src/components/controlled-demo.tsx
@@ -122,7 +122,7 @@ export function ControlledDemo() {
           grid-template-columns: 1fr 1fr;
           gap: 1rem;
         }
-        .cd-pane { min-width: 0; }
+        .cd-pane { min-width: 0; display: flex; flex-direction: column; }
         .cd-pane-label {
           font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, monospace;
           font-size: 11px;
@@ -130,14 +130,16 @@ export function ControlledDemo() {
           margin-bottom: 0.4rem;
         }
         .cd-paper {
+          flex: 1;
           background: var(--beaket-paper-paper, var(--paper, #fff));
           border: 1px solid var(--chrome);
           box-shadow: var(--shadow-offset, 2px 2px 0 0 var(--chrome));
           padding: 0.9rem 1.1rem;
         }
         .cd-textarea {
+          flex: 1;
           width: 100%;
-          min-height: 212px;
+          min-height: 180px;
           box-sizing: border-box;
           padding: 0.9rem 1.1rem;
           background: var(--frost, #f3f4f6);

--- a/sites/paper/src/components/editor-playground.tsx
+++ b/sites/paper/src/components/editor-playground.tsx
@@ -71,10 +71,12 @@ const mentionToken: TokenSpec = {
 };
 
 // The heading keeps a trailing space (via ${" "} so formatters can't strip it) —
-// the load caret sits after it, one space clear of "Paper" rather than jammed against it.
-const INITIAL = `# Paper${" "}
+// the load caret sits after it, one space clear of "Why Paper" rather than jammed against it.
+const INITIAL = `# Why Paper${" "}
 
-A markdown-first, CJK-first **Live Preview** editor built on CodeMirror 6.
+Live preview rewrites the DOM as you type — hiding and revealing syntax around your cursor. Do that mid-IME-composition and Japanese or Korean input drops or duplicates characters. It's a stubborn, still-open problem even in mature, widely-used editors.
+
+Paper makes one promise its central invariant: **never break composition** — no decoration recompute, no widget rebuild while you're mid-character. That's the editor I wanted, small enough to drop into any app.
 
 Try it:
 
@@ -82,10 +84,42 @@ Try it:
 - Type \`@\` to mention someone — it renders as an atomic chip (Backspace removes it whole)
 - Drop an image, paste a table, write some \`code\`
 
-| Feature | Status |
+| Good fit | Not the tool |
 | --- | --- |
-| Live preview | ✓ |
-| Tables | ✓ |
+| Markdown notes, docs, comments | Rich-text docs that aren't markdown |
+| CJK / mixed-language writing | Real-time collaboration |
+| Dropping an editor into your app | Page layout & print |
+| Read and write in one view | A big plugin ecosystem |
+
+## Markdown, the way it reads
+
+Everything renders **in place** as you type — no split pane, no preview tab. Mix _emphasis_, \`inline code\`, [links](https://github.com/beaket/ui), and footnotes[^gh] right in the flow of a sentence.
+
+[^gh]: GitHub-style — defined right by the reference, and also gathered at the bottom.
+
+> The cursor reveals raw syntax; everything around it stays rendered. That's live preview.
+
+CJK is first-class, not bolted on:
+
+- **English** behaves the way you'd expect
+  - _emphasis_, \`code\`, ~~strikethrough~~ — all in place
+  - tables, task lists, nested lists, footnotes
+- 日本語 — 装飾の境界でも変換が壊れない
+  - **強調** や \`コード\` を文中に混ぜても安全
+  - 脚注[^ime]を文の途中に挿しても composition は保たれる
+- 한국어로 이 문장 끝에 직접 이어서 입력해보세요 →
+
+[^ime]: 変換確定の前に装飾を組み直さない、それだけを守る。
+
+\`\`\`tsx
+// fenced code blocks keep their highlighting
+import { Paper } from "@beaket/paper/react";
+
+<Paper defaultValue="# Hello, 世界" onChange={setMarkdown} />;
+\`\`\`
+
+- [x] Live preview without breaking IME
+- [ ] Your next document
 `;
 
 const ACCENTS = [
@@ -115,7 +149,7 @@ export function EditorPlayground() {
   const [scheme, setScheme] = useState<ColorScheme>("system");
   const [showSource, setShowSource] = useState(false);
 
-  // On load, drop the caret at the end of the "# Paper " heading line (after the
+  // On load, drop the caret at the end of the "# Why Paper " heading line (after the
   // trailing space, a space clear of "Paper") so the page reads as an editor you can
   // start writing in. (The table renders as an atomic widget, so a caret can't sit
   // inside a cell — a selection there gets pushed past the table.) Skip on touch —

--- a/sites/paper/src/pages/index.astro
+++ b/sites/paper/src/pages/index.astro
@@ -13,8 +13,7 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
     </h1>
     <p>
       <strong>Paper</strong> is a markdown-first, CJK-first <strong>Live Preview</strong> editor built
-      on CodeMirror 6.<br />
-      Drop it into your app as a dependency.
+      on CodeMirror 6.
     </p>
   </section>
 
@@ -24,18 +23,6 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
     </div>
     <p class="hint">Type <code>/</code> for the slash menu · drop an image · paste a table · change the accent &amp; font.</p>
   </section>
-
-  <h2>Why Paper</h2>
-  <p>
-    Live preview rewrites the DOM as you type — hiding and revealing syntax around your cursor. Do that
-    mid-IME-composition and Japanese or Korean input drops or duplicates characters. It's a stubborn,
-    still-open problem even in mature, widely-used editors.
-  </p>
-  <p>
-    Paper makes one promise its central invariant: <strong>never break composition</strong> — no
-    decoration recompute, no widget rebuild while you're mid-character. That's the editor I wanted,
-    small enough to drop into any app.
-  </p>
 
   <p class="next"><a href={withBase('installation')}>Installation →</a></p>
 </Base>

--- a/sites/paper/src/pages/installation.astro
+++ b/sites/paper/src/pages/installation.astro
@@ -10,23 +10,18 @@ const installCode = `npm install @beaket/paper`;
 <Base title="Installation — Paper">
   <h1>Installation</h1>
 
+  <p class="callout callout-tip">
+    <svg class="callout-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+      <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Zm4.879-2.773 4.264 2.559a.25.25 0 0 1 0 .428l-4.264 2.559A.25.25 0 0 1 6 10.559V5.442a.25.25 0 0 1 .379-.215Z" />
+    </svg>
+    <span><strong>Try it live</strong> — <a href="https://stackblitz.com/fork/vitejs-vite-teylh32a?file=src%2Fmain.tsx" target="_blank" rel="noopener">open a runnable example in StackBlitz →</a></span>
+  </p>
+
   <p>Paper is published as a standalone npm package — install it from npm and import it like any other dependency:</p>
 
   <CodeBlock code={installCode} lang="bash" />
 
-  <p>
-    The package exposes two entry points: the framework-agnostic core at <code>@beaket/paper</code> and a
-    thin React wrapper at <code>@beaket/paper/react</code>. The core has no peer dependencies — it bundles
-    its CodeMirror 6 engine. <code>react</code> and <code>react-dom</code> (<code>&gt;=18</code>) are
-    <strong>optional</strong> peer dependencies for the wrapper — install them only if you use it.
-  </p>
-
-  <p class="callout callout-note">
-    <svg class="callout-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-      <path d="M0 8a8 8 0 1 1 16 0A8 8 0 0 1 0 8Zm8-6.5a6.5 6.5 0 1 0 0 13 6.5 6.5 0 0 0 0-13ZM6.5 7.75A.75.75 0 0 1 7.25 7h1a.75.75 0 0 1 .75.75v2.75h.25a.75.75 0 0 1 0 1.5h-2a.75.75 0 0 1 0-1.5h.25v-2h-.25a.75.75 0 0 1-.75-.75ZM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z" />
-    </svg>
-    <span><strong>Note</strong> — Paper is ESM-only (no CommonJS build). Use it from an ESM project or a bundler (Vite, Next.js, Remix, etc.) — a bare CommonJS <code>require()</code> won't resolve it.</span>
-  </p>
+  <p>Paper is ESM-only (no CommonJS build). Use it from an ESM project or a bundler (Vite, Next.js, Remix, etc.) — a bare CommonJS <code>require()</code> won't resolve it.</p>
 
   <p class="next"><a href={withBase('usage')}>Usage →</a></p>
 </Base>

--- a/sites/paper/src/pages/usage.astro
+++ b/sites/paper/src/pages/usage.astro
@@ -34,32 +34,6 @@ const editor = createEditor(document.querySelector("#editor")!, {
   onChange: (markdown) => console.log(markdown),
 });`;
 
-const controlledCode = `import { Paper, type PaperHandle } from "@beaket/paper/react";
-import { useEffect, useRef } from "react";
-
-// A thin bridge: controlled value/onChange over the uncontrolled <Paper>.
-function ControlledPaper({ value, onChange }: {
-  value: string;
-  onChange: (v: string) => void;
-}) {
-  const ref = useRef<PaperHandle>(null);
-
-  useEffect(() => {
-    // Sync EXTERNAL value changes into the editor. Skip the echo of the user's
-    // own edit: after onChange, value already equals what the editor holds, so
-    // this is a no-op then — no cursor jump. A real external change (load, reset,
-    // cross-tab sync) differs, so setValue applies (IME-deferred internally).
-    if (ref.current && value !== ref.current.getValue()) {
-      ref.current.setValue(value);
-    }
-  }, [value]);
-
-  return <Paper ref={ref} defaultValue={value} onChange={onChange} />;
-}
-
-// Now use it like any controlled input:
-// <ControlledPaper value={md} onChange={setMd} />`;
-
 const highlightsCode = `import { Paper, type SelectionInfo, type HighlightInput } from "@beaket/paper/react";
 import { useState } from "react";
 
@@ -113,27 +87,12 @@ function Annotator() {
 
   <h2 id="controlled">Controlled value (a bridge)</h2>
   <p>
-    Paper is uncontrolled by design — a live <code>value</code> prop would fight IME composition and
-    make React state a second source of truth (see <a href="https://github.com/beaket/ui/blob/main/packages/paper/docs/adr/0019-controlled-value-bridge-recipe.md">ADR-0019</a>).
-    When you want the React-idiomatic <code>value</code>/<code>onChange</code> shape anyway, wrap it in
-    a thin bridge — the uncontrolled surface already gives you both halves:
-  </p>
-  <CodeBlock code={controlledCode} lang="tsx" />
-  <p>
-    The one line that matters is the <code>value !== ref.current.getValue()</code> guard. When the user
-    types, <code>onChange</code> updates your state, the effect re-runs, but the value already matches
-    what the editor holds — so <code>setValue</code> is skipped and the cursor never jumps. Only a
-    genuinely <em>external</em> change differs, and that routes through the IME-deferred
-    <code>setValue</code>.
-  </p>
-  <p class="callout callout-tip">
-    <svg class="callout-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-      <path d="M8 1.5c-2.363 0-4 1.69-4 3.75 0 .984.424 1.625.984 2.304l.214.253c.223.264.47.556.673.848.284.411.537.896.621 1.49a.75.75 0 0 1-1.484.211c-.04-.282-.163-.547-.37-.847a8.456 8.456 0 0 0-.542-.68c-.084-.1-.173-.205-.268-.32C3.201 7.75 2.5 6.766 2.5 5.25 2.5 2.31 4.863.5 8 .5s5.5 1.81 5.5 4.75c0 1.516-.701 2.5-1.318 3.282-.095.115-.184.22-.268.32-.207.245-.383.453-.541.68-.208.3-.33.565-.37.847a.751.751 0 0 1-1.485-.212c.084-.593.337-1.078.621-1.489.203-.292.45-.584.673-.848.075-.088.147-.173.213-.253.561-.679.985-1.32.985-2.304 0-2.06-1.637-3.75-4-3.75ZM5.75 12h4.5a.75.75 0 0 1 0 1.5h-4.5a.75.75 0 0 1 0-1.5ZM6 15.25a.75.75 0 0 1 .75-.75h2.5a.75.75 0 0 1 0 1.5h-2.5a.75.75 0 0 1-.75-.75Z" />
-    </svg>
-    <span><strong>Caveat</strong> — store <em>exactly</em> what <code>onChange</code> emits. The bridge
-    is for wholesale/external value changes (server load, reset-to-template, cross-tab sync), not
-    per-keystroke transforms (uppercasing, normalization) — those make the value differ mid-type and
-    re-trigger <code>setValue</code>, jumping the cursor.</span>
+    Paper is uncontrolled by design — a live <code>value</code> prop would fight IME composition and make
+    React state a second source of truth. If you want the React-idiomatic <code>value</code>/<code>onChange</code>
+    shape anyway, wrap the uncontrolled surface in a thin bridge guarded by
+    <code>value !== getValue()</code>. The
+    <a href="https://github.com/beaket/ui/blob/main/packages/paper/docs/adr/0019-controlled-value-bridge-recipe.md">controlled-value recipe</a>
+    has the full code, the rationale, and the one caveat that keeps the cursor from jumping.
   </p>
   <p class="callout callout-tip">
     <svg class="callout-icon" width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">


### PR DESCRIPTION
## What

A copy/structure pass on the **@beaket/paper docs site** (`sites/paper`), driven by reading each page as a real visitor.

### Introduction (`index.astro`)
- Removed the standalone **Why Paper** section and the hero's "drop it into your app as a dependency" line. The rationale now lives **inside the live editor**, so the playground document doubles as the pitch.

### Editor playground content (`editor-playground.tsx`)
- The demo document IS "Why Paper": composition prose → a **fit / not-the-tool** table (honest pros/cons, replacing an all-✓ feature list) → a nested CJK list that *shows* markdown + footnotes living mid-sentence (Japanese inline, a short Korean "type here" invitation) → a React-API code block (`<Paper defaultValue … onChange … />`).
- Footnote **definitions sit next to their references** (Paper renders them in place + collects at the bottom).

### Installation (`installation.astro`)
- Leads with a **"Try it live on StackBlitz"** tip callout.
- Dropped the entry-points / peer-deps paragraph (it's redundant — Usage shows both imports by example) and de-callouted the ESM note to plain prose.

### Usage (`usage.astro`)
- Compressed the **Controlled value (a bridge)** section to a one-paragraph rationale + link to the recipe (ADR-0019), keeping the live demo.
- `controlled-demo`: both panes now **flex-fill to equal height** as the shared value changes (the textarea no longer stops short at a fixed `min-height`).

## Notes
- Docs-site-only (`sites/paper` is private, `v0.0.0`) — **no changeset** needed, consistent with prior `docs(paper)` commits.
- The StackBlitz URL points to an existing fork; worth a click-through to confirm it's wired to the current `@beaket/paper`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)