### PR TITLE
fix(paper): table vertical nav lands on blank lines (#520)

### DIFF
--- a/.changeset/paper-table-vertical-nav.md
+++ b/.changeset/paper-table-vertical-nav.md
@@ -1,0 +1,9 @@
+---
+"@beaket/paper": patch
+---
+
+Fix vertical cursor navigation landing on blank separator lines below a table (#520).
+
+The table widget's `<table>` had no margin reset, so a host/global `table { margin }` rule (common in markdown CSS — the docs site ships `table { margin: 1rem 0 }`) applied to it. The widget wrap is `position: relative` with `padding: 0`, so that margin collapses out above/below the block widget. CodeMirror measures only the wrap's box for its height map, so the escaped margin desynced the height map from the actual DOM for everything below the table. `posAtCoords` (which arrow-key vertical motion uses) then mapped a screen y to the line one below the visually-correct one, so ↑/↓ around the table skipped onto blank lines.
+
+Resetting `.cm-table-widget table { margin: 0 }` keeps the widget's DOM footprint equal to what the height map measures (block rhythm already comes from the blank lines, per the existing `padding: 0` design). The selector outspecifies a bare `table` rule, so it holds without `!important`. Verified in-browser (geometry is jsdom-carved-out per ADR-0005): ↑/↓ across the table, the exact issue repro (cell → ↓↓ → paragraph), non-zero goal columns, and content above the table all land on the expected lines.

--- a/packages/paper/src/editor/extensions/table-widget.ts
+++ b/packages/paper/src/editor/extensions/table-widget.ts
@@ -1283,6 +1283,12 @@ const tableTheme = EditorView.theme({
   ".cm-table-widget table": {
     borderCollapse: "collapse",
     width: "100%",
+    // Reset margin so a host/global `table { margin }` rule (common in markdown CSS) can't escape the
+    // widget wrap: the wrap is `position: relative` with `padding: 0`, so a table margin collapses out
+    // below/above the block widget. CM6 measures only the wrap's box for its height map, so that escaped
+    // margin desyncs the map from the DOM for everything below the table — vertical arrow nav then lands
+    // a line off, on blank separator lines (#520). Block rhythm comes from the blank lines, not margin.
+    margin: "0",
   },
   // Precise grid: silver 1px full border (ADR-0009)
   ".cm-table-widget th, .cm-table-widget td": {


### PR DESCRIPTION
Resolves #520.

## Problem
Vertical arrow navigation around a rendered table landed on blank separator lines (off-by-one): from the last cell, ↓↓ landed on the blank line below the paragraph instead of the paragraph.

## Root cause
A host/global `table { margin }` rule (the docs site ships `table { margin: 1rem 0 }`) applied to the table widget's `<table>`. The widget wrap is `position: relative; padding: 0`, so the margin collapses out around the block widget. CodeMirror measures only the wrap's box for its height map, so the escaped margin desynced the height map from the DOM for everything below the table — `posAtCoords` (arrow-key vertical motion) then mapped a screen y to the line one below the visually-correct one.

## Fix
Reset `.cm-table-widget table { margin: 0 }` so the widget's DOM footprint matches what the height map measures (block rhythm already comes from the blank lines). The selector outspecifies a bare `table` rule, so no `!important` needed.

## Verification
Geometry is jsdom-carved-out (ADR-0005), so verified in a real browser: ↑/↓ both ways across the table, the exact issue repro (cell → ↓↓ → paragraph), non-zero goal columns, and content above the table all land on the expected lines. 298 jsdom tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)