### PR TITLE
fix(paper): make a table deletable from its grip menu

### DIFF
--- a/.changeset/paper-delete-table.md
+++ b/.changeset/paper-delete-table.md
@@ -1,0 +1,16 @@
+---
+"@beaket/paper": patch
+---
+
+Make a table deletable from its grip menu.
+
+The row/column grip menus offered only "Delete row" / "Delete column", and both silently no-op'd
+on the last remaining row or column (`rows.length <= 1` / `cols <= 1`) — so a small table could not
+be removed from the menu at all (reported as "can't delete the table"). Keyboard deletion already
+worked (block-select via Escape or a second Backspace, then Backspace), but the menu — the
+discoverable path — had no way out.
+
+Add a "Delete table" item to both grip menus, and make "Delete row" / "Delete column" on the last
+row/column delete the whole table rather than no-op. Deletion removes the table's own lines and
+leaves the surrounding blank lines, matching the block-select Backspace path. Covered by
+`table-delete.test.ts`.

--- a/packages/paper/src/editor/extensions/table-delete.test.ts
+++ b/packages/paper/src/editor/extensions/table-delete.test.ts
@@ -54,7 +54,9 @@ describe("table deletion from the grip menu", () => {
     const menu = openMenu(v, ".cm-col-grip");
     await until(() => v.dom.querySelector(".cm-table-menu") !== null);
 
-    expect([...menu.querySelectorAll("button")].map((b) => b.textContent)).toContain("Delete table");
+    expect([...menu.querySelectorAll("button")].map((b) => b.textContent)).toContain(
+      "Delete table",
+    );
     clickItem(menu, "Delete table");
 
     expect(v.state.doc.toString()).toBe("Before.\n\n\n\nAfter.\n");
@@ -67,7 +69,9 @@ describe("table deletion from the grip menu", () => {
     const menu = openMenu(v, ".cm-row-grip");
     await until(() => v.dom.querySelector(".cm-table-menu") !== null);
 
-    expect([...menu.querySelectorAll("button")].map((b) => b.textContent)).toContain("Delete table");
+    expect([...menu.querySelectorAll("button")].map((b) => b.textContent)).toContain(
+      "Delete table",
+    );
     clickItem(menu, "Delete table");
 
     expect(v.state.doc.toString()).toBe("Before.\n\n\n\nAfter.\n");

--- a/packages/paper/src/editor/extensions/table-delete.test.ts
+++ b/packages/paper/src/editor/extensions/table-delete.test.ts
@@ -1,0 +1,87 @@
+import { EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vitest";
+import { editorExtensions } from "../create-editor";
+
+// A table you wrote must be removable from the grip menu. Before, the menu only had
+// "Delete row"/"Delete column" and those no-op'd on the last row/column — so a small table
+// could not be deleted from the menu at all (reported: "can't delete the table"). The menu DOM
+// + doc mutations are jsdom-testable (no geometry, invariant #4).
+
+let view: EditorView | null = null;
+
+function makeView(doc: string): EditorView {
+  const parent = document.createElement("div");
+  document.body.appendChild(parent);
+  view = new EditorView({
+    state: EditorState.create({ doc, extensions: editorExtensions() }),
+    parent,
+  });
+  return view;
+}
+
+async function until(cond: () => boolean, timeout = 5000): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeout) throw new Error("until(): timeout");
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+function openMenu(v: EditorView, gripSelector: string): HTMLElement {
+  const grip = v.dom.querySelector(gripSelector) as HTMLElement;
+  grip.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  return v.dom.querySelector(".cm-table-menu") as HTMLElement;
+}
+
+function clickItem(menu: HTMLElement, label: string): void {
+  const btn = [...menu.querySelectorAll("button")].find((b) => b.textContent === label);
+  if (!btn) throw new Error(`menu item not found: ${label}`);
+  btn.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+}
+
+afterEach(() => {
+  view?.destroy();
+  view = null;
+});
+
+const TABLE = ["| A | B |", "| --- | --- |", "| 1 | 2 |"].join("\n");
+
+describe("table deletion from the grip menu", () => {
+  it("the column menu offers Delete table and removes the whole table", async () => {
+    const v = makeView(`Before.\n\n${TABLE}\n\nAfter.\n`);
+    await until(() => v.dom.querySelector(".cm-col-grip") !== null);
+    const menu = openMenu(v, ".cm-col-grip");
+    await until(() => v.dom.querySelector(".cm-table-menu") !== null);
+
+    expect([...menu.querySelectorAll("button")].map((b) => b.textContent)).toContain("Delete table");
+    clickItem(menu, "Delete table");
+
+    expect(v.state.doc.toString()).toBe("Before.\n\n\n\nAfter.\n");
+    expect(v.dom.querySelector(".cm-table-widget")).toBeNull();
+  });
+
+  it("the row menu offers Delete table and removes the whole table", async () => {
+    const v = makeView(`Before.\n\n${TABLE}\n\nAfter.\n`);
+    await until(() => v.dom.querySelector(".cm-row-grip") !== null);
+    const menu = openMenu(v, ".cm-row-grip");
+    await until(() => v.dom.querySelector(".cm-table-menu") !== null);
+
+    expect([...menu.querySelectorAll("button")].map((b) => b.textContent)).toContain("Delete table");
+    clickItem(menu, "Delete table");
+
+    expect(v.state.doc.toString()).toBe("Before.\n\n\n\nAfter.\n");
+  });
+
+  it("Delete column on the only column removes the table instead of no-op", async () => {
+    const v = makeView(`Top.\n\n| Solo |\n| --- |\n| x |\n\nBottom.\n`);
+    await until(() => v.dom.querySelector(".cm-col-grip") !== null);
+    const menu = openMenu(v, ".cm-col-grip");
+    await until(() => v.dom.querySelector(".cm-table-menu") !== null);
+
+    clickItem(menu, "Delete column");
+
+    expect(v.state.doc.toString()).toBe("Top.\n\n\n\nBottom.\n");
+    expect(v.dom.querySelector(".cm-table-widget")).toBeNull();
+  });
+});

--- a/packages/paper/src/editor/extensions/table-widget.ts
+++ b/packages/paper/src/editor/extensions/table-widget.ts
@@ -853,6 +853,26 @@ class TableController {
     });
   }
 
+  /**
+   * Remove the whole table. Backs the "Delete table" menu item and the last-row / last-column
+   * case of Delete row/column (which would otherwise no-op, leaving a small table impossible to
+   * remove from the menu). Deletes only the table's own lines — the surrounding blank lines stay,
+   * matching the block-select Backspace path.
+   */
+  private deleteTable(): void {
+    if (!this.mainView) return;
+    clearActiveCell(this.mainView);
+    const tableLines = this.tableLines();
+    const from = tableLines[0]?.from ?? this.data.tableFrom;
+    const to = tableLines[tableLines.length - 1]?.to ?? from;
+    this.mainView.focus();
+    this.mainView.dispatch({
+      changes: { from, to },
+      selection: { anchor: from },
+      userEvent: "delete",
+    });
+  }
+
   private columnMenuItems(col: number): ({ label: string; action: () => void } | "-")[] {
     const insert = (offset: 0 | 1) => () => {
       const rows = this.cellTexts();
@@ -881,7 +901,11 @@ class TableController {
     };
     const remove = () => {
       const rows = this.cellTexts();
-      if ((rows[0]?.length ?? 0) <= 1) return;
+      // Deleting the only column means there's no table left — remove it whole rather than no-op.
+      if ((rows[0]?.length ?? 0) <= 1) {
+        this.deleteTable();
+        return;
+      }
       rows.forEach((row) => row.splice(col, 1));
       const aligns = [...this.data.aligns];
       aligns.splice(col, 1);
@@ -893,6 +917,7 @@ class TableController {
       { label: "Move left", action: move(-1) },
       { label: "Move right", action: move(1) },
       { label: "Delete column", action: remove },
+      { label: "Delete table", action: () => this.deleteTable() },
       "-",
       { label: "Align left", action: setAlign("left") },
       { label: "Align center", action: setAlign("center") },
@@ -918,7 +943,11 @@ class TableController {
     };
     const remove = () => {
       const rows = this.cellTexts();
-      if (rows.length <= 1) return;
+      // Deleting the only row means there's no table left — remove it whole rather than no-op.
+      if (rows.length <= 1) {
+        this.deleteTable();
+        return;
+      }
       rows.splice(row, 1);
       this.replaceTable(rows, this.data.aligns);
     };
@@ -928,6 +957,7 @@ class TableController {
       { label: "Move up", action: move(-1) },
       { label: "Move down", action: move(1) },
       { label: "Delete row", action: remove },
+      { label: "Delete table", action: () => this.deleteTable() },
     ];
   }
 }


### PR DESCRIPTION
## Problem
A table written in the editor could not be removed from the grip menu. The row/column menus offered only "Delete row" / "Delete column", and both silently no-op'd on the last remaining row or column (`rows.length <= 1` / `cols <= 1`) — so a small table could not be deleted from the menu at all (reported as "can't delete the table").

Keyboard deletion already worked (block-select via Escape or a second Backspace, then Backspace), but the discoverable menu path had no exit.

## Fix
- Add a **"Delete table"** item to both grip menus.
- Make "Delete row" / "Delete column" on the last row/column delete the whole table instead of no-op.

Deletion removes the table's own lines and leaves the surrounding blank lines, matching the block-select Backspace path.

## Verification
Verified in a real browser: column-menu "Delete table", row-menu "Delete table", and single-column "Delete column" all remove the table cleanly. The menu/state logic is jsdom-testable (not geometry) — covered by `table-delete.test.ts` (3 new tests, 301 total pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)