### PR TITLE
fix(paper): fade in-place footnote definition; reject footnoteLayout toggle (#525)

### DIFF
--- a/.changeset/paper-footnote-def-fade.md
+++ b/.changeset/paper-footnote-def-fade.md
@@ -1,0 +1,11 @@
+---
+"@beaket/paper": patch
+---
+
+Fade the in-place footnote definition so it recedes from the body flow (#525).
+
+An off-cursor footnote definition (`[^1]: …`) renders in place as an accent number + body, and is _also_ collected at the document end (ADR-0021). The in-place copy is what lets you locate and re-edit the definition without teleporting, but at full `--steel` it read like a small paragraph wedged between the surrounding prose — and because a definition's source position is arbitrary (authored anywhere), that made it look like it belonged to whichever paragraph it happened to sit under.
+
+The body span now mixes `--steel` 68% toward `--paper` (`color-mix`, theme-aware: lighter in light, dimmer in dark — no new token), so the definition visibly recedes while the accent number stays crisp as the locator/number-anchor. Font size is held at `0.8em` deliberately, **not** shrunk further: CJK glyphs lose legibility when smaller. Verified in-browser (light + dark, EN/KO/JA) — the definition reads as a faded, number-anchored footnote rather than body prose, and CJK stays legible.
+
+This resolves the `footnoteLayout: "inline" | "collected"` follow-up deferred in ADR-0021: the publish/"collected" _toggle_ is rejected (Paper has no render-to-output reading mode; any in-body hide reduces to the vanish bug or an orphaned marker), and the in-place render — faded — is the answer. See the ADR-0021 amendment.

--- a/packages/paper/docs/adr/0021-footnotes-in-place-render-plus-collected-section.md
+++ b/packages/paper/docs/adr/0021-footnotes-in-place-render-plus-collected-section.md
@@ -5,6 +5,7 @@
 - **Supersedes:** —
 - **Superseded-by:** —
 - **Amends:** —
+- **Amended:** 2026-06-24 — the deferred `footnoteLayout` toggle is **rejected**; see "Follow-up resolved" below.
 
 ---
 
@@ -96,3 +97,27 @@ Concretely:
 - Coordinate/DOM behavior (superscript placement, the in-place and collected renders, reveal-on-cursor,
   click-to-source) is carved out for browser verification (invariant #4) — done in the playground; the
   parser and `computeFootnotes` model are covered by jsdom contract tests.
+
+## Follow-up resolved (2026-06-24): the `footnoteLayout` toggle is rejected
+
+The decision above deferred a publish-oriented `footnoteLayout: "inline" | "collected"` toggle (collected =
+clean body, definitions only at the bottom). Picking it up, the toggle was prototyped (a `Compartment` +
+`setFootnoteLayout`, mirroring `colorScheme`/`readOnly`) and then **rejected**. The reasoning:
+
+- **Paper has no reading mode.** It is always one Live-Preview editor over the markdown source; "rendered"
+  is decorations over that source, and `readOnly` only disables editing (the same reveal-on-cursor
+  decorations still apply). So "collected = a publish/reading view" has nothing to attach to — a layout
+  toggle can only change how a definition looks **off-cursor**.
+- **Every "hide it off-cursor" variant is worse than showing it.** A zero-height hide is the vanish bug this
+  ADR already rejected. A bare locatable marker reads as an _orphan_ ("why is there a stray `1` mid-document?").
+  Showing the full body in place is the only non-vanishing, non-orphan option — and a footnote links to its
+  reference by **number, not position**, so a number-anchored in-place definition is not misread as belonging
+  to the adjacent paragraph (the misread came from position-implying treatments like a `└` glyph, which we
+  don't use).
+- Therefore the in-place definition **stays in both the drafting and the "I want a cleaner body" cases**; there
+  is no second layout to toggle to. The only real lever is visual weight, handled by styling, not an API.
+
+**What landed instead:** the in-place definition body is **faded** (`color-mix(--steel 68%, --paper)`,
+theme-aware) so it recedes from the body flow while the accent number stays crisp as the locator; size held at
+`0.8em` (not smaller — CJK legibility floor). No new `EditorOptions` surface; the 1.0-frozen options are
+untouched. Verified in-browser (light/dark, EN/KO/JA). Issue #525 is closed as resolved-by-rejection.

--- a/packages/paper/src/editor/extensions/footnote-render.ts
+++ b/packages/paper/src/editor/extensions/footnote-render.ts
@@ -208,11 +208,14 @@ const footnoteTheme = EditorView.theme({
     // Sit the number tight against the preceding word, like a printed footnote mark.
     padding: "0 0.1em",
   },
-  // The off-cursor definition rendered in place: an accent number + muted body; the hover tint signals
-  // it is clickable (cursor → reveals raw for editing).
+  // The off-cursor definition rendered in place: an accent number + a *faded* body so the parked
+  // definition recedes from the body flow (it reads cleanly at the bottom; here it's just a locatable,
+  // number-anchored marker). Faded by mixing --steel toward --paper — theme-aware (lighter in light,
+  // dimmer in dark) and no new token. Size held at 0.8em, NOT smaller: CJK glyphs lose legibility when
+  // shrunk further. The hover tint signals it's clickable (cursor → reveals raw for editing).
   ".cm-footnote-def": {
     cursor: "pointer",
-    color: "var(--steel)",
+    color: "color-mix(in srgb, var(--steel) 68%, var(--paper))",
     fontSize: "0.8em",
   },
   ".cm-footnote-def-num": {


### PR DESCRIPTION
## What

Resolves the `footnoteLayout: "inline" | "collected"` follow-up deferred in ADR-0021 (issue #525) — **by rejecting the toggle** and landing a small visual refinement instead.

### The fade
The off-cursor footnote definition (`[^1]: …`) renders in place (number + body) and is also collected at the document end. At full `--steel` the in-place copy read like a small paragraph wedged into the prose; since a definition's source position is arbitrary, it looked like it belonged to whichever paragraph it sat under.

The body span now mixes `color-mix(in srgb, var(--steel) 68%, var(--paper))` — theme-aware (lighter in light, dimmer in dark), no new token — so the definition **recedes** from the body flow while the accent **number stays crisp** as the locator/number-anchor. Size held at `0.8em` (deliberately not smaller — CJK legibility floor).

### Why the toggle was rejected
- **Paper has no reading mode.** It's always one Live-Preview editor over the markdown source; `readOnly` only disables editing (same reveal-on-cursor decorations apply). A `footnoteLayout` toggle could only change the *off-cursor* look.
- **Every "hide off-cursor" variant is worse than showing it:** zero-height = the vanish bug ADR-0021 already rejected; a bare marker reads as an orphan ("why is there a stray `1` mid-document?").
- A footnote links to its reference by **number, not position**, so a number-anchored in-place definition isn't misread as belonging to the adjacent paragraph. The in-place render is the answer — just faded.

## Verification
In-browser (jsdom can't cover geometry, ADR-0005): **light + dark**, **EN / KO / JA**. The definition reads as a faded, number-anchored footnote; CJK stays legible at `0.8em`. `footnotes.test.ts` (11) green; typecheck clean.

## Scope
- `footnote-render.ts`: one-line color change (+ comment).
- ADR-0021 amended with a "Follow-up resolved" section.
- Changeset: `@beaket/paper` **patch**.
- No `EditorOptions` change (1.0-frozen surface untouched).

Closes #525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)