### PR TITLE
fix(paper): keep floating menus glued to their anchor on scroll (#541)

### DIFF
--- a/.changeset/menu-scroll-reposition.md
+++ b/.changeset/menu-scroll-reposition.md
@@ -1,0 +1,9 @@
+---
+"@beaket/paper": patch
+---
+
+fix: keep floating menus glued to their anchor on scroll, and close when the anchor scrolls out of view (#541)
+
+The slash (`/`) menu, the `@`/`[[` trigger menus, and the table grip menu were positioned once when opened (from `coordsAtPos` / `getBoundingClientRect`) with `position: fixed` and no scroll listener — a side effect of #471. Scrolling the editor left them pinned to the viewport, floating over unrelated content while their anchor moved away.
+
+They now re-place from the live anchor coordinates on scroll/resize (capture-phase listener so the inner `.cm-scroller` is caught), and close once the anchor scrolls out of the editor's scroll viewport. Repositioning is skipped during IME composition so the close path never fires mid-compose.

--- a/packages/paper/src/editor/extensions/menu-engine.ts
+++ b/packages/paper/src/editor/extensions/menu-engine.ts
@@ -39,6 +39,10 @@ export class PopupMenu<T extends MenuRow> {
   /** The selectable (non-header) rows, in display order — `selected` indexes into this, never headers. */
   private items: T[] = [];
   private selected = 0;
+  /** Source position the menu is anchored to, so it can be re-placed from live coords on scroll/resize. */
+  private anchorPos = 0;
+  /** Bound scroll/resize handler that keeps the menu glued to its anchor (#541). */
+  private readonly reposition = (): void => this.place();
 
   constructor(
     private readonly view: EditorView,
@@ -59,6 +63,7 @@ export class PopupMenu<T extends MenuRow> {
     const coords = this.view.coordsAtPos(anchorPos);
     this.closeDOM();
     if (!coords) return;
+    this.anchorPos = anchorPos;
 
     const items = rows.filter((row) => !row.header);
     this.items = items;
@@ -90,6 +95,36 @@ export class PopupMenu<T extends MenuRow> {
     // Attach to view.dom so the EditorView.theme scope (under .cm-editor) applies.
     this.view.dom.appendChild(menu);
     this.el = menu;
+    // Keep the fixed-position menu glued to its anchor on scroll/resize, and close it when the anchor
+    // scrolls out of the editor viewport (#541). capture:true catches the inner .cm-scroller's scroll,
+    // which does not bubble; passive since we never preventDefault.
+    window.addEventListener("scroll", this.reposition, { capture: true, passive: true });
+    window.addEventListener("resize", this.reposition);
+  }
+
+  /**
+   * Re-place the menu from the anchor's live coords, or close it if the anchor has scrolled out of the
+   * editor's scroll viewport. Skipped during IME composition: a re-place is harmless but the close
+   * branch must never fire mid-compose (CJK first-class, #483) — the menu self-corrects on the next event.
+   */
+  private place(): void {
+    if (!this.el || this.view.composing) return;
+    const coords = this.view.coordsAtPos(this.anchorPos);
+    const scroller = this.view.scrollDOM.getBoundingClientRect();
+    // Close once the anchor scrolls out of the scroller viewport — vertically or horizontally
+    // (.cm-scroller scrolls sideways for wide tables), else the fixed menu floats over empty chrome.
+    if (
+      !coords ||
+      coords.bottom < scroller.top ||
+      coords.top > scroller.bottom ||
+      coords.right < scroller.left ||
+      coords.left > scroller.right
+    ) {
+      this.close();
+      return;
+    }
+    this.el.style.left = `${coords.left}px`;
+    this.el.style.top = `${coords.bottom + 4}px`;
   }
 
   moveSelection(delta: -1 | 1): void {
@@ -115,6 +150,10 @@ export class PopupMenu<T extends MenuRow> {
   }
 
   private closeDOM(): void {
+    if (this.el) {
+      window.removeEventListener("scroll", this.reposition, { capture: true });
+      window.removeEventListener("resize", this.reposition);
+    }
     this.el?.remove();
     this.el = null;
   }

--- a/packages/paper/src/editor/extensions/table-widget.ts
+++ b/packages/paper/src/editor/extensions/table-widget.ts
@@ -778,6 +778,10 @@ class TableController {
 
   private menu: HTMLElement | null = null;
   private menuCloseListener: ((event: MouseEvent) => void) | null = null;
+  /** The grip the open menu is anchored to, so it can be re-placed from live coords on scroll (#541). */
+  private menuAnchor: HTMLElement | null = null;
+  /** Bound scroll/resize handler that keeps the menu glued to its anchor grip. */
+  private menuReposition: (() => void) | null = null;
 
   private openMenu(kind: "col" | "row", index: number, anchor: HTMLElement): void {
     // No menu actions during IME composition (CJK first-class)
@@ -805,19 +809,49 @@ class TableController {
       menu.appendChild(btn);
     }
 
-    // Position from the grip's viewport rect and attach to view.dom (.cm-editor, overflow:visible)
-    // with position:fixed, mirroring the slash menu — this escapes the .cm-scroller overflow box so
-    // the menu is never clipped near the scroller's right/bottom edge (#471).
-    const anchorRect = anchor.getBoundingClientRect();
-    menu.style.left = `${anchorRect.left}px`;
-    menu.style.top = `${anchorRect.bottom + 4}px`;
+    // Attach to view.dom (.cm-editor, overflow:visible) with position:fixed, mirroring the slash menu —
+    // this escapes the .cm-scroller overflow box so the menu is never clipped near the scroller's
+    // right/bottom edge (#471). Position is set by positionMenu() from the grip's live viewport rect.
     (this.mainView?.dom ?? this.wrap).appendChild(menu);
     this.menu = menu;
+    this.menuAnchor = anchor;
+    this.positionMenu();
 
     this.menuCloseListener = (event) => {
       if (!menu.contains(event.target as Node)) this.closeMenu();
     };
     document.addEventListener("mousedown", this.menuCloseListener, true);
+    // Keep the menu glued to the grip on scroll/resize, closing it once the grip scrolls out of the
+    // editor viewport (#541). capture:true catches the inner .cm-scroller's non-bubbling scroll.
+    this.menuReposition = () => this.positionMenu();
+    window.addEventListener("scroll", this.menuReposition, { capture: true, passive: true });
+    window.addEventListener("resize", this.menuReposition);
+  }
+
+  /**
+   * Re-place the menu from the anchor grip's live rect, or close it if the grip has been detached or
+   * scrolled out of the editor's scroll viewport (#541). Skipped during IME composition so the close
+   * branch never fires mid-compose (CJK first-class, #483); it self-corrects on the next event.
+   */
+  private positionMenu(): void {
+    if (!this.menu || !this.menuAnchor || this.subview?.composing) return;
+    const anchorRect = this.menuAnchor.getBoundingClientRect();
+    const scroller = this.mainView?.scrollDOM.getBoundingClientRect();
+    // Close once the grip scrolls out of the scroller viewport — vertically or horizontally
+    // (.cm-scroller scrolls sideways for wide tables), else the fixed menu floats over empty chrome.
+    if (
+      !this.menuAnchor.isConnected ||
+      (scroller &&
+        (anchorRect.bottom < scroller.top ||
+          anchorRect.top > scroller.bottom ||
+          anchorRect.right < scroller.left ||
+          anchorRect.left > scroller.right))
+    ) {
+      this.closeMenu();
+      return;
+    }
+    this.menu.style.left = `${anchorRect.left}px`;
+    this.menu.style.top = `${anchorRect.bottom + 4}px`;
   }
 
   private closeMenu(): void {
@@ -825,8 +859,14 @@ class TableController {
       document.removeEventListener("mousedown", this.menuCloseListener, true);
       this.menuCloseListener = null;
     }
+    if (this.menuReposition) {
+      window.removeEventListener("scroll", this.menuReposition, { capture: true });
+      window.removeEventListener("resize", this.menuReposition);
+      this.menuReposition = null;
+    }
     this.menu?.remove();
     this.menu = null;
+    this.menuAnchor = null;
   }
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #541. The slash (`/`) menu, the `@`/`[[` trigger menus, and the table grip menu were positioned **once** at open time (from `coordsAtPos` / `getBoundingClientRect`) with `position: fixed` and no scroll listener — a side effect of #471, which switched to `position: fixed` to escape `.cm-scroller`'s overflow clip. Scrolling the editor left the menus pinned to the viewport, floating over unrelated content while their anchor scrolled away.

## Approach (Option A)

Both floating-menu code paths now:
- **Re-place from the live anchor** on `scroll`/`resize`. The scroll listener is registered capture-phase (`{ capture: true, passive: true }`) so the inner `.cm-scroller`'s non-bubbling scroll is caught; the menu stays glued to the cursor/grip.
- **Close when the anchor leaves the editor's scroll viewport** — vertically *or* horizontally (`.cm-scroller` scrolls sideways for wide tables), so a `position: fixed` menu never floats over empty chrome.
- **Skip repositioning during IME composition**, so the close path can never fire mid-compose (CJK first-class, #483).

Listeners are bound on open and removed symmetrically on every close path (re-open, outside-click close, widget/editor teardown).

Touched:
- `menu-engine.ts` — shared `PopupMenu` (covers the slash menu **and** the `@`/`[[` trigger menus)
- `table-widget.ts` — the table grip context menu

## Verification

jsdom can't reach this coordinate-dependent code (invariant #4), so it was verified live in the docs demo (`sites/paper`):

| Menu | reposition on scroll | close on detach |
| --- | --- | --- |
| slash / `@` / `[[` (`PopupMenu`) | ✅ 1:1 tracking (−46px scroll → +46px menu) | ✅ vertical |
| table grip | ✅ 1:1 tracking (menu top = gripBottom + 4) | ✅ vertical **and** horizontal scroll-out |

- `pnpm typecheck` clean · 301 tests pass · prettier clean

An independent frontend code review confirmed no blockers (listener lifecycle, `removeEventListener` matching, scroll perf, IME guard all verified clean); its one Should-fix — the horizontal-scroll close guard — is included above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)