### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete string escaping or encoding

### DIFF
--- a/.changeset/paper-paste-table-escape-backslash.md
+++ b/.changeset/paper-paste-table-escape-backslash.md
@@ -1,0 +1,7 @@
+---
+"@beaket/paper": patch
+---
+
+Escape backslashes before pipes when converting pasted tables (CodeQL `js/incomplete-sanitization`).
+
+`escapeCell` (paste-to-markdown-table conversion) escaped `|` as `\|` but left existing backslashes untouched. A pasted cell containing `\|` collapsed to `\\|`, which a GFM parser reads as a literal backslash followed by a **live column delimiter** — defeating the pipe escaping and letting cell content inject extra table columns. Backslashes are now escaped first (`\` → `\\`), so `\|` becomes `\\\|` (escaped backslash + escaped pipe) and the cell boundary holds.

--- a/packages/paper/src/editor/extensions/paste-table-convert.test.ts
+++ b/packages/paper/src/editor/extensions/paste-table-convert.test.ts
@@ -16,6 +16,12 @@ describe("tsvToRows", () => {
   it("escapes pipes inside a cell", () => {
     expect(tsvToRows("a|b\tc")).toEqual([["a\\|b", "c"]]);
   });
+
+  it("escapes backslashes before pipes so cell escaping cannot be defeated", () => {
+    // `\|` must become `\\\|` (escaped backslash + escaped pipe), never `\\|`
+    // (literal backslash + live delimiter), which would inject an extra column.
+    expect(tsvToRows("a\\|b\tc")).toEqual([["a\\\\\\|b", "c"]]);
+  });
 });
 
 describe("htmlTableToRows", () => {

--- a/packages/paper/src/editor/extensions/paste-table-convert.ts
+++ b/packages/paper/src/editor/extensions/paste-table-convert.ts
@@ -6,11 +6,9 @@ import { EditorView } from "@codemirror/view";
 // even on a plain paste the StateField creates the widget.
 
 function escapeCell(text: string): string {
-  return text
-    .replace(/\\/g, "\\\\")
-    .replace(/\|/g, "\\|")
-    .replace(/\r?\n/g, "<br>")
-    .trim();
+  // Escape backslashes before pipes: a cell containing `\|` must not collapse to
+  // `\\|` (literal backslash + live column delimiter), which would inject columns.
+  return text.replace(/\\/g, "\\\\").replace(/\|/g, "\\|").replace(/\r?\n/g, "<br>").trim();
 }
 
 export function toMarkdownTable(rows: string[][]): string | null {

--- a/packages/paper/src/editor/extensions/paste-table-convert.ts
+++ b/packages/paper/src/editor/extensions/paste-table-convert.ts
@@ -6,7 +6,11 @@ import { EditorView } from "@codemirror/view";
 // even on a plain paste the StateField creates the widget.
 
 function escapeCell(text: string): string {
-  return text.replace(/\|/g, "\\|").replace(/\r?\n/g, "<br>").trim();
+  return text
+    .replace(/\\/g, "\\\\")
+    .replace(/\|/g, "\\|")
+    .replace(/\r?\n/g, "<br>")
+    .trim();
 }
 
 export function toMarkdownTable(rows: string[][]): string | null {


### PR DESCRIPTION
Potential fix for [https://github.com/beaket/ui/security/code-scanning/5](https://github.com/beaket/ui/security/code-scanning/5)

Use a robust escaping order in `escapeCell`: escape backslashes first, then escape pipe characters, then normalize line breaks. Escaping backslashes first avoids later escapes being undermined by pre-existing backslashes in input.

Best minimal fix in `packages/paper/src/editor/extensions/paste-table-convert.ts`:
- Update line 9’s chain to include a global backslash replacement before pipe replacement.
- Keep existing behavior (newline to `<br>`, trim) unchanged.

No new imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
