### PR TITLE
feat(paper): wrap the selection on type ((, [, `, *, …)

### DIFF
--- a/.changeset/paper-wrap-selection-on-type.md
+++ b/.changeset/paper-wrap-selection-on-type.md
@@ -1,0 +1,7 @@
+---
+"@beaket/paper": minor
+---
+
+Wrap the selection on type (Notion/Obsidian style): with text selected, typing `(` `[` `{` `` ` `` `"` `'` or `*` now surrounds the selection with the pair and keeps the selection on the inner text, instead of replacing it. Always-on, no config.
+
+Because the selection stays on the inner text after a wrap, pressing the same marker twice nests it — pressing `*` twice yields bold and `` ` `` twice yields a double-backtick code span. Single `_` and `~` are deliberately excluded: a lone `_word_` won't render intra-word in CommonMark and a lone `~word~` isn't GFM strikethrough (use `*` / double-`*`, or two backticks).

--- a/packages/paper/docs/CONTEXT.md
+++ b/packages/paper/docs/CONTEXT.md
@@ -142,6 +142,10 @@ view` rendered as a permanently-atomic replace-widget (caret steps over, one Bac
 - `extensions/blockquote-keys.ts` — Enter escapes / Tab changes level.
 - `extensions/code-block-enter.ts` — Enter in a fence keeps indent, dodges the lazy language parser's
   `indentService`.
+- `extensions/wrap-selection.ts` — wrap-on-type (Notion/Obsidian): typing a pair opener (`(` `[` `{`
+  `` ` `` `"` `'` `*`) over a selection surrounds it, keeping the selection on the inner text (so a
+  second press nests → `**bold**`). The package's first `EditorView.inputHandler`; pure seam
+  `wrapEdit(state, text)`. Empty selection / pasted text fall through to default insertion.
 
 **Copy**
 

--- a/packages/paper/src/editor/create-editor.ts
+++ b/packages/paper/src/editor/create-editor.ts
@@ -30,6 +30,7 @@ import type { TokenSpec } from "./extensions/token-render";
 import { tokenRender } from "./extensions/token-render";
 import type { TriggerSpec } from "./extensions/trigger-menu";
 import { triggerMenu } from "./extensions/trigger-menu";
+import { wrapSelection } from "./extensions/wrap-selection";
 import { baseTheme, type ColorScheme, darkThemeStyle, sizeTheme } from "./theme";
 export { defaultSlashItems } from "./extensions/slash-command";
 export type { SlashItemsConfig, SlashItemSpec } from "./extensions/slash-command";
@@ -123,6 +124,9 @@ export function editorExtensions(opts: EditorOptions = {}): Extension[] {
     history(),
     keymap.of([...defaultKeymap, ...historyKeymap]),
     EditorView.lineWrapping,
+    // Wrap-on-type: typing `(` `[` `` ` `` etc. over a selection surrounds it (Notion/Obsidian style).
+    // An inputHandler with no competitors, so plain precedence is fine.
+    wrapSelection(),
     baseTheme,
     darkThemeStyle(opts.colorScheme),
     sizeTheme(opts.height, opts.minHeight),

--- a/packages/paper/src/editor/extensions/wrap-selection.test.ts
+++ b/packages/paper/src/editor/extensions/wrap-selection.test.ts
@@ -1,0 +1,76 @@
+import { EditorSelection, EditorState } from "@codemirror/state";
+import { describe, expect, it } from "vitest";
+import { editorExtensions } from "../create-editor";
+import { wrapEdit } from "./wrap-selection";
+
+// Wrap-the-selection-on-type (Notion/Obsidian): with text selected, typing a pair opener surrounds
+// the selection and keeps the selection on the inner text, instead of replacing it. The decision
+// lives in the pure `wrapEdit(state, text)` seam (jsdom can't fire the beforeinput that drives the
+// inputHandler), so it is tested directly here.
+
+function stateWith(doc: string, ranges: { anchor: number; head: number }[]): EditorState {
+  return EditorState.create({
+    doc,
+    extensions: editorExtensions(),
+    selection: EditorSelection.create(ranges.map((r) => EditorSelection.range(r.anchor, r.head))),
+  });
+}
+
+/** Apply a wrapEdit spec and return the resulting doc + main selection, for assertion. */
+function apply(state: EditorState, text: string) {
+  const spec = wrapEdit(state, text);
+  if (!spec) return null;
+  const next = state.update(spec).state;
+  return { doc: next.doc.toString(), main: next.selection.main };
+}
+
+describe("wrapEdit — wrap the selection on type", () => {
+  it("wraps a mid-string selection with a symmetric marker, selection on inner text", () => {
+    // "asd3fas3df", select "3fas3" (indices 3..8), type ` → asd`3fas3`df
+    const r = apply(stateWith("asd3fas3df", [{ anchor: 3, head: 8 }]), "`");
+    expect(r?.doc).toBe("asd`3fas3`df");
+    expect([r?.main.from, r?.main.to]).toEqual([4, 9]); // still covers "3fas3"
+  });
+
+  it("wraps with the matching closer for asymmetric brackets", () => {
+    expect(apply(stateWith("hello", [{ anchor: 0, head: 5 }]), "[")?.doc).toBe("[hello]");
+    expect(apply(stateWith("hello", [{ anchor: 0, head: 5 }]), "(")?.doc).toBe("(hello)");
+    expect(apply(stateWith("hello", [{ anchor: 0, head: 5 }]), "{")?.doc).toBe("{hello}");
+  });
+
+  it("supports the full default pair set", () => {
+    for (const [open, close] of [
+      ["(", ")"],
+      ["[", "]"],
+      ["{", "}"],
+      ["`", "`"],
+      ['"', '"'],
+      ["'", "'"],
+      ["*", "*"],
+    ]) {
+      expect(apply(stateWith("x", [{ anchor: 0, head: 1 }]), open)?.doc).toBe(`${open}x${close}`);
+    }
+  });
+
+  it("preserves selection direction (head before anchor)", () => {
+    const r = apply(stateWith("hello", [{ anchor: 5, head: 0 }]), "*");
+    expect(r?.doc).toBe("*hello*");
+    expect(r?.main.anchor).toBe(6);
+    expect(r?.main.head).toBe(1);
+  });
+
+  it("returns null for a collapsed selection (defer to default insertion)", () => {
+    expect(wrapEdit(stateWith("hello", [{ anchor: 2, head: 2 }]), "`")).toBeNull();
+  });
+
+  it("returns null for a char outside the pair set", () => {
+    expect(wrapEdit(stateWith("hello", [{ anchor: 0, head: 5 }]), "x")).toBeNull();
+    expect(wrapEdit(stateWith("hello", [{ anchor: 0, head: 5 }]), "~")).toBeNull();
+    expect(wrapEdit(stateWith("hello", [{ anchor: 0, head: 5 }]), "_")).toBeNull();
+  });
+
+  it("returns null for pasted / multi-char text", () => {
+    expect(wrapEdit(stateWith("hello", [{ anchor: 0, head: 5 }]), "((")).toBeNull();
+    expect(wrapEdit(stateWith("hello", [{ anchor: 0, head: 5 }]), "world")).toBeNull();
+  });
+});

--- a/packages/paper/src/editor/extensions/wrap-selection.ts
+++ b/packages/paper/src/editor/extensions/wrap-selection.ts
@@ -1,0 +1,74 @@
+import type { Extension, TransactionSpec } from "@codemirror/state";
+import { EditorSelection, type EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+
+// Wrap-the-selection-on-type (Notion / Obsidian style): with text selected, typing one of the
+// opener chars below surrounds the selection with the pair instead of replacing it, and leaves the
+// selection on the inner text. Always-on, no consumer config — a sibling of blockquote-keys /
+// table-auto-convert (the API surface freezes at 1.0, so this stays a behavior, not an option).
+//
+// Pairs are limited to single-keypress markers that produce valid, rendering markdown when doubled
+// around a selection:
+//   - brackets `(` `[` `{` (asymmetric close)
+//   - code / quotes `` ` `` `"` `'` (symmetric)
+//   - emphasis `*` → `*text*` italic (symmetric)
+// Deliberately omitted: `~~`/`**` strikethrough+bold (need *doubled* markers, can't come from one
+// keypress) and `_` (CommonMark won't render `_x_` intra-word, unlike `*`). Use Cmd-B etc. for those.
+const WRAP_PAIRS: Record<string, string> = {
+  "(": ")",
+  "[": "]",
+  "{": "}",
+  "`": "`",
+  '"': '"',
+  "'": "'",
+  "*": "*",
+};
+
+/**
+ * Pure decision seam (the package convention, cf. `computeFootnotes` / `findTokenMatches`): if
+ * `text` is a single wrap opener and at least one selection range is non-empty, return the
+ * transaction that wraps every non-empty range (empty ranges just insert the char) keeping the
+ * selection on the inner text. Returns `null` to defer to the default insertion — when `text` has no
+ * pair, is pasted/multi-char, or the whole selection is collapsed.
+ */
+export function wrapEdit(state: EditorState, text: string): TransactionSpec | null {
+  const close = WRAP_PAIRS[text];
+  if (!close) return null;
+  if (state.selection.ranges.every((r) => r.empty)) return null;
+  return state.changeByRange((range) => {
+    if (range.empty) {
+      return {
+        changes: { from: range.from, insert: text },
+        range: EditorSelection.cursor(range.from + text.length),
+      };
+    }
+    // Selection lands on the inner text (shifted past the inserted opener), original direction kept.
+    const innerFrom = range.from + text.length;
+    const innerTo = range.to + text.length;
+    return {
+      changes: [
+        { from: range.from, insert: text },
+        { from: range.to, insert: close },
+      ],
+      range:
+        range.head >= range.anchor
+          ? EditorSelection.range(innerFrom, innerTo)
+          : EditorSelection.range(innerTo, innerFrom),
+    };
+  });
+}
+
+/**
+ * Thin `inputHandler` dispatcher over {@link wrapEdit}. Skipped during IME composition (invariant #1)
+ * — a wrap can only come from a non-composition single-char insert over a selection anyway. A wrap is
+ * one dispatch (one undo step) and changes the doc, so `onChange` (keyed on `docChanged`) still fires.
+ */
+export function wrapSelection(): Extension {
+  return EditorView.inputHandler.of((view, _from, _to, text) => {
+    if (view.composing) return false;
+    const spec = wrapEdit(view.state, text);
+    if (!spec) return false;
+    view.dispatch(spec, { scrollIntoView: true, userEvent: "input.wrap" });
+    return true;
+  });
+}


### PR DESCRIPTION
## What

With text selected (mouse or keyboard), typing a pair opener now **surrounds** the selection instead of replacing it — the Notion/Obsidian "wrap selection" gesture.

```
asd3fas3df  →  select "3fas3", type `  →  asd`3fas3`df
```

Supported openers: `(` `[` `{` `` ` `` `"` `'` `*`. The selection stays on the inner text after a wrap, so **pressing the same marker twice nests it** — `*`×2 → `**bold**`, `` ` ``×2 → a double-backtick code span.

`_` and single `~` are deliberately excluded: a lone `_word_` won't render intra-word in CommonMark, and a lone `~word~` isn't GFM strikethrough (needs `~~`).

## How

- New `extensions/wrap-selection.ts` — the package's first `EditorView.inputHandler`. Always-on, no consumer config (sibling of blockquote-keys / table-auto-convert; keeps the 1.0-frozen API surface clean).
- Decision lives in a pure seam `wrapEdit(state, text)` (jsdom can't fire the `beforeinput` that drives the handler); the handler is a thin dispatcher that bails during IME composition (invariant #1). One dispatch = one undo step; `onChange` still fires (keyed on `docChanged`).

## Verification

- jsdom contract tests (7) on `wrapEdit` + full suite **309 passing**, typecheck clean.
- Browser-verified in `sites/paper`: wrap works; empty-cursor `(` inserts a single char (no auto-close); `*`×2 produces `**bold**`.

## Known limitation

Table-cell subviews don't wrap yet (their extension set is separate) — acceptable for v1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)