### PR TITLE
fix(paper-site): make API Reference tables mobile-friendly

### DIFF
--- a/sites/paper/src/pages/api.astro
+++ b/sites/paper/src/pages/api.astro
@@ -9,6 +9,7 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
 
   <h2 id="props"><code>&lt;Paper&gt;</code> props</h2>
   <p>Import from <code>@beaket/paper/react</code>. All props are optional.</p>
+  <div class="table-scroll">
   <table>
     <thead><tr><th>Prop</th><th>Type</th><th>Notes</th></tr></thead>
     <tbody>
@@ -31,9 +32,11 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
       <tr><td><code>className</code></td><td><code>string</code></td><td>Class on the editor container element.</td></tr>
     </tbody>
   </table>
+  </div>
 
   <h2 id="handle">Imperative handle (<code>ref</code>)</h2>
   <p>The <code>ref</code> exposes a <code>PaperHandle</code>:</p>
+  <div class="table-scroll">
   <table>
     <thead><tr><th>Method</th><th>Returns</th><th>Notes</th></tr></thead>
     <tbody>
@@ -44,9 +47,11 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
       <tr><td><code>getView()</code></td><td><code>EditorView</code></td><td>Escape hatch — the raw CodeMirror 6 <code>EditorView</code>. No cross-version guarantees.</td></tr>
     </tbody>
   </table>
+  </div>
 
   <h2 id="core">Core <code>createEditor(parent, options)</code></h2>
   <p>The vanilla core takes the mount element and an <code>EditorOptions</code> object, returning the CodeMirror <code>EditorView</code>. These options are the editor's own surface; <code>highlights</code>, <code>activeHighlightId</code>, and <code>className</code> are React-wrapper additions, not core options:</p>
+  <div class="table-scroll">
   <table>
     <thead><tr><th>Option</th><th>Type</th><th>Notes</th></tr></thead>
     <tbody>
@@ -64,6 +69,7 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
       <tr><td><code>onHighlightStatusChange</code> / <code>onHighlightClick</code></td><td>callbacks</td><td>Highlight surface. The highlight <em>list</em> is set imperatively via <code>setHighlightsEffect</code>.</td></tr>
     </tbody>
   </table>
+  </div>
 
   <p class="next"><a href={withBase('styling')}>Styling →</a></p>
 </Base>

--- a/sites/paper/src/styles/global.css
+++ b/sites/paper/src/styles/global.css
@@ -317,6 +317,21 @@ blockquote {
   }
 }
 
+/* The API tables carry long, unbreakable type signatures (e.g.
+   `(m: Map<string, AnchorStatus>) => void`). On a phone those can't wrap, so a
+   bare table would push past the viewport and scroll the whole page sideways.
+   Wrapping each table in .table-scroll keeps the overflow contained to the
+   table — it scrolls horizontally on its own while the page stays put. */
+.table-scroll {
+  overflow-x: auto;
+  /* The table's own margin would collapse oddly through the wrapper; carry it
+     here so spacing matches an unwrapped table. */
+  margin: 1rem 0;
+}
+.table-scroll table {
+  margin: 0;
+}
+
 table {
   border-collapse: collapse;
   width: 100%;


### PR DESCRIPTION
## What

Fixes the one Paper docs page that broke on mobile: the **API Reference** page (`sites/paper/`).

## Why

Auditing all five pages, `index` / `installation` / `usage` / `styling` were already responsive (layout media queries, `overflow-x:auto` on code blocks, full-bleed playground, etc.).

Only **`api.astro`** was missing it. The page has three wide tables (Props / Imperative handle / Core options) whose cells contain long, unbreakable type signatures (e.g. `(m: Map<string, AnchorStatus>) => void`). The global table style is only `width: 100%` with no horizontal-scroll handling, so on phone widths the tables pushed past the viewport and **scrolled the whole page sideways**, breaking the layout.

## How

- Wrap each table in `api.astro` with a `.table-scroll` container
- Add `.table-scroll { overflow-x: auto }` to `global.css`

The overflow is now contained to the table — it scrolls horizontally on its own while the page layout holds. Prose (the Notes column) still wraps normally, so the horizontal scroll is minimized to just the unbreakable code.

## Test

`pnpm build` passes, and the built `dist/api/index.html` confirms all three tables are wrapped in `.table-scroll`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfK2Hji6tkk7FW6hvo24pr