### PR TITLE
fix(paper-site): stop docs pages rendering at desktop width on mobile

### DIFF
--- a/sites/paper/src/styles/global.css
+++ b/sites/paper/src/styles/global.css
@@ -172,6 +172,13 @@ pre code {
   }
   .layout {
     flex-direction: column;
+    /* The desktop rule sets align-items: flex-start, which in a *column* flex
+       sizes each item to its own content width (max-content) on the cross axis.
+       That let .content grow to its widest child — a code block or table — and
+       drag the whole page past the viewport, so overflow-x:auto never engaged
+       and the page rendered at desktop width on phones. Stretch pins .content
+       to the viewport so its min-width:0 holds and wide children scroll. */
+    align-items: stretch;
   }
   .sidebar {
     position: static;


### PR DESCRIPTION
## Problem

Follow-up to #552. That PR wrapped the API tables in a scroll container, but on the live site the docs pages were **still rendering at desktop width on phones** — and not just the API page. `usage`, `api`, and `styling` all blew past the viewport.

## Root cause

The mobile layout switches `.layout` to `flex-direction: column` but keeps the desktop `align-items: flex-start`. On a **column** flex, `align-items` controls the cross (horizontal) axis, and `flex-start` sizes each item to its **max-content** width. So `.content` grew to its widest child — a code block or a table — and dragged the whole page past the device width.

Because the container had no definite width, the `overflow-x: auto` on code blocks (and the `.table-scroll` added in #552) never engaged — there was nothing to scroll *within*. The page just expanded and the phone zoomed out.

Measured with a headless browser at a 390px viewport (before this fix):

| Page | document scrollWidth |
| --- | --- |
| usage | **774px** ❌ |
| api | **588px** ❌ |
| styling | **734px** ❌ |
| installation | 390px ✅ |
| index | 390px ✅ |

(`installation`/`index` were fine only because neither has a child wide enough to force the overflow.)

## Fix

Reset `align-items: stretch` on `.layout` inside the mobile breakpoint. That pins `.content` to the viewport (its existing `min-width: 0` already lets it shrink), so wide code blocks and tables scroll horizontally inside their own box while the page stays at device width.

## Verification

Re-measured the built site in a headless browser at both 360px and 390px — `document.scrollWidth` now equals the viewport on **every** page, `OVERFLOW=false` across the board. The wide code/table elements remain but are now contained within their `overflow-x: auto` scrollers instead of expanding the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QfK2Hji6tkk7FW6hvo24pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01QfK2Hji6tkk7FW6hvo24pr)_