### PR TITLE
feat(paper): font-synthesis:none + opt-in --beaket-paper-word-break knob (#554)

### DIFF
--- a/.changeset/paper-font-synthesis-word-break.md
+++ b/.changeset/paper-font-synthesis-word-break.md
@@ -1,0 +1,8 @@
+---
+"@beaket/paper": minor
+---
+
+Editor base theme: render only real bold/italic faces (`font-synthesis: none`) and expose `word-break` as a public `--beaket-paper-word-break` knob (#554).
+
+- **`font-synthesis: none`** on `.cm-content` — when a configured family lacks a real bold or italic face, the browser no longer synthesizes a faux-bold / faux-oblique. For CJK glyphs synthesis smears strokes and muddies weight; rich text here is body weight plus real Markdown bold, so the regression risk is low.
+- **`--beaket-paper-word-break`** (default `normal`, unchanged CJK per-character breaking) — a host can now opt into `keep-all` (break Korean at spaces, not mid-word, a common readability recommendation) from the outside without fighting the cascade against the internal `.cm-*` rules. It pairs with the existing `overflow-wrap: break-word`, so long unbreakable tokens still wrap.

--- a/packages/paper/src/editor/theme.test.ts
+++ b/packages/paper/src/editor/theme.test.ts
@@ -78,6 +78,8 @@ describe("theme typography is variabilized (CJK-first defaults)", () => {
     expect(tokens["--font-size"]).toBe("var(--beaket-paper-font-size, 16.5px)");
     expect(tokens["--line-height"]).toBe("var(--beaket-paper-line-height, 1.75)");
     expect(tokens["--measure"]).toBe("var(--beaket-paper-measure, none)");
+    // #554: word-break is opt-in (default `normal`), so a host can set keep-all from the outside.
+    expect(tokens["--word-break"]).toBe("var(--beaket-paper-word-break, normal)");
   });
 });
 
@@ -124,6 +126,7 @@ describe("dark theme keeps the override + bridge chains, swapping only the built
       "--font-size",
       "--line-height",
       "--measure",
+      "--word-break",
       // Derived at use time from --accent (which is dark here), so they follow without re-declaration.
       "--accent-sel",
       "--accent-weak",

--- a/packages/paper/src/editor/theme.ts
+++ b/packages/paper/src/editor/theme.ts
@@ -92,6 +92,10 @@ export const tokens = {
   "--line-height": "var(--beaket-paper-line-height, 1.75)",
   // Opt-in readable measure (max line width). Default `none` = full width, unchanged behavior.
   "--measure": "var(--beaket-paper-measure, none)",
+  // Opt-in word-break knob (#554). Default `normal` = CJK per-character breaking, unchanged behavior.
+  // A host opts into `keep-all` (break Korean at spaces, not mid-word) from the outside without fighting
+  // the cascade against the internal .cm-* rules; pairs with overflow-wrap so long tokens still wrap.
+  "--word-break": "var(--beaket-paper-word-break, normal)",
 };
 
 // Dark mode (ADR-0009 dark canvas). Same architecture as `tokens`: each entry keeps its var() chain
@@ -169,11 +173,15 @@ export const baseTheme = EditorView.theme({
     overflowY: "auto",
   },
   ".cm-content": {
-    // CJK per-character line breaking: Hangul too breaks at characters instead of keeping words intact (keep-all).
-    wordBreak: "normal",
+    // CJK per-character line breaking by default (Hangul too breaks at characters, not keeping words
+    // intact). Exposed as a knob (#554) so a host can opt into `keep-all` for Korean readability.
+    wordBreak: "var(--word-break)",
     // Strict line-break prohibition (kinsoku) — small kana, the long-vowel mark (chonpu), closing brackets, and punctuation never start a line (JLREQ §3).
     lineBreak: "strict",
     overflowWrap: "break-word",
+    // Render only real bold/italic faces, never browser-synthesized ones (#554). Faux-bold / faux-oblique
+    // smear CJK strokes badly; rich text here is body weight + real Markdown bold, so the regression risk is low.
+    fontSynthesis: "none",
     // Half-width spacing for punctuation (yakumono nibun aki) + spacing between Japanese/Western and Japanese/Korean (JLREQ §3). Chrome applies this by default;
     // made explicit to guarantee JLREQ behavior in Safari/Firefox etc. No effect on CM6 coordinate measurement (verified).
     textSpacingTrim: "normal",

--- a/sites/paper/src/pages/styling.astro
+++ b/sites/paper/src/pages/styling.astro
@@ -11,6 +11,7 @@ const cssCode = `.my-editor-wrapper {
   --beaket-paper-font: Georgia, serif;
   --beaket-paper-font-size: 16.5px;
   --beaket-paper-measure: 42rem;      /* max line width; default none = full width */
+  --beaket-paper-word-break: keep-all; /* Korean: break at spaces, not mid-word; default normal */
 }`;
 ---
 


### PR DESCRIPTION
Resolves #554 — two small typography fills for the editor base theme.

## 1. `font-synthesis: none`
Added to `.cm-content`. When a configured family lacks a real bold/italic face, the browser no longer synthesizes faux-bold / faux-oblique — which smears CJK strokes. The default font stack ships real bold faces for Latin, Korean, and Japanese, so `**bold**` still renders heavy.

**Browser-verified** (live `sites/paper`):
- `getComputedStyle('.cm-content').fontSynthesis === 'none'`
- `document.fonts.check('700 …')` true for every family in the default stack (`-apple-system`, `Apple SD Gothic Neo`, `Hiragino Sans`/`Kaku Gothic ProN`, `Noto Sans KR`)
- Heading + body bold render visibly heavy across EN/KO/JA

## 2. `--beaket-paper-word-break` knob
`word-break` is now `var(--beaket-paper-word-break, normal)`, following the existing `--measure` / `--font-size` pattern. Default `normal` keeps the current CJK per-character breaking unchanged; a host can opt into `keep-all` (break Korean at spaces, not mid-word) from an ancestor without fighting the internal `.cm-*` cascade. Pairs with the existing `overflow-wrap: break-word` so long unbreakable tokens still wrap.

**Browser-verified:** setting `--beaket-paper-word-break: keep-all` on the editor flips computed `word-break` to `keep-all`.

## Tests / docs
- `theme.test.ts` — locks the new public token + adds it to the dark-coverage `LIGHT_ONLY` set. 341 tests + typecheck pass.
- `styling.astro` — documents the new knob.
- Changeset: **minor** `@beaket/paper`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)