### PR TITLE
fix(cli): add timeout and preserve error context in registry fetch

### DIFF
--- a/.changeset/registry-fetch-timeout.md
+++ b/.changeset/registry-fetch-timeout.md
@@ -1,0 +1,14 @@
+---
+"@beaket/ui": patch
+---
+
+fix(cli): add a 10s timeout to registry fetches and preserve the original error
+
+`fetchRegistry` and `fetchComponent` called `fetch()` with no `AbortController`, so a slow or
+unreachable GitHub raw CDN hung the CLI until the OS-level TCP timeout fired (potentially minutes).
+Both catch blocks also discarded the underlying error, collapsing ENOTFOUND / ECONNREFUSED / proxy
+failures into the generic "Make sure the repository is public." message.
+
+Each request now aborts after 10s and the thrown message includes the real cause (or
+"request timed out after 10s" when the timeout fires), so `npx @beaket/ui add button` against a
+degraded network fails fast with an actionable reason.

--- a/packages/cli/src/utils/registry.test.ts
+++ b/packages/cli/src/utils/registry.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  FETCH_TIMEOUT_MS,
+  fetchComponent,
+  fetchRegistry,
+  type ComponentDefinition,
+} from "./registry.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+// A fetch that never resolves on its own but rejects with an AbortError once
+// its signal aborts — mirrors a hung connection to a slow/unreachable CDN.
+function hangingFetch() {
+  return vi.fn((_url: string, init?: { signal?: AbortSignal }) => {
+    return new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      signal?.addEventListener("abort", () => {
+        reject(new DOMException("The operation was aborted", "AbortError"));
+      });
+    });
+  });
+}
+
+function rejectingFetch(error: Error) {
+  return vi.fn(() => Promise.reject(error));
+}
+
+const buttonDef: ComponentDefinition = {
+  name: "button",
+  dependencies: [],
+  registryDependencies: [],
+  files: ["components/button.tsx"],
+};
+
+describe("fetchRegistry", () => {
+  it("aborts after the timeout with a message naming the timeout", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", hangingFetch());
+
+    const promise = fetchRegistry();
+    const assertion = expect(promise).rejects.toThrow(
+      /Failed to fetch registry from .*: request timed out after 10s/,
+    );
+
+    await vi.advanceTimersByTimeAsync(FETCH_TIMEOUT_MS);
+    await assertion;
+  });
+
+  it("preserves the underlying error reason", async () => {
+    vi.stubGlobal(
+      "fetch",
+      rejectingFetch(new Error("getaddrinfo ENOTFOUND raw.githubusercontent.com")),
+    );
+
+    await expect(fetchRegistry()).rejects.toThrow(
+      /getaddrinfo ENOTFOUND raw\.githubusercontent\.com/,
+    );
+    // Still keeps the actionable guidance.
+    await expect(fetchRegistry()).rejects.toThrow(/Make sure the repository is public/);
+  });
+
+  it("reports non-ok HTTP responses", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response("nope", { status: 404 }))),
+    );
+
+    await expect(fetchRegistry()).rejects.toThrow(/HTTP 404/);
+  });
+});
+
+describe("fetchComponent", () => {
+  it("aborts after the timeout with a message naming the timeout", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", hangingFetch());
+
+    const promise = fetchComponent(buttonDef);
+    const assertion = expect(promise).rejects.toThrow(
+      /Failed to fetch components\/button\.tsx from .*: request timed out after 10s/,
+    );
+
+    await vi.advanceTimersByTimeAsync(FETCH_TIMEOUT_MS);
+    await assertion;
+  });
+
+  it("preserves the underlying error reason", async () => {
+    vi.stubGlobal("fetch", rejectingFetch(new Error("connect ECONNREFUSED")));
+
+    await expect(fetchComponent(buttonDef)).rejects.toThrow(/connect ECONNREFUSED/);
+  });
+});

--- a/packages/cli/src/utils/registry.test.ts
+++ b/packages/cli/src/utils/registry.test.ts
@@ -28,6 +28,21 @@ function rejectingFetch(error: Error) {
   return vi.fn(() => Promise.reject(error));
 }
 
+// Headers arrive immediately (fetch resolves) but the body read hangs until the
+// signal aborts — mirrors a CDN that stalls mid-body after sending headers.
+function bodyHangsFetch() {
+  return vi.fn((_url: string, init?: { signal?: AbortSignal }) => {
+    const signal = init?.signal;
+    const hang = () =>
+      new Promise<never>((_resolve, reject) => {
+        signal?.addEventListener("abort", () => {
+          reject(new DOMException("The operation was aborted", "AbortError"));
+        });
+      });
+    return Promise.resolve({ ok: true, json: hang, text: hang } as unknown as Response);
+  });
+}
+
 const buttonDef: ComponentDefinition = {
   name: "button",
   dependencies: [],
@@ -69,6 +84,17 @@ describe("fetchRegistry", () => {
     );
 
     await expect(fetchRegistry()).rejects.toThrow(/HTTP 404/);
+  });
+
+  it("aborts when the body read stalls after headers arrive", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", bodyHangsFetch());
+
+    const promise = fetchRegistry();
+    const assertion = expect(promise).rejects.toThrow(/request timed out after 10s/);
+
+    await vi.advanceTimersByTimeAsync(FETCH_TIMEOUT_MS);
+    await assertion;
   });
 });
 

--- a/packages/cli/src/utils/registry.ts
+++ b/packages/cli/src/utils/registry.ts
@@ -18,17 +18,46 @@ export interface ComponentFile {
 // GitHub raw URL base - update this to your repo
 const GITHUB_RAW_BASE = "https://raw.githubusercontent.com/beaket/ui/main";
 
+// Node's fetch has no built-in timeout; without one a slow or unreachable CDN
+// hangs the CLI until the OS-level TCP timeout fires (minutes).
+export const FETCH_TIMEOUT_MS = 10_000;
+
+async function fetchWithTimeout(url: string): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    return await fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// Surface the real cause (ENOTFOUND, ECONNREFUSED, proxy errors, timeouts)
+// instead of collapsing everything into the generic guidance message.
+function describeFetchError(error: unknown): string {
+  if (error instanceof Error) {
+    if (error.name === "AbortError") {
+      return `request timed out after ${FETCH_TIMEOUT_MS / 1000}s`;
+    }
+    return error.message;
+  }
+  return String(error);
+}
+
 export async function fetchRegistry(): Promise<Registry> {
   const url = `${GITHUB_RAW_BASE}/registry/registry.json`;
 
   try {
-    const response = await fetch(url);
+    const response = await fetchWithTimeout(url);
     if (!response.ok) {
       throw new Error(`HTTP ${response.status}`);
     }
     return (await response.json()) as Registry;
   } catch (error) {
-    throw new Error(`Failed to fetch registry from ${url}. Make sure the repository is public.`);
+    throw new Error(
+      `Failed to fetch registry from ${url}: ${describeFetchError(error)}. Make sure the repository is public.`,
+    );
   }
 }
 
@@ -39,14 +68,14 @@ export async function fetchComponent(componentDef: ComponentDefinition): Promise
     const url = `${GITHUB_RAW_BASE}/src/${filePath}`;
 
     try {
-      const response = await fetch(url);
+      const response = await fetchWithTimeout(url);
       if (!response.ok) {
         throw new Error(`HTTP ${response.status}`);
       }
       const content = await response.text();
       files.push({ path: filePath, content });
     } catch (error) {
-      throw new Error(`Failed to fetch ${filePath} from ${url}`);
+      throw new Error(`Failed to fetch ${filePath} from ${url}: ${describeFetchError(error)}`);
     }
   }
 

--- a/packages/cli/src/utils/registry.ts
+++ b/packages/cli/src/utils/registry.ts
@@ -22,12 +22,22 @@ const GITHUB_RAW_BASE = "https://raw.githubusercontent.com/beaket/ui/main";
 // hangs the CLI until the OS-level TCP timeout fires (minutes).
 export const FETCH_TIMEOUT_MS = 10_000;
 
-async function fetchWithTimeout(url: string): Promise<Response> {
+// The timer stays armed until readBody resolves so the body download is covered
+// too — fetch() resolves when headers arrive, not when the body is fully read, so
+// a CDN that stalls mid-body would otherwise slip past the timeout.
+async function fetchWithTimeout<T>(
+  url: string,
+  readBody: (res: Response) => Promise<T>,
+): Promise<T> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
   try {
-    return await fetch(url, { signal: controller.signal });
+    const response = await fetch(url, { signal: controller.signal });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    return await readBody(response);
   } finally {
     clearTimeout(timer);
   }
@@ -49,11 +59,7 @@ export async function fetchRegistry(): Promise<Registry> {
   const url = `${GITHUB_RAW_BASE}/registry/registry.json`;
 
   try {
-    const response = await fetchWithTimeout(url);
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status}`);
-    }
-    return (await response.json()) as Registry;
+    return await fetchWithTimeout(url, async (res) => (await res.json()) as Registry);
   } catch (error) {
     throw new Error(
       `Failed to fetch registry from ${url}: ${describeFetchError(error)}. Make sure the repository is public.`,
@@ -68,11 +74,7 @@ export async function fetchComponent(componentDef: ComponentDefinition): Promise
     const url = `${GITHUB_RAW_BASE}/src/${filePath}`;
 
     try {
-      const response = await fetchWithTimeout(url);
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-      const content = await response.text();
+      const content = await fetchWithTimeout(url, (res) => res.text());
       files.push({ path: filePath, content });
     } catch (error) {
       throw new Error(`Failed to fetch ${filePath} from ${url}: ${describeFetchError(error)}`);


### PR DESCRIPTION
## Summary

Resolves #596.

`fetchRegistry()` and `fetchComponent()` in `packages/cli/src/utils/registry.ts` called `fetch()` with no `AbortController`, and both catch blocks discarded the original error. This caused two problems:

1. **Hang on a slow/unreachable CDN.** Node's `fetch` has no built-in timeout, so `npx @beaket/ui add button` on a degraded network stalled after "✔ Checking registry." until the OS-level TCP timeout fired (minutes).
2. **Lost error context.** ENOTFOUND, connection-refused, and corporate-proxy failures all collapsed into the generic "Make sure the repository is public." message.

## Changes

- Added a shared `fetchWithTimeout` helper backed by an `AbortController` with a 10s timeout (`FETCH_TIMEOUT_MS`), used by both fetch functions.
- Added a `describeFetchError` helper that surfaces the real cause, or reports `request timed out after 10s` on `AbortError`.
- Both thrown messages now append the underlying reason; `fetchRegistry` keeps the actionable "Make sure the repository is public." guidance.
- Added `registry.test.ts` covering timeout abort, preserved error reason, and non-ok HTTP responses for both functions (5 tests, passing).
- Added a `@beaket/ui` patch changeset.

## Triage decisions

Per the issue's maintainer-triage note:
- **Timeout value:** 10s, matching the suggested sketch.
- **Diagnostic line:** none added — the reason is folded directly into the thrown error message rather than emitted separately.
- **Wording:** `Failed to fetch registry from <url>: <reason>. Make sure the repository is public.`

## Verification

`pnpm vitest run packages/cli/src/utils/registry.test.ts` → 5 passed. `pnpm --filter @beaket/ui typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApX7LKeNSaPN5266qQeBqr

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApX7LKeNSaPN5266qQeBqr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registry and component downloads now time out after 10 seconds instead of waiting indefinitely.
  * Error messages now include the underlying network or HTTP failure details.
  * Timeout errors clearly identify the affected registry or component request.
* **Tests**
  * Added coverage for request timeouts, network failures, and non-successful HTTP responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->