### PR TITLE
refactor(table): extract pure parse/serialize model into table-model.ts

### DIFF
--- a/.changeset/table-model-extract.md
+++ b/.changeset/table-model-extract.md
@@ -1,0 +1,19 @@
+---
+"@beaket/paper": patch
+---
+
+refactor(table): extract the pure parse/serialize model into `table-model.ts`
+
+Root cause: `extensions/table-widget.ts` had grown to ~1,600 lines covering four distinct concerns
+(pure model, widget DOM/grid rendering, cell subview sync, keymap handlers) in one file, so a change
+to any one concern required reading the whole file for context and risked touching the others.
+
+This is the first, lowest-risk split: the pure model layer — `parseAligns`, `parseRowCells`,
+`parseTable`, `serializeRow`, `serializeDelimiter`, and the `TableAlign` / `CellRange` / `TableData`
+types — moves to a new `extensions/table-model.ts` (no view/DOM dependency; state-only). It already
+had its own `table-model.test.ts`, now pointed at the new module. `table-widget.ts` imports what it
+needs from there. Behavior is unchanged (move only); the full suite stays green.
+
+Also documents the previously-undocumented table keymap invariants (in-cell Tab/Enter/Shift-Enter/
+arrow-escape, the two-step Backspace select-then-delete, and the boundary-newline guard) in
+`packages/paper/docs/DECISIONS.md`.

--- a/packages/paper/docs/DECISIONS.md
+++ b/packages/paper/docs/DECISIONS.md
@@ -38,6 +38,26 @@ change needs an ADR vs. a changeset. Each bullet below links to its ADR.
   ([ADR-0002](./adr/0002-table-structure-syntax-permanently-hidden.md),
   [ADR-0003](./adr/0003-cell-editor-as-codemirror-subview.md),
   [ADR-0008](./adr/0008-table-cell-line-break-hidden-br.md))
+- **Table keymap invariants.** The grid is a single atomic range (`EditorView.atomicRanges`), so
+  the caret never lands _inside_ the table's source text — every table key is an explicit override
+  of that default. The rules future work must preserve (no ADR — these document existing behavior;
+  they live in `extensions/table-widget.ts`, split model in `extensions/table-model.ts`):
+  - **In the cell subview** — `Enter` moves down one row (creating a row past the last one);
+    `Shift-Enter` inserts a hidden `<br>` line break (ADR-0008); `Tab` / `Shift-Tab` step to the
+    next / previous cell in sequence (wrapping across rows, growing the grid at the end); `↑` / `↓`
+    _at the cell's visual top/bottom edge_ move to the adjacent row or **escape** the table (raw
+    `↑`/`↓` inside the cell fall through to default intra-cell movement); `←` / `→` _at the text
+    start/end_ step to the previous / next cell or escape; `Escape` ends editing and leaves the
+    table **block-selected** (outline ring). **Every one of these is suppressed during IME
+    composition** (`view.composing`) — commit only, never navigate — per the composing-guard
+    contract (invariant #1, CJK first-class).
+  - **Around the table (main view)** — `Backspace` immediately after a table first **selects** the
+    whole table, and a second `Backspace` **deletes** it (an Obsidian-style two-step, overriding the
+    atomic range's one-press delete); `↑` / `↓` on the line adjacent to a table **enters** it
+    (symmetric to the edge-arrow escape).
+  - **Boundary guard** — a transaction filter blocks deleting the blank-line separator newline(s)
+    after a table, which would otherwise let GFM absorb the following paragraph into a table row;
+    a change that removes the whole table is allowed through.
 - **Composing guard contract (the most expensive invariant).** During `view.composing`: no
   decoration recompute, no widget DOM rebuild, no menu action; map existing decorations to the new
   coordinates; re-evaluate on `compositionend`. **Every new extension or feature must honor this.**

--- a/packages/paper/src/editor/extensions/table-model.test.ts
+++ b/packages/paper/src/editor/extensions/table-model.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseAligns, parseRowCells, serializeDelimiter, serializeRow } from "./table-widget";
+import { parseAligns, parseRowCells, serializeDelimiter, serializeRow } from "./table-model";
 
 describe("parseRowCells", () => {
   it("splits a basic row into cell ranges", () => {

--- a/packages/paper/src/editor/extensions/table-model.ts
+++ b/packages/paper/src/editor/extensions/table-model.ts
@@ -1,0 +1,119 @@
+import type { EditorState } from "@codemirror/state";
+
+// Table model — pure parse/serialize over the markdown source (no view/DOM dependency).
+// lezer is used only to *locate* the Table node (in table-widget.ts); cell ranges are computed
+// here by scanning lines directly, because lezer's TableCell node isn't created for empty cells
+// and so can't give a click-entry position for an empty cell.
+
+export type TableAlign = "left" | "center" | "right" | null;
+
+export interface CellRange {
+  /** Cell content range in body document coordinates (trimmed). If editable=false, from/to are invalid */
+  from: number;
+  to: number;
+  text: string;
+  editable: boolean;
+}
+
+export interface TableData {
+  source: string;
+  tableFrom: number;
+  aligns: TableAlign[];
+  /** rows[0] = header, rows[1..] = body rows (delimiter row excluded) */
+  rows: CellRange[][];
+}
+
+export function parseAligns(delimiter: string): TableAlign[] {
+  return delimiter
+    .replace(/^\s*\|/, "")
+    .replace(/\|\s*$/, "")
+    .split("|")
+    .map((seg) => {
+      const s = seg.trim();
+      const left = s.startsWith(":");
+      const right = s.endsWith(":");
+      if (left && right) return "center";
+      if (right) return "right";
+      if (left) return "left";
+      return null;
+    });
+}
+
+export function parseRowCells(lineText: string, lineFrom: number): CellRange[] {
+  // Collect positions of unescaped pipes
+  const pipes: number[] = [];
+  for (let i = 0; i < lineText.length; i++) {
+    if (lineText[i] === "|" && lineText[i - 1] !== "\\") pipes.push(i);
+  }
+  if (pipes.length === 0) return [];
+
+  // GFM allows omitting the pipes at the row edges — compensate with virtual boundaries
+  const bounds = [...pipes];
+  if (lineText.slice(0, pipes[0]).trim() !== "") bounds.unshift(-1);
+  if (lineText.slice(pipes[pipes.length - 1] + 1).trim() !== "") bounds.push(lineText.length);
+
+  const cells: CellRange[] = [];
+  for (let i = 0; i < bounds.length - 1; i++) {
+    const segStart = bounds[i] + 1;
+    const segEnd = bounds[i + 1];
+    const seg = lineText.slice(segStart, segEnd);
+    // Treat only one padding space at each edge as outside the cell — a full trim would erase
+    // a trailing space the user just typed during the body→subview reverse sync
+    const leading = seg.startsWith(" ") ? 1 : 0;
+    const trailing = seg.length > leading && seg.endsWith(" ") ? 1 : 0;
+    const text = seg.slice(leading, seg.length - trailing);
+    const from = lineFrom + segStart + leading;
+    cells.push({ from, to: from + text.length, text, editable: true });
+  }
+  return cells;
+}
+
+const MISSING_CELL: CellRange = { from: -1, to: -1, text: "", editable: false };
+
+export function parseTable(state: EditorState, nodeFrom: number, nodeTo: number): TableData {
+  const firstLine = state.doc.lineAt(nodeFrom);
+  const lastLine = state.doc.lineAt(nodeTo);
+  const rows: CellRange[][] = [];
+  let aligns: TableAlign[] = [];
+
+  for (let n = firstLine.number; n <= lastLine.number; n++) {
+    const line = state.doc.line(n);
+    if (n === firstLine.number + 1) {
+      aligns = parseAligns(line.text);
+      continue;
+    }
+    rows.push(parseRowCells(line.text, line.from));
+  }
+
+  const cols = Math.max(aligns.length, rows[0]?.length ?? 0);
+  for (const row of rows) {
+    while (row.length < cols) row.push(MISSING_CELL);
+    row.length = cols;
+  }
+
+  return {
+    source: state.sliceDoc(firstLine.from, lastLine.to),
+    tableFrom: firstLine.from,
+    aligns,
+    rows,
+  };
+}
+
+export function serializeRow(cells: string[]): string {
+  return "|" + cells.map((c) => (c ? ` ${c} ` : "  ")).join("|") + "|";
+}
+
+export function serializeDelimiter(aligns: TableAlign[]): string {
+  return (
+    "|" +
+    aligns
+      .map((a) => {
+        if (a === "center") return " :---: ";
+        if (a === "right") return " ---: ";
+        if (a === "left") return " :--- ";
+        return " --- ";
+      })
+      .join("|") +
+    "|"
+  );
+}

--- a/packages/paper/src/editor/extensions/table-widget.ts
+++ b/packages/paper/src/editor/extensions/table-widget.ts
@@ -15,6 +15,8 @@ import { Decoration, EditorView, ViewPlugin, WidgetType, keymap } from "@codemir
 import { renderCellInline } from "./cell-inline-renderer";
 import { guardedDecorations } from "./composing-guard";
 import { markdownExtension } from "./markdown";
+import type { TableAlign, TableData } from "./table-model";
+import { parseTable, serializeDelimiter, serializeRow } from "./table-model";
 
 // ADR-0002: A table is always a rendered grid widget; structure syntax (|, delimiter rows) stays permanently hidden.
 // ADR-0003: Editing happens in a CM subview shown only on the one focused cell — it shares the document with the
@@ -24,25 +26,7 @@ import { markdownExtension } from "./markdown";
 // Preventing table churn: even when cell editing changes the table source, the widget DOM is not recreated;
 // it's updated in place via updateDOM() — keeping the subview from being destroyed during editing is the key.
 
-export type TableAlign = "left" | "center" | "right" | null;
-
 export const cellSync = Annotation.define<"from-cell" | "from-main">();
-
-interface CellRange {
-  /** Cell content range in body document coordinates (trimmed). If editable=false, from/to are invalid */
-  from: number;
-  to: number;
-  text: string;
-  editable: boolean;
-}
-
-interface TableData {
-  source: string;
-  tableFrom: number;
-  aligns: TableAlign[];
-  /** rows[0] = header, rows[1..] = body rows (delimiter row excluded) */
-  rows: CellRange[][];
-}
 
 interface ActiveCell {
   tableFrom: number;
@@ -83,86 +67,6 @@ export function clearActiveCell(view: EditorView): void {
 /** Start cell editing on a specific table from the outside (e.g. a slash command) */
 export function activateCell(view: EditorView, tableFrom: number, row = 0, col = 0): void {
   view.dispatch({ effects: setActiveCellEffect.of({ tableFrom, row, col }) });
-}
-
-// ---------------------------------------------------------------------------
-// Parsing — use lezer only to locate the Table; compute cell ranges directly by scanning lines.
-// (lezer's TableCell node isn't created for empty cells, so it can't give a click entry position)
-
-export function parseAligns(delimiter: string): TableAlign[] {
-  return delimiter
-    .replace(/^\s*\|/, "")
-    .replace(/\|\s*$/, "")
-    .split("|")
-    .map((seg) => {
-      const s = seg.trim();
-      const left = s.startsWith(":");
-      const right = s.endsWith(":");
-      if (left && right) return "center";
-      if (right) return "right";
-      if (left) return "left";
-      return null;
-    });
-}
-
-export function parseRowCells(lineText: string, lineFrom: number): CellRange[] {
-  // Collect positions of unescaped pipes
-  const pipes: number[] = [];
-  for (let i = 0; i < lineText.length; i++) {
-    if (lineText[i] === "|" && lineText[i - 1] !== "\\") pipes.push(i);
-  }
-  if (pipes.length === 0) return [];
-
-  // GFM allows omitting the pipes at the row edges — compensate with virtual boundaries
-  const bounds = [...pipes];
-  if (lineText.slice(0, pipes[0]).trim() !== "") bounds.unshift(-1);
-  if (lineText.slice(pipes[pipes.length - 1] + 1).trim() !== "") bounds.push(lineText.length);
-
-  const cells: CellRange[] = [];
-  for (let i = 0; i < bounds.length - 1; i++) {
-    const segStart = bounds[i] + 1;
-    const segEnd = bounds[i + 1];
-    const seg = lineText.slice(segStart, segEnd);
-    // Treat only one padding space at each edge as outside the cell — a full trim would erase
-    // a trailing space the user just typed during the body→subview reverse sync
-    const leading = seg.startsWith(" ") ? 1 : 0;
-    const trailing = seg.length > leading && seg.endsWith(" ") ? 1 : 0;
-    const text = seg.slice(leading, seg.length - trailing);
-    const from = lineFrom + segStart + leading;
-    cells.push({ from, to: from + text.length, text, editable: true });
-  }
-  return cells;
-}
-
-const MISSING_CELL: CellRange = { from: -1, to: -1, text: "", editable: false };
-
-function parseTable(state: EditorState, nodeFrom: number, nodeTo: number): TableData {
-  const firstLine = state.doc.lineAt(nodeFrom);
-  const lastLine = state.doc.lineAt(nodeTo);
-  const rows: CellRange[][] = [];
-  let aligns: TableAlign[] = [];
-
-  for (let n = firstLine.number; n <= lastLine.number; n++) {
-    const line = state.doc.line(n);
-    if (n === firstLine.number + 1) {
-      aligns = parseAligns(line.text);
-      continue;
-    }
-    rows.push(parseRowCells(line.text, line.from));
-  }
-
-  const cols = Math.max(aligns.length, rows[0]?.length ?? 0);
-  for (const row of rows) {
-    while (row.length < cols) row.push(MISSING_CELL);
-    row.length = cols;
-  }
-
-  return {
-    source: state.sliceDoc(firstLine.from, lastLine.to),
-    tableFrom: firstLine.from,
-    aligns,
-    rows,
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -1020,25 +924,6 @@ interface ControllerHost extends HTMLElement {
 
 interface GripHost extends HTMLElement {
   __grip?: HTMLElement;
-}
-
-export function serializeRow(cells: string[]): string {
-  return "|" + cells.map((c) => (c ? ` ${c} ` : "  ")).join("|") + "|";
-}
-
-export function serializeDelimiter(aligns: TableAlign[]): string {
-  return (
-    "|" +
-    aligns
-      .map((a) => {
-        if (a === "center") return " :---: ";
-        if (a === "right") return " ---: ";
-        if (a === "left") return " :--- ";
-        return " --- ";
-      })
-      .join("|") +
-    "|"
-  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #570 (first, agreed step — the safe split, not the full 4-way decomposition).

## Context

`extensions/table-widget.ts` had grown to ~1,600 lines mixing four concerns (pure model, widget/grid rendering, cell subview sync, keymap handlers). Issue #570 flags the full split point as a maintainer decision. After confirming scope with the maintainer, this PR does **only the lowest-risk first step** the issue itself calls "the natural first split", and defers carving up the ~760-line `TableController` to a follow-up.

## What changed

- **New `extensions/table-model.ts`** — the pure, state-only model layer: `parseAligns`, `parseRowCells`, `parseTable`, `serializeRow`, `serializeDelimiter`, and the `TableAlign` / `CellRange` / `TableData` types. No view/DOM dependency.
- **`table-widget.ts`** imports those from `./table-model` (1595 → 1480 lines). Pure code move, no behavior change.
- **`table-model.test.ts`** now targets the new module (it was already the model's test).
- **`docs/DECISIONS.md`** — documents the previously-undocumented table keymap invariants (in-cell Tab/Enter/Shift-Enter/arrow-escape, the two-step Backspace select-then-delete, and the boundary-newline guard). Recorded as a DECISIONS.md entry rather than a full ADR, since it documents existing behavior.
- **Changeset** — `@beaket/paper` patch.

## Not in scope (deferred)

Splitting `TableController` and the widget/keymap concerns into `table-cell-view.ts` / `table-keymap.ts` — the genuinely risky part the issue reserves for a maintainer. Left for a follow-up.

## Verification

- `pnpm typecheck` — clean
- `pnpm test` — **39 files, 367 tests pass** (43 table-specific)
- `prettier --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LzGwa4tbZbWdko8CBSpgD8)_