### PR TITLE
fix(paper-react): getView() returns undefined before mount instead of throwing

### DIFF
--- a/.changeset/paper-getview-undefined-before-mount.md
+++ b/.changeset/paper-getview-undefined-before-mount.md
@@ -1,0 +1,19 @@
+---
+"@beaket/paper": minor
+---
+
+fix(react): `PaperHandle.getView()` returns `undefined` before mount instead of throwing
+
+Root cause: the `EditorView` is created in a passive `useEffect`, which runs after the commit
+phase, while React `ref` callbacks (and `useImperativeHandle`) fire during commit. A consumer using
+the documented `getView()` escape hatch from a ref callback therefore hit `viewRef.current === null`
+and the handle threw `Paper: view is not mounted yet`, crashing the React tree on first render.
+
+Fix: `getView()` now returns `EditorView | undefined`, yielding `undefined` until the view mounts.
+The idiomatic `const v = h.getView(); if (!v) return;` now works, bringing the hatch in line with its
+curated siblings — `getSelection()` returns `null`, `getValue()` returns `""` — instead of being the
+one handle that throws.
+
+This changes the return type from `EditorView` to `EditorView | undefined` (a semver-legal breaking
+type change on `0.x`). See ADR-0013's 2026-07-11 amendment; the `onReady` callback and raw
+`extensions[]` slot from the issue were deliberately not added (ADR-0015).

--- a/packages/paper/docs/adr/0013-react-shell-and-distribution.md
+++ b/packages/paper/docs/adr/0013-react-shell-and-distribution.md
@@ -233,3 +233,11 @@ The body above is **historical** — it was written on 2026-06-17, before the re
 - `PaperProps` now includes the live anchor/highlight props (`highlights`, `activeHighlightId`, `onHighlightStatusChange`, `onHighlightClick`, `onSelect`) of ADR-0014, reconfigured live via dedicated controllers — no longer "left blank."
 - A `colorScheme` live prop (`"light" | "dark" | "system"`) exists, flipped via a compartment reconfigure without recreation (dark mode, which the body deferred under ADR-0009, has shipped — v0.2.0).
 - The package now lives in the `beaket.ui` monorepo at `packages/paper` — i.e. the co-location of **Decision 7** (recorded as deferred future work in the body) has since been carried out.
+
+## Amendment (2026-07-11) — `getView()` returns `undefined` before mount instead of throwing (#511)
+
+Decision 3's escape hatch was typed `getView(): EditorView` and **threw** `Paper: view is not mounted yet` whenever `viewRef.current` was null. But the view is created in a passive `useEffect`, which runs _after_ the commit phase — so a consumer calling `getView()` from a React `ref` callback (the documented hatch for attaching extensions post-mount) crashed the tree on first render, forcing a `try/catch` + `requestAnimationFrame`-poll dance.
+
+`getView()` now returns `EditorView | undefined`, yielding `undefined` until the view mounts. This makes the idiomatic `const v = h.getView(); if (!v) return;` work and brings the hatch in line with its curated siblings — `getSelection()` returns `null`, `getValue()` returns `""` — rather than being the one handle that throws. The project's own docs-site demos already assumed this falsy-return shape (`editor-playground.tsx`, `highlights-demo.tsx`).
+
+The signature change (`EditorView` → `EditorView | undefined`) is a semver-legal breaking change on `0.x` (see `DECISIONS.md` → Versioning). Option A of #511 (`getView()` returns `undefined`) was taken; the requested `onReady`/`onCreateView` callback (option B) was not added — the falsy-return contract covers the reported need without growing the surface that freezes at 1.0 — and the raw `extensions[]` injection slot (option C) stays foreclosed by ADR-0015.

--- a/packages/paper/src/react/paper.tsx
+++ b/packages/paper/src/react/paper.tsx
@@ -24,8 +24,13 @@ export interface PaperHandle {
   focus(): void;
   /** Selection range (source coordinates). null on empty selection. The anchor input surface of ADR-0014. */
   getSelection(): { from: number; to: number; text: string } | null;
-  /** Raw CM6 EditorView — no cross-version guarantees (unsafe). Power-user escape hatch. */
-  getView(): EditorView;
+  /**
+   * Raw CM6 EditorView — no cross-version guarantees (unsafe). Power-user escape hatch.
+   * Returns `undefined` until the view has mounted (the effect that creates it runs after
+   * commit), so a ref callback can guard with `const v = h.getView(); if (!v) return;` —
+   * matching `getSelection()` (null) and `getValue()` ("") rather than throwing.
+   */
+  getView(): EditorView | undefined;
 }
 
 export interface PaperProps {
@@ -170,11 +175,7 @@ export const Paper = forwardRef<PaperHandle, PaperProps>(function Paper(
         if (from === to) return null;
         return { from, to, text: view.state.sliceDoc(from, to) };
       },
-      getView: () => {
-        const view = viewRef.current;
-        if (!view) throw new Error("Paper: view is not mounted yet");
-        return view;
-      },
+      getView: () => viewRef.current ?? undefined,
     }),
     [],
   );

--- a/sites/paper/src/pages/api.astro
+++ b/sites/paper/src/pages/api.astro
@@ -45,7 +45,7 @@ const withBase = (p: string) => (base.endsWith('/') ? base + p : base + '/' + p)
       <tr><td><code>setValue(md)</code></td><td><code>void</code></td><td>Replace the whole document. Deferred until an active IME composition settles. Does not fire <code>onChange</code>.</td></tr>
       <tr><td><code>focus()</code></td><td><code>void</code></td><td>Focus the editor.</td></tr>
       <tr><td><code>getSelection()</code></td><td><code>&#123; from, to, text &#125; | null</code></td><td>Current selection in source coordinates; <code>null</code> when empty.</td></tr>
-      <tr><td><code>getView()</code></td><td><code>EditorView</code></td><td>Escape hatch — the raw CodeMirror 6 <code>EditorView</code>. No cross-version guarantees.</td></tr>
+      <tr><td><code>getView()</code></td><td><code>EditorView | undefined</code></td><td>Escape hatch — the raw CodeMirror 6 <code>EditorView</code>. No cross-version guarantees. Returns <code>undefined</code> until the view has mounted, so a ref callback can guard with <code>const v = h.getView(); if (!v) return;</code>.</td></tr>
     </tbody>
   </table>
   </div>

--- a/sites/paper/src/pages/usage.astro
+++ b/sites/paper/src/pages/usage.astro
@@ -109,7 +109,9 @@ const renderMermaid = async (code, el, ctx) => {
   <CodeBlock code={setValueCode} lang="ts" />
   <p>
     For anything the curated handle does not expose, <code>ref.current.getView()</code> returns the
-    underlying CodeMirror <code>EditorView</code> as an escape hatch. See the
+    underlying CodeMirror <code>EditorView</code> as an escape hatch. It returns <code>undefined</code>
+    until the view has mounted (e.g. when called from a ref callback), so guard with
+    <code>const v = ref.current?.getView(); if (!v) return;</code>. See the
     <a href={withBase('api')}>API Reference</a> for the full prop and handle surface.
   </p>
 


### PR DESCRIPTION
Fixes #511.

## Problem

`PaperHandle.getView()` threw `Error: Paper: view is not mounted yet` when the underlying CodeMirror `EditorView` had not mounted yet. The view is created in a passive `useEffect` (which runs *after* the commit phase), while React `ref` callbacks and `useImperativeHandle` fire *during* commit. So a consumer using the documented `getView()` escape hatch from a ref callback — the intended hatch for attaching extensions post-mount — crashed the React tree on first render, and had to wrap every access in `try/catch` + `requestAnimationFrame`-polling.

## Fix (issue option A)

`getView()` now returns `EditorView | undefined`, yielding `undefined` until the view mounts. The idiomatic `const v = h.getView(); if (!v) return;` now works, bringing the hatch in line with its curated siblings:

| handle | before mount |
| --- | --- |
| `getSelection()` | `null` |
| `getValue()` | `""` |
| `getView()` | ~~throws~~ → `undefined` |

The project's own docs-site demos (`editor-playground.tsx`, `highlights-demo.tsx`) already assumed this falsy-return shape (`const view = ref.current?.getView(); if (!view) return;`).

## Why not the other options in the issue

- **`onReady`/`onCreateView` callback (option B)** — not added; the falsy-return contract covers the reported need without growing the public surface that freezes at 1.0.
- **First-class `extensions[]` injection slot (option C)** — foreclosed by **ADR-0015** (`no raw CodeMirror extension injection slot`), which explicitly rejects it for 1.0.

## Semver

The return-type change (`EditorView` → `EditorView | undefined`) is a semver-legal breaking type change on `0.x`, so the changeset is a **minor** (per `DECISIONS.md` → Versioning: breaking changes ride `0.x` minors).

## Changes

- `packages/paper/src/react/paper.tsx` — `getView()` returns `viewRef.current ?? undefined`; type + JSDoc updated.
- `packages/paper/docs/adr/0013-react-shell-and-distribution.md` — amendment recording the contract change and why options B/C were declined.
- `sites/paper/src/pages/api.astro`, `usage.astro` — docs reflect the `| undefined` return and the guard pattern.
- `.changeset/paper-getview-undefined-before-mount.md` — minor changeset.

## Verification

- `pnpm typecheck` (paper) — clean.
- `pnpm test` (paper) — 367/367 pass.
- Both existing `getView()` consumers in the repo already guard with `if (!view) return`, so they are compatible.

Note: the React wrapper is intentionally kept out of the jsdom test surface (ADR-0005 — thin wiring, no React test deps), so no React-harness test was added for this one-line wiring change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142uEJMRzK1S7qavDEcwry7

---
_Generated by [Claude Code](https://claude.ai/code/session_0142uEJMRzK1S7qavDEcwry7)_