### PR TITLE
docs(paper): adjudicate DECISIONS.md Deferred list for the 1.0 gate (#481)

### DIFF
--- a/.changeset/adjudicate-deferred-list-1-0.md
+++ b/.changeset/adjudicate-deferred-list-1-0.md
@@ -15,7 +15,8 @@ any behavior change:
   `onSelect`/active flush) are recorded as the matrix #483 inherits; IME stays delegated, not verified.
 - **Orphan re-emit on in-session delete; prefix/suffix context anchors** — accepted for 1.0 with the
   bounded consequence named (a stale `exact`/`approximate` status until the next `setHighlights`/reload;
-  the decoration itself is dropped by the `from < to` filter) and the ADR-0014 resumption trigger kept.
+  the decoration itself is dropped on map — empty mark decorations are removed) and the ADR-0014
+  resumption trigger kept.
   The `Anchor` slots and `onHighlightStatusChange` map are additive-only, so the 1.0 interface freeze is
   not blocked.
 - **`.cm-selectionBackground` dormant** — accepted for 1.0 (browser-native selection); `drawSelection()`

--- a/.changeset/adjudicate-deferred-list-1-0.md
+++ b/.changeset/adjudicate-deferred-list-1-0.md
@@ -1,0 +1,23 @@
+---
+"@beaket/paper": patch
+---
+
+docs(paper): adjudicate the DECISIONS.md "Deferred (not bugs)" list for the 1.0 gate
+
+Root cause: the 1.0 exit criterion (#481) requires every `DECISIONS.md` Deferred item to be resolved
+or consciously accepted with written rationale, but the three items were still recorded as open
+deferrals. Verified all three against current code — accurate, not stale — and adjudicated each without
+any behavior change:
+
+- **Physical-key Korean IME spot-check** — redirected, not a #481 code deferral: it is the deliberate
+  jsdom-strategy boundary (ADR-0005) and is owned by the CJK/IME real-device verification gate (#483,
+  blocked by #479). The specific guarded paths (`setValue`, highlight-deferral hold, coalesced
+  `onSelect`/active flush) are recorded as the matrix #483 inherits; IME stays delegated, not verified.
+- **Orphan re-emit on in-session delete; prefix/suffix context anchors** — accepted for 1.0 with the
+  bounded consequence named (a stale `exact`/`approximate` status until the next `setHighlights`/reload;
+  the decoration itself is dropped by the `from < to` filter) and the ADR-0014 resumption trigger kept.
+  The `Anchor` slots and `onHighlightStatusChange` map are additive-only, so the 1.0 interface freeze is
+  not blocked.
+- **`.cm-selectionBackground` dormant** — accepted for 1.0 (browser-native selection); `drawSelection()`
+  declined for IME/composing-guard risk and lightness. The dead rule is kept as the wired token path and
+  annotated dormant at the call site in `theme.ts` so the decision is self-documenting and reversible.

--- a/packages/paper/docs/DECISIONS.md
+++ b/packages/paper/docs/DECISIONS.md
@@ -174,11 +174,42 @@ chains (single source of truth), forced-block-only — never merged into the tok
 Not yet exposed (deliberate scope cut, revisit on demand): a `theme?: Extension` option to append a
 consumer CodeMirror theme.
 
-## Deferred (not bugs)
+## Deferred (not bugs) — adjudicated for 1.0 ([#481](https://github.com/beaket/ui/issues/481))
 
-- Physical-key Korean IME spot-check for the guarded paths (`setValue`, highlight deferral, coalesced
-  `onSelect` flush) — verified with synthetic composition events only.
-- Orphan-status re-emit during a delete; prefix/suffix context anchors (the `Anchor` type reserves
-  both fields) — defer until real orphan rates are observed.
-- `.cm-selectionBackground` is dormant (no `drawSelection()`); selection uses the browser-native
-  highlight. Add `drawSelection()` if a porcelain selection tint is wanted.
+These were reviewed against the 1.0 exit criterion — _"no open P1/P2 bugs, and every Deferred item
+resolved or consciously accepted with written rationale"_ ([#481](https://github.com/beaket/ui/issues/481)).
+None is a code defect; each is recorded below with its disposition, verified still-current against the
+code at adjudication time. The three keep three **distinct** shapes on purpose — a verification carve-out,
+a live design deferral, and dormant-code housekeeping — don't flatten them into one "accepted" bullet.
+
+- **Physical-key Korean IME spot-check — _redirected_, not a code deferral.** The guarded paths
+  (`setValue`, highlight deferral via `createHighlightController`'s composition hold, and the coalesced
+  `onSelect` / `activeHighlightId` flush) are verified with **synthetic** composition events only.
+  Real hardware-IME verification is the deliberate boundary of the jsdom strategy
+  ([ADR-0005](./adr/0005-quality-via-jsdom-contract-and-regression-tests.md) — jsdom cannot reproduce a
+  genuine IME pipeline), and it is owned by the **CJK/IME real-device verification** exit criterion
+  ([#483](https://github.com/beaket/ui/issues/483), blocked by the verification-method precursor
+  [#479](https://github.com/beaket/ui/issues/479)), not by #481. That exact list of guarded paths is the
+  concrete test matrix #483 inherits. Until #483 passes, IME is **delegated and still owed — not verified.**
+
+- **Orphan-status re-emit on in-session delete; prefix/suffix context anchors — _accepted for 1.0_.**
+  Reaffirms [ADR-0014](./adr/0014-selection-annotation-mechanism.md) decisions 2 / 7. Bounded
+  consequence: when an in-session edit deletes anchored text, `highlightField` only maps positions on
+  `docChanged` (no re-resolution), so the collapsed range is dropped by the `from < to` filter **but the
+  status map still reports the stale `exact` / `approximate`** — self-healing on the next `setHighlights`
+  or reload (the main re-resolution path). prefix/suffix stay reserved additive-optional `Anchor` slots
+  (decision 7 — evolution is additive-optional only), and `onHighlightStatusChange` already emits a full
+  map, so both a later orphan re-emit and the B→C context-anchor extension change only _when / what fills
+  the map_, never the signature — **the 1.0 interface freeze is not blocked either way.** Resumption
+  trigger retained: revisit if observed orphan rates justify prefix/suffix or eager re-emit.
+
+- **`.cm-selectionBackground` dormant — _accepted for 1.0_ (browser-native selection).** The rule in
+  `theme.ts` styles `.cm-selectionBackground` with `--accent-sel`, but CM6 only emits that element when
+  `drawSelection()` is installed — it is not, so selection stays browser-native and the rule never
+  matches. Not installing `drawSelection()` is deliberate: it swaps native selection for a synthetic
+  drawn layer that interacts with the contentEditable caret/composition rendering — a poor trade against
+  the composing guard (the package's most expensive invariant,
+  [ADR-0004](./adr/0004-composing-guard-defer-plus-map.md)) for a purely cosmetic selection tint no
+  consumer has requested (lightness — _"there must be a reason to add it"_). The rule is **kept and
+  annotated dormant** at the call site: it is the already-wired, dark-aware, consumer-overridable token
+  path, so the decision is reversible in one line if demand ever flips. No `drawSelection()` for 1.0.

--- a/packages/paper/docs/DECISIONS.md
+++ b/packages/paper/docs/DECISIONS.md
@@ -195,8 +195,9 @@ a live design deferral, and dormant-code housekeeping — don't flatten them int
 - **Orphan-status re-emit on in-session delete; prefix/suffix context anchors — _accepted for 1.0_.**
   Reaffirms [ADR-0014](./adr/0014-selection-annotation-mechanism.md) decisions 2 / 7. Bounded
   consequence: when an in-session edit deletes anchored text, `highlightField` only maps positions on
-  `docChanged` (no re-resolution), so the collapsed range is dropped by the `from < to` filter **but the
-  status map still reports the stale `exact` / `approximate`** — self-healing on the next `setHighlights`
+  `docChanged` (no re-resolution), so the collapsed range is dropped on map (empty mark decorations are
+  removed) **but the status map still reports the stale `exact` / `approximate`** — self-healing on the
+  next `setHighlights`
   or reload (the main re-resolution path). prefix/suffix stay reserved additive-optional `Anchor` slots
   (decision 7 — evolution is additive-optional only), and `onHighlightStatusChange` already emits a full
   map, so both a later orphan re-emit and the B→C context-anchor extension change only _when / what fills

--- a/packages/paper/src/editor/theme.ts
+++ b/packages/paper/src/editor/theme.ts
@@ -197,6 +197,10 @@ export const baseTheme = EditorView.theme({
   "&.cm-focused": {
     outline: "none",
   },
+  // Dormant for 1.0: no `drawSelection()` is installed, so CM6 keeps browser-native selection and never
+  // emits `.cm-selectionBackground` — this rule never matches. Kept as the already-wired token path; a
+  // porcelain selection tint is a one-line `drawSelection()` add, deliberately declined (IME risk vs. the
+  // composing guard, and lightness). See DECISIONS.md "Deferred (not bugs) — adjudicated for 1.0" (#481).
   ".cm-selectionBackground, &.cm-focused .cm-selectionBackground": {
     backgroundColor: "var(--accent-sel)",
   },


### PR DESCRIPTION
## What & why

1.0 exit criterion #481 requires every `DECISIONS.md` "Deferred (not bugs)" item to be **resolved or consciously accepted with written rationale**. This adjudicates all three. Each was verified against current code first — they are **accurate, not stale** — and each is recorded with no behavior change.

Reviewed with the beaket ui advisor before and after (pre-work design review + post-work sign-off on the diff).

### The `no open P1/P2 bugs` half
Confirmed clear: the only open P1/P2 `area:paper` issues are the sibling milestone gates #482 (perf) and #483 (CJK/IME real-device) — no actual P1/P2 *bugs* remain.

### Adjudication (three distinct shapes, deliberately not flattened)

- **Physical-key Korean IME spot-check → _redirected_, not a code deferral.** The guarded paths (`setValue`, highlight deferral via `createHighlightController`'s composition hold, coalesced `onSelect`/`activeHighlightId` flush) are verified with synthetic composition events only. Real hardware-IME verification is the deliberate jsdom boundary (ADR-0005) and is owned by the CJK/IME real-device gate (#483, blocked by precursor #479), which now inherits that exact guarded-path checklist. IME stays **delegated and still owed — not verified.**
- **Orphan re-emit on in-session delete + prefix/suffix anchors → _accepted for 1.0_.** Reaffirms ADR-0014 decisions 2/7. Bounded consequence named (stale `exact`/`approximate` status until the next `setHighlights`/reload; the decoration itself is dropped on map). `Anchor` slots and the `onHighlightStatusChange` map are additive-only, so the interface freeze is unblocked. ADR-0014 resumption trigger retained.
- **`.cm-selectionBackground` dormant → _accepted for 1.0_ (browser-native selection).** `drawSelection()` declined: it swaps native selection for a synthetic drawn layer that fights the composing guard (ADR-0004) for a purely cosmetic tint no consumer has requested (lightness). The dead rule is **kept and annotated dormant** at the call site in `theme.ts` — it's the already-wired, dark-aware, consumer-overridable token path, reversible in one line.

## Changes

- `packages/paper/docs/DECISIONS.md` — rewrote the "Deferred (not bugs)" section to record the three dispositions.
- `packages/paper/src/editor/theme.ts` — one behavior-neutral comment marking the `.cm-selectionBackground` rule deliberately dormant, pointing back to DECISIONS.md.
- `.changeset/` — patch changeset (`@beaket/paper`) recording the adjudication.

## Recording mechanism

DECISIONS.md rewrite only — no ADR/amendment: all three **reaffirm** existing decisions (ADR-0005 carve-out, ADR-0014 decisions 2/5/7, the browser-native-selection status quo), so they don't clear the ADR bar.

## Verification

- `pnpm check:adr` — green (all ADR references resolve)
- `tsc --noEmit` (paper) — clean
- `pnpm test` (paper) — 372 tests pass

## Note on #481

This discharges the **actionable** half (the Deferred adjudication) and confirms the bug half. #481 is a 1.0 milestone/`type:arch` gate, so **closing it is left to the maintainer** — after confirming this lands and that #483 carries the inherited IME guarded-path checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Et4giHKg5znc4i3wnrSjGv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Et4giHKg5znc4i3wnrSjGv)_