### PR TITLE
feat(pagination): one instrument — fused strip with a single accent edge (D·3)

### DIFF
--- a/.changeset/pagination-one-instrument.md
+++ b/.changeset/pagination-one-instrument.md
@@ -1,0 +1,17 @@
+---
+"@beaket/ui": minor
+---
+
+feat(pagination): one instrument — fused strip with a single accent edge
+
+Pagination adopts the action shadow, but as one machine rather than a row of
+buttons: cells fuse into a single strip (shared borders, no gaps) carrying one
+static 1px accent edge.
+
+- Strip: new `pagination-strip` slot wraps all cells with `shadow-offset-action`
+- Press: the chassis stays still — the pressed key's label travels 1px inside
+  the frame while the cell darkens (`active:bg-bg-active`)
+- Current page: an ink-solid cell whose label stays held down 1px — the key
+  locked at its landing point
+- Ellipsis becomes a bordered blank key; focus outline lifts above neighboring
+  cell borders

--- a/src/components/pagination.tsx
+++ b/src/components/pagination.tsx
@@ -116,11 +116,18 @@ export function Pagination(props: PaginationProps) {
   };
 
   const pageNumbers = getPageNumbers();
+  // One fused instrument: cells share borders inside a strip that carries a
+  // single static accent edge; pressing a key travels its label 1px inside the
+  // frame, and the current page stays held down.
   const buttonBaseClass =
-    "flex items-center justify-center h-8 px-3 border text-sm transition-colors relative before:absolute before:inset-[-8px] before:content-['']";
-  const buttonActiveClass = "bg-bg-emphasis text-fg-on-emphasis border-border-strong";
-  const buttonInactiveClass = "border-border hover:bg-bg-hover";
+    "group flex items-center justify-center h-8 px-3 -ml-px first:ml-0 border text-sm transition-colors relative before:absolute before:inset-[-8px] before:content-[''] focus-visible:z-[2] focus-visible:outline-2 focus-visible:outline-border-focus focus-visible:outline-offset-2";
+  const buttonActiveClass =
+    "bg-bg-emphasis text-fg-on-emphasis border-border-strong z-[1] cursor-default before:hidden";
+  const buttonInactiveClass = "border-border cursor-pointer hover:bg-bg-hover active:bg-bg-active";
   const buttonDisabledClass = "border-border-muted text-fg-disabled cursor-not-allowed";
+  const keyClass =
+    "inline-block transition-transform duration-100 group-active:translate-x-px group-active:translate-y-px";
+  const heldKeyClass = "inline-block translate-x-px translate-y-px";
 
   const hasPrev = page > 1;
   const hasNext = page < totalPages;
@@ -128,122 +135,143 @@ export function Pagination(props: PaginationProps) {
   return (
     <nav
       data-slot="pagination"
-      className={cn("flex items-center justify-center gap-1", className)}
+      className={cn("flex items-center justify-center", className)}
       aria-label="Pagination"
     >
-      {/* Previous button */}
-      {isButtonMode ? (
-        <button
-          type="button"
-          data-slot="pagination-prev"
-          className={cn(buttonBaseClass, hasPrev ? buttonInactiveClass : buttonDisabledClass)}
-          disabled={!hasPrev}
-          onClick={() => hasPrev && props.onPageChange(page - 1)}
-          aria-label="Previous page"
-        >
-          <ChevronLeft className="h-4 w-4" />
-        </button>
-      ) : hasPrev ? (
-        <a
-          data-slot="pagination-prev"
-          href={props.buildPageUrl(page - 1)}
-          className={cn(buttonBaseClass, buttonInactiveClass)}
-          aria-label="Previous page"
-        >
-          <ChevronLeft className="h-4 w-4" />
-        </a>
-      ) : (
-        <span
-          data-slot="pagination-prev"
-          className={cn(buttonBaseClass, buttonDisabledClass)}
-          role="link"
-          aria-disabled="true"
-          aria-label="Previous page"
-        >
-          <ChevronLeft className="h-4 w-4" />
-        </span>
-      )}
-
-      {/* Page numbers */}
-      {pageNumbers.map((pageNum) => {
-        if (pageNum === "ellipsis-start" || pageNum === "ellipsis-end") {
-          return (
-            <span
-              key={pageNum}
-              data-slot="pagination-ellipsis"
-              className="text-fg-subtle px-2 py-1"
-              aria-hidden="true"
-            >
-              ...
+      <div data-slot="pagination-strip" className="shadow-offset-action flex items-center">
+        {/* Previous button */}
+        {isButtonMode ? (
+          <button
+            type="button"
+            data-slot="pagination-prev"
+            className={cn(buttonBaseClass, hasPrev ? buttonInactiveClass : buttonDisabledClass)}
+            disabled={!hasPrev}
+            onClick={() => hasPrev && props.onPageChange(page - 1)}
+            aria-label="Previous page"
+          >
+            {hasPrev ? (
+              <span className={keyClass}>
+                <ChevronLeft className="h-4 w-4" />
+              </span>
+            ) : (
+              <ChevronLeft className="h-4 w-4" />
+            )}
+          </button>
+        ) : hasPrev ? (
+          <a
+            data-slot="pagination-prev"
+            href={props.buildPageUrl(page - 1)}
+            className={cn(buttonBaseClass, buttonInactiveClass)}
+            aria-label="Previous page"
+          >
+            <span className={keyClass}>
+              <ChevronLeft className="h-4 w-4" />
             </span>
-          );
-        }
+          </a>
+        ) : (
+          <span
+            data-slot="pagination-prev"
+            className={cn(buttonBaseClass, buttonDisabledClass)}
+            role="link"
+            aria-disabled="true"
+            aria-label="Previous page"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </span>
+        )}
 
-        const isCurrentPage = pageNum === page;
+        {/* Page numbers */}
+        {pageNumbers.map((pageNum) => {
+          if (pageNum === "ellipsis-start" || pageNum === "ellipsis-end") {
+            return (
+              <span
+                key={pageNum}
+                data-slot="pagination-ellipsis"
+                className="text-fg-subtle border-border -ml-px flex h-8 items-center justify-center border px-3 select-none"
+                aria-hidden="true"
+              >
+                ...
+              </span>
+            );
+          }
 
-        if (isButtonMode) {
+          const isCurrentPage = pageNum === page;
+
+          if (isButtonMode) {
+            return (
+              <button
+                key={pageNum}
+                type="button"
+                data-slot="pagination-page"
+                className={cn(
+                  buttonBaseClass,
+                  isCurrentPage ? buttonActiveClass : buttonInactiveClass,
+                )}
+                onClick={() => props.onPageChange(pageNum)}
+                aria-current={isCurrentPage ? "page" : undefined}
+              >
+                <span className={isCurrentPage ? heldKeyClass : keyClass}>{pageNum}</span>
+              </button>
+            );
+          }
+
           return (
-            <button
+            <a
               key={pageNum}
-              type="button"
               data-slot="pagination-page"
+              href={props.buildPageUrl(pageNum)}
               className={cn(
                 buttonBaseClass,
                 isCurrentPage ? buttonActiveClass : buttonInactiveClass,
               )}
-              onClick={() => props.onPageChange(pageNum)}
               aria-current={isCurrentPage ? "page" : undefined}
             >
-              {pageNum}
-            </button>
+              <span className={isCurrentPage ? heldKeyClass : keyClass}>{pageNum}</span>
+            </a>
           );
-        }
+        })}
 
-        return (
-          <a
-            key={pageNum}
-            data-slot="pagination-page"
-            href={props.buildPageUrl(pageNum)}
-            className={cn(buttonBaseClass, isCurrentPage ? buttonActiveClass : buttonInactiveClass)}
-            aria-current={isCurrentPage ? "page" : undefined}
+        {/* Next button */}
+        {isButtonMode ? (
+          <button
+            type="button"
+            data-slot="pagination-next"
+            className={cn(buttonBaseClass, hasNext ? buttonInactiveClass : buttonDisabledClass)}
+            disabled={!hasNext}
+            onClick={() => hasNext && props.onPageChange(page + 1)}
+            aria-label="Next page"
           >
-            {pageNum}
+            {hasNext ? (
+              <span className={keyClass}>
+                <ChevronRight className="h-4 w-4" />
+              </span>
+            ) : (
+              <ChevronRight className="h-4 w-4" />
+            )}
+          </button>
+        ) : hasNext ? (
+          <a
+            data-slot="pagination-next"
+            href={props.buildPageUrl(page + 1)}
+            className={cn(buttonBaseClass, buttonInactiveClass)}
+            aria-label="Next page"
+          >
+            <span className={keyClass}>
+              <ChevronRight className="h-4 w-4" />
+            </span>
           </a>
-        );
-      })}
-
-      {/* Next button */}
-      {isButtonMode ? (
-        <button
-          type="button"
-          data-slot="pagination-next"
-          className={cn(buttonBaseClass, hasNext ? buttonInactiveClass : buttonDisabledClass)}
-          disabled={!hasNext}
-          onClick={() => hasNext && props.onPageChange(page + 1)}
-          aria-label="Next page"
-        >
-          <ChevronRight className="h-4 w-4" />
-        </button>
-      ) : hasNext ? (
-        <a
-          data-slot="pagination-next"
-          href={props.buildPageUrl(page + 1)}
-          className={cn(buttonBaseClass, buttonInactiveClass)}
-          aria-label="Next page"
-        >
-          <ChevronRight className="h-4 w-4" />
-        </a>
-      ) : (
-        <span
-          data-slot="pagination-next"
-          className={cn(buttonBaseClass, buttonDisabledClass)}
-          role="link"
-          aria-disabled="true"
-          aria-label="Next page"
-        >
-          <ChevronRight className="h-4 w-4" />
-        </span>
-      )}
+        ) : (
+          <span
+            data-slot="pagination-next"
+            className={cn(buttonBaseClass, buttonDisabledClass)}
+            role="link"
+            aria-disabled="true"
+            aria-label="Next page"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </span>
+        )}
+      </div>
     </nav>
   );
 }


### PR DESCRIPTION
## What

Pagination adopts the G·1 action shadow (#636), but as **one machine rather than a row of buttons** — the second component in the solace sweep.

- **Strip** — a new `pagination-strip` slot fuses all cells (shared borders, no gaps) and carries a single static 1px `shadow-offset-action` accent edge
- **Press** — the chassis stays still; the pressed key's label travels 1px inside the frame (`group-active:translate`) while the cell darkens (`active:bg-bg-active`)
- **Current page** — an ink-solid cell whose label stays held down 1px: the key locked at its landing point
- **Ellipsis** — promoted from bare text to a bordered blank key
- Cells gain the standard focus-visible outline pattern, lifted (`z-[2]`) above neighboring cell borders; the current cell drops its `before` touch-target extension so its `z-[1]` doesn't steal clicks from adjacent keys; disabled cells (including link-mode spans) never travel

## Why this shape

Chosen via the candidate-board loop (P·A Every Key / P·B Edge on Approach / P·C Held Key / P·D One Instrument, then 4 real-use variations of P·D). Concentrating the voice into one edge keeps the accent from turning into noise across eight fused pressables, and the held-down current key states "you are here" with physics instead of color alone.

## Verification

- `tsc --noEmit` clean
- Pagination story interaction tests 14/14 pass (link + button modes, disabled bounds, aria-current)
- Storybook visual QA at 6006 (AllStates + Overview), confirmed by @jihnma

Changeset: `@beaket/ui` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M8TJKZycXhCNFNFY2QsxY