### PR TITLE
feat(checkbox, switch, radio): instrument grammar — static accent edge, keys travel (K·4 + B)

### DIFF
--- a/.changeset/small-controls-instrument.md
+++ b/.changeset/small-controls-instrument.md
@@ -1,0 +1,16 @@
+---
+"@beaket/ui": minor
+---
+
+feat(checkbox, switch, radio): instrument grammar — static accent edge on small controls
+
+Small controls adopt the action shadow as instruments: the chassis floats on a
+static 1px accent edge (`shadow-offset-action`, no hover growth, no drop), and
+press physics belong to the inner key instead — the checkbox indicator and the
+switch thumb travel 1px under the press. Hover feedback is a surface tint
+(`bg-bg-hover` unchecked, `bg-bg-emphasis-hover` checked); a checked radio gets
+no press affordance since it cannot be unchecked. Disabled removes the edge.
+
+Switch checked also moves from `bg-success-solid` to ink (`bg-bg-emphasis`),
+matching checkbox/radio — state is carried by thumb position + ink, and the
+success role returns to meaning outcomes, not "on".

--- a/.impeccable.md
+++ b/.impeccable.md
@@ -12,7 +12,7 @@ Indie developers, solo founders, and small product teams at startups who want a 
 
 **Brutalist.** Sharp corners, flat colors, offset shadows, system fonts. The design language is industrial: borders are visible, states are obvious, hierarchy is structural not decorative. Think concrete architecture — raw materials, visible construction, beauty through honesty of form.
 
-**The shadow layer is the voice layer.** Elevation is drawn, not lit — and its ink is semantic. Surfaces (cards, overlays) cast a quiet grey shade; anything you can press carries a thin, sharp **accent edge** instead — the theme's one vivid voice living under every pressable thing. Hover grows the edge; pressing drops the control onto it. Softness of the paper, sharpness of the edge, both at once.
+**The shadow layer is the voice layer.** Elevation is drawn, not lit — and its ink is semantic. Surfaces (cards, overlays) cast a quiet grey shade; anything you can press carries a thin, sharp **accent edge** instead — the theme's one vivid voice living under every pressable thing. Hover grows the edge; pressing drops the control onto it. Small controls and fused strips are **instruments**: the chassis holds a static edge while the inner key — a check, a thumb, a label — travels 1px under the press. Softness of the paper, sharpness of the edge, both at once.
 
 **Anti-references (what this must NOT look like):**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Brutalist design system. No gradients, no border-radius (except Radio), no blur 
 
 Roles: `danger`, `success`, `warning`, `info`, `info-alt`, `accent` — 7 slots each (`-solid`, `-fg-on-solid`, `-solid-hover`, `-solid-active`, `-fg`, `-bg`, `-border`).
 
-Shadow states — pressables: rest = thin accent edge (`shadow-offset-action`), hover grows (`hover:shadow-offset-action-hover`), active drops onto the edge (`active:shadow-none active:translate-x-px active:translate-y-px`), disabled `none`. Surfaces keep the static grey `shadow-offset` / `-overlay`. Sizes vary by theme (solace: 1px).
+Shadow states — pressables: rest = thin accent edge (`shadow-offset-action`), hover grows (`hover:shadow-offset-action-hover`), active drops onto the edge (`active:shadow-none active:translate-x-px active:translate-y-px`), disabled `none`. Instruments (small controls: checkbox/switch/radio; fused strips: pagination): the chassis keeps a **static** accent edge (no hover growth, no drop) and pressing travels the inner key (indicator/thumb/label) 1px instead; hover is a surface tint. Surfaces keep the static grey `shadow-offset` / `-overlay`. Sizes vary by theme (solace: 1px).
 
 ## Component Template
 

--- a/src/components/checkbox.tsx
+++ b/src/components/checkbox.tsx
@@ -16,11 +16,14 @@ export function Checkbox({ className, ...props }: Props) {
       data-slot="checkbox"
       className={cn(
         "group peer border-border-strong relative size-4 shrink-0 border before:absolute before:inset-[-14px] before:content-['']",
-        "bg-bg-input",
+        // Instrument grammar: the chassis floats on a static accent edge; press
+        // physics belong to the indicator (the key), not the box.
+        "bg-bg-input shadow-offset-action cursor-pointer transition-colors duration-100",
+        "enabled:data-[state=unchecked]:hover:bg-bg-hover enabled:data-[state=unchecked]:active:bg-bg-active",
         "focus-visible:outline-border-focus focus-visible:outline-2 focus-visible:outline-offset-2",
-        "data-[state=checked]:border-border-strong data-[state=checked]:bg-bg-emphasis data-[state=checked]:text-fg-on-emphasis",
-        "data-[state=indeterminate]:border-border-strong data-[state=indeterminate]:bg-bg-emphasis data-[state=indeterminate]:text-fg-on-emphasis",
-        "disabled:border-border-muted disabled:bg-bg-disabled disabled:text-fg-disabled disabled:hover:border-border-muted disabled:cursor-not-allowed disabled:border-dashed",
+        "data-[state=checked]:border-border-strong data-[state=checked]:bg-bg-emphasis data-[state=checked]:text-fg-on-emphasis enabled:data-[state=checked]:hover:bg-bg-emphasis-hover",
+        "data-[state=indeterminate]:border-border-strong data-[state=indeterminate]:bg-bg-emphasis data-[state=indeterminate]:text-fg-on-emphasis enabled:data-[state=indeterminate]:hover:bg-bg-emphasis-hover",
+        "disabled:border-border-muted disabled:bg-bg-disabled disabled:text-fg-disabled disabled:hover:border-border-muted disabled:cursor-not-allowed disabled:border-dashed disabled:shadow-none",
         "disabled:data-[state=checked]:border-border-muted disabled:data-[state=checked]:bg-bg-disabled disabled:data-[state=checked]:text-fg-disabled",
         "aria-[invalid=true]:border-danger-solid aria-[invalid=true]:focus-visible:outline-danger-solid",
         className,
@@ -29,7 +32,7 @@ export function Checkbox({ className, ...props }: Props) {
     >
       <CheckboxPrimitive.Indicator
         data-slot="checkbox-indicator"
-        className="flex items-center justify-center text-current"
+        className="flex items-center justify-center text-current transition-transform duration-100 group-active:translate-x-px group-active:translate-y-px"
       >
         <Check className="size-3 group-data-[state=indeterminate]:hidden" />
         <Minus className="hidden size-3 group-data-[state=indeterminate]:block" />

--- a/src/components/radio.tsx
+++ b/src/components/radio.tsx
@@ -30,11 +30,14 @@ export function RadioItem({ className, ...props }: RadioItemProps) {
       data-slot="radio-item"
       className={cn(
         "group peer border-border-strong relative size-4 shrink-0 rounded-full border before:absolute before:inset-[-14px] before:content-['']",
-        "bg-bg-input",
-        "hover:border-border",
+        // Instrument grammar: static accent edge on the chassis; hover/press
+        // feedback is a surface tint. A checked radio can't be unchecked, so it
+        // gets no press affordance.
+        "bg-bg-input shadow-offset-action cursor-pointer transition-colors duration-100",
+        "enabled:data-[state=unchecked]:hover:bg-bg-hover enabled:data-[state=unchecked]:active:bg-bg-active",
         "focus-visible:outline-border-focus focus-visible:outline-2 focus-visible:outline-offset-2",
-        "data-[state=checked]:border-border-strong",
-        "disabled:border-border-muted disabled:bg-bg-disabled disabled:text-fg-disabled disabled:hover:border-border-muted disabled:cursor-not-allowed disabled:border-dashed",
+        "data-[state=checked]:border-border-strong data-[state=checked]:cursor-default",
+        "disabled:border-border-muted disabled:bg-bg-disabled disabled:text-fg-disabled disabled:hover:border-border-muted disabled:cursor-not-allowed disabled:border-dashed disabled:shadow-none",
         "disabled:data-[state=checked]:border-border-muted",
         "aria-[invalid=true]:border-danger-solid aria-[invalid=true]:focus-visible:outline-danger-solid",
         className,

--- a/src/components/switch.tsx
+++ b/src/components/switch.tsx
@@ -5,8 +5,11 @@ import { twMerge } from "tailwind-merge";
 
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
+// Instrument grammar: the track floats on a static accent edge; pressing
+// travels the thumb (the key) 1px instead of dropping the chassis. Checked
+// fills with ink — state is carried by thumb position + ink, not a signal role.
 const switchVariants = cva(
-  "group peer inline-flex shrink-0 cursor-pointer items-center p-0.5 transition-colors outline-none data-[state=checked]:bg-success-solid data-[state=unchecked]:bg-border-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-border-focus disabled:cursor-not-allowed disabled:border-dashed disabled:border-border-muted disabled:bg-bg-disabled disabled:text-fg-disabled disabled:data-[state=checked]:bg-bg-disabled border border-border-strong relative before:absolute before:inset-[-14px] before:content-['']",
+  "group peer inline-flex shrink-0 cursor-pointer items-center p-0.5 transition-colors duration-100 outline-none shadow-offset-action data-[state=checked]:bg-bg-emphasis enabled:data-[state=checked]:hover:bg-bg-emphasis-hover data-[state=unchecked]:bg-border-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-border-focus disabled:shadow-none disabled:cursor-not-allowed disabled:border-dashed disabled:border-border-muted disabled:bg-bg-disabled disabled:text-fg-disabled disabled:data-[state=checked]:bg-bg-disabled border border-border-strong relative before:absolute before:inset-[-14px] before:content-['']",
   {
     variants: {
       size: {
@@ -22,13 +25,13 @@ const switchVariants = cva(
 );
 
 const switchThumbVariants = cva(
-  "pointer-events-none block bg-bg-input group-disabled:bg-border-muted ring-0 transition-transform data-[state=unchecked]:translate-x-0",
+  "pointer-events-none block bg-bg-input group-disabled:bg-border-muted ring-0 transition-transform data-[state=unchecked]:translate-x-0 group-active:translate-y-px group-active:data-[state=unchecked]:translate-x-px",
   {
     variants: {
       size: {
-        sm: "size-2 data-[state=checked]:translate-x-4",
-        md: "size-2.5 data-[state=checked]:translate-x-5",
-        lg: "size-3.5 data-[state=checked]:translate-x-6",
+        sm: "size-2 data-[state=checked]:translate-x-4 group-active:data-[state=checked]:translate-x-[17px]",
+        md: "size-2.5 data-[state=checked]:translate-x-5 group-active:data-[state=checked]:translate-x-[21px]",
+        lg: "size-3.5 data-[state=checked]:translate-x-6 group-active:data-[state=checked]:translate-x-[25px]",
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## What

Round 3 of the Solace G·1 action-shadow sweep: the small-control family (checkbox · switch · radio) adopts the accent edge with the **instrument grammar** (spec-board candidate K·4), plus the side decision **B** — switch checked ink.

- **Static chassis edge**: all three controls float on a static 1px `shadow-offset-action` — no hover growth, no chassis drop. Disabled removes the edge (existing dashed pattern unchanged).
- **Press physics live on the inner key**: the checkbox indicator and the switch thumb travel 1px under the press (`group-active`); the chassis stays put, like the pagination strip (D·3).
- **Hover is a surface tint**: `bg-bg-hover` on unchecked, `bg-bg-emphasis-hover` on checked (checkbox/switch). A checked radio can't be unchecked, so it gets `cursor-default` and no press affordance.
- **Switch checked: success green → ink** (`bg-bg-emphasis`). State is carried by thumb position + ink; the success role returns to meaning outcomes, not "on". This also un-anchors the switch from whatever green other themes carry.
- Small controls gain `cursor-pointer` (they never had it; now they're voiced pressables).
- CLAUDE.md / `.impeccable.md`: documented the instrument grammar as the precedent for fused strips and small controls.

## Why K·4

Chosen on the spec board over verbatim button physics (K·1) and latching-checked variants (K·2/K·3): the boundary now reads *enterable = quiet, pressable = edged* — inputs/textarea/select stay grey while every pressable control carries the one vivid voice, and press feedback stays inside the chassis so a dense form doesn't shimmer.

## Verification

- vitest 261/262 — the one failure is the pre-existing avatar fallback test (baseline unchanged)
- `tsc --noEmit` clean
- Storybook-verified (Checkbox/Radio/Switch AllStates + Overview kitchen sink): accent edge on all three, disabled edge removal, hover tint computed `#f3f4f2`, checked switch computed `#05070c`, `group-active` travel rules win the cascade over the checked base translate (specificity checked in CSSOM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M8TJKZycXhCNFNFY2QsxY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Refined checkbox, switch, and radio interactions with clearer hover and press feedback.
  * Added subtle 1px movement to inner indicators and switch thumbs during presses.
  * Updated checked-state styling for switches and radios for improved visual consistency.
  * Improved disabled-state appearance by reducing active visual emphasis.
  * Added smoother transitions and more precise cursor behavior for small controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->