### PR TITLE
docs(impeccable): Ink & Instrument — identity rewrite, brutalism demoted to influence

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -2,7 +2,7 @@
 
 ### Users
 
-Indie developers, solo founders, and small product teams at startups who want a UI library with a strong design opinion. They're building SaaS products, side projects, and production apps where visual identity matters. They specifically chose brutalist aesthetics — this isn't a fallback, it's an intentional rejection of the polished-everything trend.
+Indie developers, solo founders, and small product teams at startups who want a UI library with a strong design opinion. They're building SaaS products, side projects, and production apps where visual identity matters. They specifically chose a drawn, opinionated aesthetic — this isn't a fallback, it's an intentional rejection of the polished-everything trend.
 
 ### Brand Personality
 
@@ -10,9 +10,13 @@ Indie developers, solo founders, and small product teams at startups who want a 
 
 ### Aesthetic Direction
 
-**Brutalist.** Sharp corners, flat colors, offset shadows, system fonts. The design language is industrial: borders are visible, states are obvious, hierarchy is structural not decorative. Think concrete architecture — raw materials, visible construction, beauty through honesty of form.
+**Ink & Instrument.** A printed page you can press. Everything on screen is drawn, not lit: sharp corners, flat color, borders as pen strokes, shadows as offset marks. The reference isn't concrete architecture — it's the print shop and the machine shop: a well-set page, ruled forms, keys that travel when pressed.
+
+**One pen.** The neutral ramp is a single ink. Text, strong borders, and solid fills come from the same pen (tone-11), so lines and fills always agree about what matters. Ink is never diluted, only rationed: a stroke speaks in the ink voice or the hairline voice — there is no middle grey. (Measured, not asserted: at 1px, darkness reads as a switch, not a dial — a "slightly softer black" does not exist at hairline width.) Hue carries meaning but never emphasis; the one vivid voice — the accent — belongs solely to what you can act on.
 
 **The shadow layer is the voice layer.** Elevation is drawn, not lit — and its ink is semantic. Surfaces (cards, overlays) cast a quiet grey shade; anything you can press carries a thin, sharp **accent edge** instead — the theme's one vivid voice living under every pressable thing. Hover grows the edge; pressing drops the control onto it. Small controls and fused strips are **instruments**: the chassis holds a static edge while the inner key — a check, a thumb, a label — travels 1px under the press. Softness of the paper, sharpness of the edge, both at once.
+
+**Brutalism is an influence here, not the identity.** We keep its refusals — no gradients, no blur, no rounding, nothing that lies about structure — because print keeps them too. We don't keep its aggression: the goal is not rawness but precision. When a decision feels ambiguous, don't ask "is this brutalist enough?" Ask: is the stroke precise, is the metaphor complete, is there still one pen and one vivid voice?
 
 **Anti-references (what this must NOT look like):**
 
@@ -20,6 +24,7 @@ Indie developers, solo founders, and small product teams at startups who want a 
 - Material Design — too corporate, too systematic, too Google
 - Stripe/Linear — too polished, too aspirational, not raw enough
 - Bootstrap — too generic, no design point of view
+- Web-brutalism showcases — aggression as the point; we keep the refusals, not the shout
 
 **Emotional goals:** Users should feel confidence and clarity (I know exactly what's happening), respect for craft (someone cared about this), and edgy distinction (this looks different — in a good way).
 


### PR DESCRIPTION
## What

Rewrites the identity sections of `.impeccable.md`:

- **Aesthetic Direction** — the "Brutalist / concrete architecture" paragraph is replaced by **Ink & Instrument** (print shop + machine shop metaphor) and a new **One pen** paragraph. The existing "shadow layer is the voice layer" paragraph is kept verbatim — it was already the new language.
- **New closing paragraph** — *"Brutalism is an influence here, not the identity"*: keep the refusals (no gradients, no blur, no rounding), drop the aggression, and replace the old tiebreaker question ("is this brutalist enough?") with three new ones: is the stroke precise, is the metaphor complete, is there still one pen and one vivid voice?
- **Users** — "brutalist aesthetics" → "a drawn, opinionated aesthetic" (the rejection stance is unchanged).
- **Anti-references** — adds web-brutalism showcases ("we keep the refusals, not the shout").

## Why

A border-experiment session (artifact loop, verified in-browser with computed styles) tried to soften the black `border-strong` and failed in every direction — the current ink won all head-to-heads. Two measured principles came out of it and are now recorded in the One pen paragraph:

1. At 1px hairline width, darkness reads as a **switch, not a dial** (tone-10/9 are indistinguishable from black; tone-8/7 from each other). A "slightly softer black" does not exist.
2. **Lines and fills must agree** — greying borders while text/fills stay ink reads as noise. Ink is rationed, never diluted.

The friction was never the ink; it was the label. The doc's own newest sentence ("Softness of the paper, sharpness of the edge") already wasn't brutalism.

## Out of scope

Outward-facing labels follow in a separate commit once wording is decided: `CLAUDE.md:24`, `README.md:3`, `packages/cli/README.md:3`, docs site (`index.astro`/`doc.astro` meta, `design-rules.astro` intro).

No changeset: repo-root design doc, ships in no package tarball (changeset-check is scoped to `src/**`/`packages/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M8TJKZycXhCNFNFY2QsxY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the design guidance to define an “Ink & Instrument” visual direction centered on a single ink-inspired voice and accent edges.
  * Refined the intended audience description.
  * Added web-brutalism showcases to the list of visual references to avoid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->