### PR TITLE
feat(button): edge-grammar refinements + variant/prop cleanup

### DIFF
--- a/.changeset/button-ghost-link-no-edge.md
+++ b/.changeset/button-ghost-link-no-edge.md
@@ -1,0 +1,19 @@
+---
+"@beaket/ui": patch
+---
+
+fix(button): ghost and link no longer leak the accent edge
+
+Ghost and link were meant to have no accent edge, but the base applied
+`shadow-offset-action` to every variant and their `shadow-none` override never
+won — twMerge can't dedupe a custom shadow utility against `shadow-none`, so both
+classes survived and the custom edge won the cascade. Ghost showed a blue 1px
+edge at rest (and grew it on hover); link wore a button edge instead of reading
+as a link.
+
+The accent edge now lives on the variants that carry it (via a shared `edge`
+string appended to primary/destructive/outline/secondary/success/stark/warning)
+rather than on the base, so ghost and link simply omit it — kept out, not
+overridden. Ghost is now fully quiet (ink text, grey hover fill, no edge); link
+reads as a link (accent text, hover underline, no edge). Edged variants are
+unchanged. No token or palette change.

--- a/.changeset/button-outline-airy-hover.md
+++ b/.changeset/button-outline-airy-hover.md
@@ -1,0 +1,14 @@
+---
+"@beaket/ui": patch
+---
+
+fix(button): outline hovers on the accent edge, not a grey fill
+
+The outline button was airy at rest but filled with a grey wash on hover
+(`hover:bg-bg-hover`) on top of its accent edge growing — two signals at once,
+and the fill read as muddy against the paper. Outline now drops the grey fill on
+hover and held-open and leans on the accent edge it already grows (from the base
+grammar); the press keeps a faint grey settle (`active:bg-bg-active`) to confirm
+the drop. Ghost is unchanged: with no edge, its grey fill is its only hover
+signal. No token or palette change — `bg-hover` is a shared, already-light token;
+this was a grammar fix, not a color one.

--- a/.changeset/button-primary-light-rim.md
+++ b/.changeset/button-primary-light-rim.md
@@ -1,0 +1,21 @@
+---
+"@beaket/ui": minor
+---
+
+feat(button): primary wears a light rim that sheds on engage
+
+The primary button's rest edge no longer doubles. Its border was the full accent
+(`border-accent-solid`) sitting directly over the full accent shadow — the same
+blue on both, so the two 1px lines merged into one thick 2px band on the bottom
+and right. The border now takes the lighter accent tone (`border-accent-border`),
+so at rest the light rim and the full-accent shadow read as two tones — depth,
+not a doubled line — with the strong voice living in the shadow where it grows
+and drops.
+
+On engage the rim sheds: `hover:border-transparent` (and `data-[state=open]`
+mirrors it) drops the rim into the ink fill so the accent consolidates into the
+one growing shadow rather than piling into a thick accent band. The border is
+added to the shared transition (`transition-[box-shadow,translate,border-color]`)
+so the rim fades with the shadow instead of snapping — which also smooths the
+hover border-color change on the other bordered variants. No new tokens; other
+variants and the rest/hover/press/held-open shadow grammar are unchanged.

--- a/.changeset/button-remove-mono.md
+++ b/.changeset/button-remove-mono.md
@@ -1,0 +1,15 @@
+---
+"@beaket/ui": minor
+---
+
+feat(button): remove the `mono` prop
+
+The `mono` prop (monospace + wide tracking for CTA-style text) had no documented
+role in the Ink & Instrument vocabulary, was demonstrated only by an orphan
+`MonoVariants` composition the docs never rendered (plus a redundant single
+story), and was a Button-only flourish. Monospace lives on where it means
+something — code badges, numeric table cells — not as a per-button toggle.
+
+The `mono` prop is dropped from `Button` along with its `Mono` and `MonoVariants`
+stories. Consumers who want monospace CTA text can pass `className="font-mono
+tracking-wide"`. Since components are copy-paste, existing copies are unaffected.

--- a/.changeset/button-remove-stark.md
+++ b/.changeset/button-remove-stark.md
@@ -1,0 +1,15 @@
+---
+"@beaket/ui": minor
+---
+
+feat(button): remove the `stark` variant
+
+`stark` (a strong-bordered button that inverted to solid ink on hover) had no
+documented role in the Ink & Instrument vocabulary — it appeared nowhere in the
+design docs, was used only as a demo trigger in stories, and overlapped with
+`outline` (bordered neutral) and `primary` (solid ink). In a system where every
+mark is meant to be deliberate, an unarticulated variant is a cut, not a keeper.
+
+The `variant` union drops `"stark"`; the demo triggers that used it (dialog,
+sheet, dropdown-menu stories) move to `outline`. Since components are copy-paste,
+existing consumer copies are unaffected; new copies simply won't include it.

--- a/src/components/button.stories.tsx
+++ b/src/components/button.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { ReactNode } from "react";
 import { expect, fn, userEvent, within } from "storybook/test";
 import { Button } from "./button";
 
@@ -17,7 +18,6 @@ const meta: Meta<typeof Button> = {
         "ghost",
         "link",
         "success",
-        "stark",
         "warning",
       ],
     },
@@ -31,111 +31,18 @@ const meta: Meta<typeof Button> = {
     disabled: {
       control: "boolean",
     },
-    mono: {
-      control: "boolean",
-    },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Button>;
 
-export const Primary: Story = {
+// The interactive playground — pick any variant/size/state via Controls.
+// Per-variant/size/state examples live in the AllVariants/AllSizes/AllStates
+// compositions below (also what the docs site renders).
+export const Default: Story = {
   args: {
     children: "Button",
-    variant: "primary",
-  },
-};
-
-export const Destructive: Story = {
-  args: {
-    children: "Delete",
-    variant: "destructive",
-  },
-};
-
-export const Outline: Story = {
-  args: {
-    children: "Button",
-    variant: "outline",
-  },
-};
-
-export const Secondary: Story = {
-  args: {
-    children: "Button",
-    variant: "secondary",
-  },
-};
-
-export const Ghost: Story = {
-  args: {
-    children: "Button",
-    variant: "ghost",
-  },
-};
-
-export const Link: Story = {
-  args: {
-    children: "Link",
-    variant: "link",
-  },
-};
-
-export const Success: Story = {
-  args: {
-    children: "Save",
-    variant: "success",
-  },
-};
-
-export const Stark: Story = {
-  args: {
-    children: "Button",
-    variant: "stark",
-  },
-};
-
-export const Warning: Story = {
-  args: {
-    children: "Warning",
-    variant: "warning",
-  },
-};
-
-export const Mono: Story = {
-  args: {
-    children: "SUBMIT",
-    variant: "success",
-    mono: true,
-  },
-};
-
-export const Loading: Story = {
-  args: {
-    children: "Loading",
-    loading: true,
-  },
-};
-
-export const Disabled: Story = {
-  args: {
-    children: "Disabled",
-    disabled: true,
-  },
-};
-
-export const Small: Story = {
-  args: {
-    children: "Small",
-    size: "sm",
-  },
-};
-
-export const Large: Story = {
-  args: {
-    children: "Large",
-    size: "lg",
   },
 };
 
@@ -149,25 +56,7 @@ export const AllVariants = () => (
     <Button variant="ghost">Ghost</Button>
     <Button variant="link">Link</Button>
     <Button variant="success">Success</Button>
-    <Button variant="stark">Stark</Button>
     <Button variant="warning">Warning</Button>
-  </div>
-);
-
-export const MonoVariants = () => (
-  <div className="flex flex-wrap gap-2">
-    <Button variant="primary" mono>
-      SIGN IN
-    </Button>
-    <Button variant="success" mono>
-      SUBMIT
-    </Button>
-    <Button variant="destructive" mono>
-      DELETE
-    </Button>
-    <Button variant="warning" mono>
-      CONFIRM
-    </Button>
   </div>
 );
 
@@ -180,10 +69,66 @@ export const AllSizes = () => (
   </div>
 );
 
+// Interaction states across the edge grammar the system is built on — what a
+// static "disabled + loading" row can't show. Two variants, because the grammar
+// differs on engage: primary sheds its rim and darkens its ink fill; outline
+// stays airy, growing only its edge, with a faint grey settle on press.
+//   Hover / Held-open: forced with data-state="open" — real styles, since the
+//     component's data-[state=open]: rules mirror its hover: rules by design.
+//   Pressed: the active declarations reconstructed with the component's own
+//     tokens; box-shadow and transform go inline, as :active can't hold statically.
+const StateCell = ({ label, children }: { label: string; children: ReactNode }) => (
+  <div className="flex flex-col items-center gap-2">
+    {children}
+    <span className="text-fg-subtle text-xs">{label}</span>
+  </div>
+);
+
+const StateRow = ({
+  variant,
+  pressedClassName,
+}: {
+  variant: "primary" | "outline";
+  pressedClassName: string;
+}) => (
+  <div className="flex flex-col gap-3">
+    <span className="text-fg-muted text-sm font-medium">{variant}</span>
+    <div className="flex flex-wrap items-start gap-6">
+      <StateCell label="Rest">
+        <Button variant={variant}>Button</Button>
+      </StateCell>
+      <StateCell label="Hover / Held-open">
+        <Button variant={variant} data-state="open">
+          Button
+        </Button>
+      </StateCell>
+      <StateCell label="Pressed">
+        <Button
+          variant={variant}
+          className={pressedClassName}
+          style={{ boxShadow: "none", transform: "translate(1px, 1px)" }}
+        >
+          Button
+        </Button>
+      </StateCell>
+      <StateCell label="Disabled">
+        <Button variant={variant} disabled>
+          Button
+        </Button>
+      </StateCell>
+      <StateCell label="Loading">
+        <Button variant={variant} loading>
+          Button
+        </Button>
+      </StateCell>
+    </div>
+  </div>
+);
+
 export const AllStates = () => (
-  <div className="flex gap-2">
-    <Button disabled>Disabled</Button>
-    <Button loading>Loading</Button>
+  <div className="flex flex-col gap-8">
+    <StateRow variant="primary" pressedClassName="border-transparent bg-bg-emphasis-active" />
+    <StateRow variant="outline" pressedClassName="bg-bg-active" />
   </div>
 );
 

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -6,23 +6,13 @@ import { twMerge } from "tailwind-merge";
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
 export interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  /** primary | secondary | destructive | outline | ghost | link | success | stark | warning. Button style variant */
+  /** primary | secondary | destructive | outline | ghost | link | success | warning. Button style variant */
   variant?:
-    | "primary"
-    | "destructive"
-    | "outline"
-    | "secondary"
-    | "ghost"
-    | "link"
-    | "success"
-    | "stark"
-    | "warning";
+    "primary" | "destructive" | "outline" | "secondary" | "ghost" | "link" | "success" | "warning";
   /** sm | md | lg | icon. Button size */
   size?: "sm" | "md" | "lg" | "icon";
   /** Shows a loading spinner and disables the button */
   loading?: boolean;
-  /** Use monospace font for CTA-style text */
-  mono?: boolean;
   /** Merges props onto the immediate child element instead of rendering a button */
   asChild?: boolean;
 }
@@ -34,7 +24,6 @@ export function Button({
   loading,
   disabled,
   children,
-  mono = false,
   asChild = false,
   type,
   ...props
@@ -44,7 +33,7 @@ export function Button({
   return (
     <Comp
       data-slot="button"
-      className={cn(buttonVariants({ variant, size, mono }), className)}
+      className={cn(buttonVariants({ variant, size }), className)}
       type={!asChild ? (type ?? "button") : undefined}
       disabled={!asChild ? disabled || loading : undefined}
       {...props}
@@ -65,43 +54,49 @@ export function Button({
   );
 }
 
+// The accent edge — the "you can press this" voice — belongs to edged pressables:
+// thin at rest, grown on hover, and held grown while a trigger's overlay is open
+// (data-[state=open], which Radix sets only on asChild triggers; inert otherwise).
+// It lives on the variants that carry it rather than on the base, so ghost and link
+// simply omit it — kept out, not overridden, since twMerge can't dedupe a custom
+// shadow utility against shadow-none (the old opt-out silently leaked the edge).
+const edge =
+  "shadow-offset-action hover:shadow-offset-action-hover data-[state=open]:shadow-offset-action-hover";
+
 const buttonVariants = cva(
   [
     "inline-flex items-center justify-center gap-2",
     "font-medium",
     "cursor-pointer",
-    "shadow-offset-action",
-    "hover:shadow-offset-action-hover",
-    // Held open — a trigger whose menu/popover is open sustains its hover state:
-    // the grown edge stays (still pressable, now the active owner). data-[state=open]
-    // is only set when this Button is a Radix trigger (asChild); inert otherwise.
-    "data-[state=open]:shadow-offset-action-hover",
     "active:shadow-none active:translate-x-px active:translate-y-px",
     "disabled:shadow-none disabled:cursor-not-allowed disabled:border-dashed disabled:border-border-muted disabled:bg-bg-disabled disabled:text-fg-disabled",
     "focus-visible:outline-2 focus-visible:outline-border-focus focus-visible:outline-offset-2",
     "[&_svg]:size-4",
-    "transition-[box-shadow,translate] duration-100",
+    "transition-[box-shadow,translate,border-color] duration-100",
   ].join(" "),
   {
     variants: {
       variant: {
-        primary:
-          "bg-bg-emphasis text-fg-on-emphasis border border-accent-solid hover:bg-bg-emphasis-hover data-[state=open]:bg-bg-emphasis-hover active:bg-bg-emphasis-active disabled:text-fg-disabled no-underline",
-        destructive:
-          "bg-danger-solid text-danger-fg-on-solid border border-danger-solid hover:bg-danger-solid-hover hover:border-danger-solid-hover data-[state=open]:bg-danger-solid-hover data-[state=open]:border-danger-solid-hover active:bg-danger-solid-active disabled:text-fg-disabled no-underline",
-        outline:
-          "border border-border bg-transparent text-fg hover:bg-bg-hover data-[state=open]:bg-bg-hover active:bg-bg-active",
-        secondary:
-          "bg-accent-bg text-accent-fg border border-accent-border hover:border-accent-solid data-[state=open]:border-accent-solid",
+        // Primary carries a light accent rim at rest (border-accent-border) over
+        // the full accent shadow — the two tones read as depth, not a doubled
+        // 2px band. On engage the rim sheds (border-transparent) so the voice
+        // consolidates into the growing shadow, not a thick accent band.
+        primary: `bg-bg-emphasis text-fg-on-emphasis border border-accent-border hover:border-transparent data-[state=open]:border-transparent hover:bg-bg-emphasis-hover data-[state=open]:bg-bg-emphasis-hover active:bg-bg-emphasis-active disabled:text-fg-disabled no-underline ${edge}`,
+        destructive: `bg-danger-solid text-danger-fg-on-solid border border-danger-solid hover:bg-danger-solid-hover hover:border-danger-solid-hover data-[state=open]:bg-danger-solid-hover data-[state=open]:border-danger-solid-hover active:bg-danger-solid-active disabled:text-fg-disabled no-underline ${edge}`,
+        // Outline is airy at rest; on engage its signal is the accent edge
+        // growing, not a grey fill — so hover and held-open drop the fill and lean
+        // on the edge. The press keeps a faint grey settle (active:bg-bg-active) to
+        // confirm the drop.
+        outline: `border border-border bg-transparent text-fg active:bg-bg-active ${edge}`,
+        secondary: `bg-accent-bg text-accent-fg border border-accent-border hover:border-accent-solid data-[state=open]:border-accent-solid ${edge}`,
+        // Ghost and link are not edged pressables, so they carry no accent edge.
+        // Ghost's only hover signal is the grey fill (no edge to grow); link reads
+        // as a link — accent text with a hover underline — not a keyed button.
         ghost:
-          "text-fg hover:bg-bg-hover data-[state=open]:bg-bg-hover active:bg-bg-active shadow-none hover:shadow-none data-[state=open]:shadow-none active:shadow-none active:translate-x-0 active:translate-y-0",
-        link: "text-fg-link underline-offset-4 hover:underline data-[state=open]:underline shadow-none hover:shadow-none data-[state=open]:shadow-none active:shadow-none active:translate-x-0 active:translate-y-0",
-        success:
-          "bg-success-solid text-success-fg-on-solid border border-success-solid hover:bg-success-solid-hover hover:border-success-solid-hover data-[state=open]:bg-success-solid-hover data-[state=open]:border-success-solid-hover active:bg-success-solid-active disabled:text-fg-disabled no-underline",
-        stark:
-          "border border-border-strong bg-transparent text-fg hover:bg-bg-emphasis hover:text-fg-on-emphasis data-[state=open]:bg-bg-emphasis data-[state=open]:text-fg-on-emphasis active:bg-bg-emphasis",
-        warning:
-          "bg-warning-solid text-warning-fg-on-solid border border-warning-solid hover:bg-warning-solid-hover hover:border-warning-solid-hover data-[state=open]:bg-warning-solid-hover data-[state=open]:border-warning-solid-hover active:bg-warning-solid-active disabled:text-fg-disabled no-underline",
+          "text-fg hover:bg-bg-hover data-[state=open]:bg-bg-hover active:bg-bg-active active:translate-x-0 active:translate-y-0",
+        link: "text-fg-link underline-offset-4 hover:underline data-[state=open]:underline active:translate-x-0 active:translate-y-0",
+        success: `bg-success-solid text-success-fg-on-solid border border-success-solid hover:bg-success-solid-hover hover:border-success-solid-hover data-[state=open]:bg-success-solid-hover data-[state=open]:border-success-solid-hover active:bg-success-solid-active disabled:text-fg-disabled no-underline ${edge}`,
+        warning: `bg-warning-solid text-warning-fg-on-solid border border-warning-solid hover:bg-warning-solid-hover hover:border-warning-solid-hover data-[state=open]:bg-warning-solid-hover data-[state=open]:border-warning-solid-hover active:bg-warning-solid-active disabled:text-fg-disabled no-underline ${edge}`,
       },
       size: {
         sm: "h-8 px-3 text-xs",
@@ -109,15 +104,10 @@ const buttonVariants = cva(
         lg: "h-10 px-6 text-sm",
         icon: "size-9 p-0",
       },
-      mono: {
-        true: "font-mono tracking-wide",
-        false: "",
-      },
     },
     defaultVariants: {
       variant: "primary",
       size: "md",
-      mono: false,
     },
   },
 );

--- a/src/components/dialog.stories.tsx
+++ b/src/components/dialog.stories.tsx
@@ -222,7 +222,7 @@ export const AllStates = () => (
       </Dialog.Footer>
     </Dialog>
 
-    <Dialog preventClose trigger={<Button variant="stark">Prevent Close</Button>}>
+    <Dialog preventClose trigger={<Button variant="outline">Prevent Close</Button>}>
       <Dialog.Header>
         <Dialog.Title>Cannot Dismiss</Dialog.Title>
         <Dialog.Description>Must use buttons to close.</Dialog.Description>

--- a/src/components/dropdown-menu.stories.tsx
+++ b/src/components/dropdown-menu.stories.tsx
@@ -298,7 +298,7 @@ export const AllStates = () => (
 
     <DropdownMenu>
       <DropdownMenu.Trigger asChild>
-        <Button variant="stark">With Shortcuts</Button>
+        <Button variant="outline">With Shortcuts</Button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content>
         <DropdownMenu.Item>

--- a/src/components/overview.stories.tsx
+++ b/src/components/overview.stories.tsx
@@ -138,7 +138,6 @@ export const AllComponents: StoryObj = {
           <Button variant="destructive">Destructive</Button>
           <Button variant="success">Success</Button>
           <Button variant="warning">Warning</Button>
-          <Button variant="stark">Stark</Button>
           <Button variant="link">Link</Button>
           <Button disabled>Disabled</Button>
           <Button size="sm">Small</Button>

--- a/src/components/sheet.stories.tsx
+++ b/src/components/sheet.stories.tsx
@@ -242,7 +242,7 @@ export const AllStates = () => (
       </Sheet.Footer>
     </Sheet>
 
-    <Sheet preventClose trigger={<Button variant="stark">Prevent Close</Button>}>
+    <Sheet preventClose trigger={<Button variant="outline">Prevent Close</Button>}>
       <Sheet.Header>
         <Sheet.Title>Cannot Dismiss</Sheet.Title>
         <Sheet.Description>Must use buttons to close.</Sheet.Description>


### PR DESCRIPTION
## What

A focused pass on **Button**: interaction-edge grammar refinements, two API cuts, and a Storybook tidy-up. Five changesets carry the release-note detail.

### Refinements
- **primary** — a light accent rim at rest (`border-accent-border`) over the full accent shadow reads as *depth*, not a doubled 2px band; on engage the rim sheds so the vivid voice consolidates into the growing shadow instead of a thick accent band. *(minor)*
- **outline** — hovers on the accent edge it already grows, dropping the grey fill that read muddy against the paper; the press keeps a faint grey settle to confirm the drop. *(patch)*
- **ghost / link** — fix a leaked accent edge. The base applied `shadow-offset-action` to every variant and the `shadow-none` override never won (twMerge can't dedupe a custom shadow utility against `shadow-none`), so ghost showed a blue edge at rest and link wore a button edge. The edge now lives on the variants that carry it; ghost is quiet, link reads as a link. *(patch)*

### Cleanup
- **remove `stark`** — no documented role in the design vocabulary, no production use, overlapped `outline`/`primary`. Demo triggers move to `outline`. *(minor)*
- **remove `mono`** — no documented role, orphan showcase; monospace lives where it means something (code badges, table cells), not as a per-button toggle. Consumers can pass `className="font-mono tracking-wide"`. *(minor)*

### Stories (no changeset — `.stories.tsx` isn't distributed)
- Collapse the per-variant/size/state stories into a `Default` playground + the `AllVariants`/`AllSizes`/`AllStates` compositions (docs already render only the compositions).
- Enrich `AllStates` into an **interaction-state matrix** (rest → hover/held-open → pressed → disabled/loading) for both `primary` and `outline`, so the edge grammar the system is built on is actually visible. Hover/held-open is forced with real `data-state="open"` styles; pressed is reconstructed from the component's own tokens.

## Verification
- `tsc` clean · Prettier clean · affected story tests pass (44)
- Browser-verified in Storybook (solace): ghost/link edge gone, outline airy hover, primary rim sheds on engage, and the `AllStates` matrix renders each state correctly.

## Not in scope (deferred)
- `secondary` shows an accent tint that reads purple in 5 of 6 themes (only solace's accent is blue). Fixing it — making `secondary` neutral, and/or diversifying per-theme accents — is a palette/identity decision to take deliberately, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M8TJKZycXhCNFNFY2QsxY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Primary buttons now use a refined light rim that transitions smoothly during interaction.
  * Outline button hover states emphasize the accent edge instead of a grey fill.
  * Button state documentation now includes rest, hover, pressed, disabled, and loading states.

* **Bug Fixes**
  * Removed unwanted accent edges from ghost and link buttons.

* **Breaking Changes**
  * Removed the `mono` button option; use custom monospace styling instead.
  * Removed the `stark` button variant; use `outline` instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->