### PR TITLE
chore(renovate): hold typescript on v6 until tooling supports native TS7

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,11 @@
     {
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
+    },
+    {
+      "description": "Hold TypeScript on v6 until the ecosystem supports the native (Go) compiler's JS API. TS 7's `typescript` module ships only `version`/`versionMajorMinor`, so tools that consume the programmatic compiler API break: tsup/rollup-plugin-dts (@beaket/paper d.ts build), react-docgen-typescript (docs prop tables + Storybook docgen), and @volar/kit/astro-check (docs typecheck). No TS-7-compatible releases of these are published yet.",
+      "matchPackageNames": ["typescript"],
+      "allowedVersions": "<7"
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
## Summary

Resolves #606 (Renovate's `typescript` 6.0.3 → 7.0.2 major bump) by **declining the upgrade** and constraining Renovate so it stops re-proposing it.

TypeScript 7 is the native (Go) compiler. At `7.0.2` the `typescript` npm module exposes **only** `version` and `versionMajorMinor` — it ships no programmatic compiler API. The `tsc` binary works fine (a plain `tsc --noEmit` passes), but every tool in this repo that imports the TS compiler API breaks.

## What I verified

I applied #606's bump locally on TS 7.0.2 and ran the full CI pipeline. Findings:

| CI step | Result on TS 7 |
|---|---|
| theme-tokens sync, lint, `format:check`, `test:cli`, `test:editor` | ✅ pass |
| root `tsc --noEmit` | ⚠️ needed `baseUrl` removed (removed in TS7), then passes |
| **`@beaket/paper` build** (`tsup` → rollup-plugin-dts) | ❌ `ts.sys` is undefined during `.d.ts` generation |
| **`docs` typecheck / Storybook docgen** (`react-docgen-typescript`) | ❌ `ts.JsxEmit` is undefined |
| **`docs` `astro check`** (`@volar/kit`) | ❌ consumes the same missing API |

`react-docgen-typescript`'s latest published version (2.4.0) has no TS7 support, and Storybook's docgen (`@joshwooding/vite-plugin-react-docgen-typescript`) wraps it — so Chromatic would break too. There are no TS-7-compatible releases of these tools yet. Making TS 7 work would mean replacing multiple load-bearing tools with no ready alternatives — far beyond a routine dependency bump.

## Change

Add a Renovate `packageRule` pinning `typescript` to `allowedVersions: "<7"`, with a `description` documenting the reason. This stops #606 and future v7 majors from recurring until the ecosystem ships the native compiler's JS API.

Minor/patch TS 6.x updates continue to auto-merge as before.

## Follow-up

Once merged, #606 can be closed as superseded (Renovate will also stop re-opening it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TZtyuL8rNjt6ML7235i9Zh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted automated TypeScript updates to versions below 7.
  * Documented the version constraint for maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->