### PR TITLE
refactor(stories): fold the functional-component stories into Button-concise shape

### DIFF
--- a/.changeset/stories-concise-sweep-fn.md
+++ b/.changeset/stories-concise-sweep-fn.md
@@ -1,0 +1,30 @@
+---
+---
+
+Stories-only refactor (batch 2 — the functional components): fold the
+per-permutation stories into the Button-style shape and collapse each
+component's several per-behavior `*Test` stories into one consolidated
+`InteractionTest`. Exports drop 52 → 31 across dropdown-menu (15 → 8),
+data-table (15 → 10), dialog (11 → 7), and sheet (11 → 6).
+
+Kept — genuinely-distinct feature/behavior compositions:
+
+- dropdown-menu: `WithSubmenus`, `WithCheckboxItems`, `WithRadioItems`,
+  `InsetItems`, and the `TriggerOpenState` held-open edge demo.
+- data-table: `WithSearch`, `WithPagination`, `WithSelection`, `Compact`,
+  `EmptyState`, `WithWideContent`, and **both** `FullFeatured` (the span-3
+  showcase preview card) and `AllFeatures` (the docs-body breakdown) — they map
+  to two distinct registry surfaces, so both stay.
+- dialog / sheet: `PreventClose`, `Controlled`, dialog's `WithForm`, and sheet's
+  `FullScreen`.
+
+Folded — pure prop-permutations that the `All*` composition already covers:
+`DestructiveItem` + `WithDisabledItems` (dropdown), `WithRowClick` (data-table),
+`Destructive` (dialog), and `LeftSide` / `TopSide` / `BottomSide` (sheet). Their
+`*Test` stories were merged into the single `InteractionTest` each file now
+carries. The registry-referenced `Default`, `AllStates`, `FullFeatured`, and
+`AllFeatures` stories are preserved.
+
+No component `.tsx` changed and stories ship in no tarball, so this is an empty
+(no-bump) changeset, present only to satisfy the `src/**` changeset-check —
+matching the precedent set by #642 and batch 1 (#652).

--- a/src/components/data-table.stories.tsx
+++ b/src/components/data-table.stories.tsx
@@ -112,16 +112,6 @@ export const WithSelection: Story = {
   },
 };
 
-export const WithRowClick: Story = {
-  args: {
-    columns,
-    data: users,
-    onRowClick: fn((row: User) => {
-      console.log("Row clicked:", row);
-    }),
-  },
-};
-
 export const Compact: Story = {
   args: {
     columns,
@@ -186,133 +176,69 @@ export const AllFeatures = () => (
   </div>
 );
 
-// Interaction tests
-export const SearchTest: Story = {
+// One consolidated test folding the five former per-behavior tests. Every
+// feature is on one table, exercised in an order chosen to avoid coupling:
+// pagination, then sorting (returns to unsorted), then selection, then search
+// (auto-resets to page 1 and clears), then row click.
+const interactionUsers: User[] = [
+  ...users,
+  { id: "6", name: "Frank Moore", email: "frank@example.com", role: "Viewer", status: "inactive" },
+];
+
+export const InteractionTest: Story = {
+  tags: ["!autodocs"],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
   args: {
     columns,
-    data: users,
+    data: interactionUsers,
     searchable: true,
     searchPlaceholder: "Search users...",
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Verify search input is present
-    const searchInput = canvas.getByPlaceholderText("Search users...");
-    await expect(searchInput).toBeInTheDocument();
-
-    // Type in search input
-    await userEvent.type(searchInput, "Alice");
-
-    // Verify filtered result (only Alice should be visible)
-    const aliceRow = canvas.getByText("Alice Johnson");
-    await expect(aliceRow).toBeInTheDocument();
-
-    // Clear search
-    await userEvent.clear(searchInput);
-  },
-};
-
-export const SortingTest: Story = {
-  args: {
-    columns,
-    data: users,
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Find and click the Name header to sort
-    const nameHeader = canvas.getByText("Name");
-    await userEvent.click(nameHeader);
-
-    // Click again for descending sort
-    await userEvent.click(nameHeader);
-
-    // Click again to clear sort
-    await userEvent.click(nameHeader);
-  },
-};
-
-export const SelectionTest: Story = {
-  args: {
-    columns,
-    data: users.slice(0, 3),
-    selectable: true,
-    onSelectionChange: fn(),
-  },
-  play: async ({ args, canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Get all checkboxes
-    const checkboxes = canvas.getAllByRole("checkbox");
-    await expect(checkboxes.length).toBe(4); // 1 select-all + 3 rows
-
-    // Click first row checkbox (not select-all)
-    await userEvent.click(checkboxes[1]);
-
-    // Verify onSelectionChange was called
-    await expect(args.onSelectionChange).toHaveBeenCalled();
-
-    // Click select-all checkbox
-    await userEvent.click(checkboxes[0]);
-  },
-};
-
-export const PaginationTest: Story = {
-  args: {
-    columns,
-    data: [
-      ...users,
-      ...users.map((u, i) => ({ ...u, id: `${u.id}-copy-${i}`, email: `copy.${i}@example.com` })),
-    ],
     paginated: true,
     pageSize: 3,
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Verify pagination info is shown
-    const paginationInfo = canvas.getByText(/Showing 1 to 3 of/);
-    await expect(paginationInfo).toBeInTheDocument();
-
-    // Find and click next page button
-    const nextButton = canvas.getByRole("button", { name: "Next page" });
-    await expect(nextButton).toBeEnabled();
-    await userEvent.click(nextButton);
-
-    // Verify we're on page 2
-    const page2Info = canvas.getByText(/Showing 4 to 6 of/);
-    await expect(page2Info).toBeInTheDocument();
-
-    // Page 2 button should be active
-    const page2Button = canvas.getByRole("button", { name: "2" });
-    await expect(page2Button).toHaveAttribute("aria-current", "page");
-
-    // Go back to first page
-    const page1Button = canvas.getByRole("button", { name: "1" });
-    await userEvent.click(page1Button);
-
-    // Verify we're back on page 1
-    const page1Info = canvas.getByText(/Showing 1 to 3 of/);
-    await expect(page1Info).toBeInTheDocument();
-  },
-};
-
-export const RowClickTest: Story = {
-  args: {
-    columns,
-    data: users.slice(0, 2),
+    selectable: true,
+    onSelectionChange: fn(),
     onRowClick: fn(),
   },
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // Find a row and click it
-    const firstRow = canvas.getByText("Alice Johnson").closest("tr");
-    if (firstRow) {
-      await userEvent.click(firstRow);
-      await expect(args.onRowClick).toHaveBeenCalledTimes(1);
-    }
+    // Pagination — six rows across two pages of three
+    await expect(canvas.getByText(/Showing 1 to 3 of 6/)).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole("button", { name: "Next page" }));
+    await expect(canvas.getByText(/Showing 4 to 6 of 6/)).toBeInTheDocument();
+    await expect(canvas.getByRole("button", { name: "2" })).toHaveAttribute("aria-current", "page");
+    await userEvent.click(canvas.getByRole("button", { name: "1" }));
+    await expect(canvas.getByText(/Showing 1 to 3 of 6/)).toBeInTheDocument();
+
+    // Sorting — the Name header cycles ascending → descending → unsorted
+    const nameHeader = canvas.getByRole("columnheader", { name: "Name" });
+    await userEvent.click(nameHeader);
+    await expect(nameHeader).toHaveAttribute("aria-sort", "ascending");
+    await userEvent.click(nameHeader);
+    await expect(nameHeader).toHaveAttribute("aria-sort", "descending");
+    await userEvent.click(nameHeader);
+    await expect(nameHeader).toHaveAttribute("aria-sort", "none");
+
+    // Selection — select-all checks the page's rows and fires the callback
+    const checkboxes = canvas.getAllByRole("checkbox");
+    await expect(checkboxes).toHaveLength(4); // select-all + three visible rows
+    await userEvent.click(checkboxes[0]);
+    await expect(args.onSelectionChange).toHaveBeenCalled();
+    await expect(canvas.getAllByRole("checkbox")[1]).toBeChecked();
+
+    // Search — filtering narrows to the matching row, then clears
+    const search = canvas.getByPlaceholderText("Search users...");
+    await userEvent.type(search, "Alice");
+    await expect(canvas.getByText("Alice Johnson")).toBeInTheDocument();
+    await expect(canvas.queryByText("Bob Smith")).not.toBeInTheDocument();
+    await userEvent.clear(search);
+
+    // Row click — clicking a data row (not its checkbox) fires onRowClick
+    const row = canvas.getByText("Alice Johnson").closest("tr")!;
+    await userEvent.click(row);
+    await expect(args.onRowClick).toHaveBeenCalled();
   },
 };
 

--- a/src/components/dialog.stories.tsx
+++ b/src/components/dialog.stories.tsx
@@ -136,29 +136,6 @@ export const WithForm: Story = {
   },
 };
 
-export const Destructive: Story = {
-  args: {
-    trigger: <Button variant="destructive">Delete Account</Button>,
-    children: (
-      <>
-        <Dialog.Header>
-          <Dialog.Title>Are you sure?</Dialog.Title>
-          <Dialog.Description>
-            This action cannot be undone. This will permanently delete your account and remove your
-            data from our servers.
-          </Dialog.Description>
-        </Dialog.Header>
-        <Dialog.Footer>
-          <Dialog.Close>
-            <Button variant="outline">Cancel</Button>
-          </Dialog.Close>
-          <Button variant="destructive">Delete Account</Button>
-        </Dialog.Footer>
-      </>
-    ),
-  },
-};
-
 function ControlledDialogExample() {
   const [open, setOpen] = useState(false);
 
@@ -263,154 +240,81 @@ export const AllStates = () => (
   </div>
 );
 
-// Interaction Tests
-export const OpenCloseTest: Story = {
-  args: {
-    trigger: <Button>Open Dialog</Button>,
-    children: (
-      <>
+// One consolidated test folding the four former per-behavior tests across
+// three instances: the default dialog (closes via the X button and via an
+// action button), preventClose (Escape is a no-op, action still closes), and
+// hideCloseButton (no X button, action still closes).
+export const InteractionTest: Story = {
+  tags: ["!autodocs"],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  render: () => (
+    <div className="flex gap-2">
+      <Dialog trigger={<Button>Open default</Button>}>
         <Dialog.Header>
-          <Dialog.Title>Test Dialog</Dialog.Title>
+          <Dialog.Title>Default</Dialog.Title>
         </Dialog.Header>
         <Dialog.Footer>
           <Dialog.Close>
             <Button variant="outline">Close</Button>
           </Dialog.Close>
         </Dialog.Footer>
-      </>
-    ),
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
+      </Dialog>
 
-    // Open dialog
-    const trigger = canvas.getByRole("button", { name: "Open Dialog" });
-    await userEvent.click(trigger);
-
-    // Wait for dialog to be visible
-    const dialogElement = await screen.findByRole("dialog");
-    await expect(dialogElement).toBeInTheDocument();
-
-    // Close dialog via close button
-    const closeButton = within(dialogElement).getByRole("button", { name: "Close" });
-    await userEvent.click(closeButton);
-
-    // Verify dialog is closed
-    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-  },
-};
-
-export const CloseViaXButtonTest: Story = {
-  args: {
-    trigger: <Button>Open Dialog</Button>,
-    children: (
-      <>
+      <Dialog preventClose trigger={<Button>Open prevent-close</Button>}>
         <Dialog.Header>
-          <Dialog.Title>Test Dialog</Dialog.Title>
-        </Dialog.Header>
-      </>
-    ),
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Open dialog
-    const trigger = canvas.getByRole("button", { name: "Open Dialog" });
-    await userEvent.click(trigger);
-
-    // Wait for dialog to be visible
-    const dialogElement = await screen.findByRole("dialog");
-    await expect(dialogElement).toBeInTheDocument();
-
-    // Close via X button
-    const xButton = within(dialogElement).getByRole("button", { name: "Close dialog" });
-    await userEvent.click(xButton);
-
-    // Verify dialog is closed
-    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-  },
-};
-
-export const PreventCloseTest: Story = {
-  args: {
-    preventClose: true,
-    trigger: <Button>Open Dialog</Button>,
-    children: (
-      <>
-        <Dialog.Header>
-          <Dialog.Title>Cannot dismiss by escape</Dialog.Title>
+          <Dialog.Title>Prevent close</Dialog.Title>
         </Dialog.Header>
         <Dialog.Footer>
           <Dialog.Close>
             <Button>Close via button</Button>
           </Dialog.Close>
         </Dialog.Footer>
-      </>
-    ),
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
+      </Dialog>
 
-    // Open dialog
-    const trigger = canvas.getByRole("button", { name: "Open Dialog" });
-    await userEvent.click(trigger);
-
-    // Wait for dialog to be visible
-    const dialogElement = await screen.findByRole("dialog");
-    await expect(dialogElement).toBeInTheDocument();
-
-    // Try to close with Escape - should not close due to preventClose
-    await userEvent.keyboard("{Escape}");
-
-    // Dialog should still be visible
-    await expect(screen.queryByRole("dialog")).toBeInTheDocument();
-
-    // Close via button - should work
-    const closeButton = within(dialogElement).getByRole("button", { name: "Close via button" });
-    await userEvent.click(closeButton);
-
-    // Verify dialog is closed
-    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-  },
-};
-
-export const HideCloseButtonTest: Story = {
-  args: {
-    hideCloseButton: true,
-    trigger: <Button>Open Dialog</Button>,
-    children: (
-      <>
+      <Dialog hideCloseButton trigger={<Button>Open no-X</Button>}>
         <Dialog.Header>
-          <Dialog.Title>No X Button</Dialog.Title>
+          <Dialog.Title>No X button</Dialog.Title>
         </Dialog.Header>
         <Dialog.Footer>
           <Dialog.Close>
-            <Button>Close</Button>
+            <Button variant="outline">Close</Button>
           </Dialog.Close>
         </Dialog.Footer>
-      </>
-    ),
-  },
+      </Dialog>
+    </div>
+  ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // Open dialog
-    const trigger = canvas.getByRole("button", { name: "Open Dialog" });
-    await userEvent.click(trigger);
+    // Default dialog: opens on trigger, closes via its X button
+    await userEvent.click(canvas.getByRole("button", { name: "Open default" }));
+    let dialog = await screen.findByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Close dialog" }));
+    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
-    // Wait for dialog to be visible
-    const dialogElement = await screen.findByRole("dialog");
-    await expect(dialogElement).toBeInTheDocument();
+    // ...and via an action button
+    await userEvent.click(canvas.getByRole("button", { name: "Open default" }));
+    dialog = await screen.findByRole("dialog");
+    await userEvent.click(within(dialog).getByRole("button", { name: "Close" }));
+    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
-    // Verify X button does not exist
-    const xButton = within(dialogElement).queryByRole("button", { name: "Close dialog" });
-    await expect(xButton).not.toBeInTheDocument();
+    // preventClose: Escape is a no-op; the action button still closes
+    await userEvent.click(canvas.getByRole("button", { name: "Open prevent-close" }));
+    dialog = await screen.findByRole("dialog");
+    await userEvent.keyboard("{Escape}");
+    await expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await userEvent.click(within(dialog).getByRole("button", { name: "Close via button" }));
+    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
-    // Close via action button - should work
-    const closeButton = within(dialogElement).getByRole("button", { name: "Close" });
-    await userEvent.click(closeButton);
-
-    // Verify dialog is closed
+    // hideCloseButton: no X button; the action button closes
+    await userEvent.click(canvas.getByRole("button", { name: "Open no-X" }));
+    dialog = await screen.findByRole("dialog");
+    await expect(
+      within(dialog).queryByRole("button", { name: "Close dialog" }),
+    ).not.toBeInTheDocument();
+    await userEvent.click(within(dialog).getByRole("button", { name: "Close" }));
     await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   },
 };

--- a/src/components/dropdown-menu.stories.tsx
+++ b/src/components/dropdown-menu.stories.tsx
@@ -16,7 +16,7 @@ import {
   Users,
 } from "lucide-react";
 import { useState } from "react";
-import { expect, screen, userEvent, within } from "storybook/test";
+import { expect, screen, userEvent, waitFor, within } from "storybook/test";
 import { Button } from "./button";
 import { DropdownMenu } from "./dropdown-menu";
 
@@ -29,6 +29,9 @@ const meta: Meta<typeof DropdownMenu> = {
 export default meta;
 type Story = StoryObj<typeof DropdownMenu>;
 
+// The interactive playground — icons, labels, separators, and shortcuts. Every
+// item variant (destructive, disabled, shortcuts) lives in the AllStates
+// composition below.
 export const Default: Story = {
   render: () => (
     <DropdownMenu>
@@ -69,6 +72,7 @@ export const Default: Story = {
   ),
 };
 
+// Nested submenus, grouped items, and a disabled item together.
 export const WithSubmenus: Story = {
   render: () => (
     <DropdownMenu>
@@ -203,39 +207,8 @@ export const WithRadioItems: Story = {
   render: () => <RadioItemsExample />,
 };
 
-export const DestructiveItem: Story = {
-  render: () => (
-    <DropdownMenu>
-      <DropdownMenu.Trigger asChild>
-        <Button variant="outline">Actions</Button>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content>
-        <DropdownMenu.Item>Edit</DropdownMenu.Item>
-        <DropdownMenu.Item>Duplicate</DropdownMenu.Item>
-        <DropdownMenu.Separator />
-        <DropdownMenu.Item variant="destructive">Delete</DropdownMenu.Item>
-      </DropdownMenu.Content>
-    </DropdownMenu>
-  ),
-};
-
-export const WithDisabledItems: Story = {
-  render: () => (
-    <DropdownMenu>
-      <DropdownMenu.Trigger asChild>
-        <Button variant="outline">Open Menu</Button>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content>
-        <DropdownMenu.Item>Edit</DropdownMenu.Item>
-        <DropdownMenu.Item disabled>Copy (Disabled)</DropdownMenu.Item>
-        <DropdownMenu.Item>Paste</DropdownMenu.Item>
-        <DropdownMenu.Separator />
-        <DropdownMenu.Item disabled>Delete (Disabled)</DropdownMenu.Item>
-      </DropdownMenu.Content>
-    </DropdownMenu>
-  ),
-};
-
+// Inset items and labels align their text to the icon column even without an
+// icon, so a mixed menu stays on one left edge.
 export const InsetItems: Story = {
   render: () => (
     <DropdownMenu>
@@ -260,6 +233,8 @@ export const InsetItems: Story = {
   ),
 };
 
+// Composition for docs — item variants side by side: plain, icons + a
+// destructive row, shortcuts, and disabled items.
 export const AllStates = () => (
   <div className="flex flex-wrap gap-4">
     <DropdownMenu>
@@ -358,144 +333,12 @@ export const TriggerOpenState = () => (
   </div>
 );
 
-// Interaction Tests
-export const OpenCloseTest: Story = {
-  render: () => (
-    <DropdownMenu>
-      <DropdownMenu.Trigger asChild>
-        <Button>Open Menu</Button>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content>
-        <DropdownMenu.Item>Profile</DropdownMenu.Item>
-        <DropdownMenu.Item>Settings</DropdownMenu.Item>
-        <DropdownMenu.Item>Log out</DropdownMenu.Item>
-      </DropdownMenu.Content>
-    </DropdownMenu>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Open dropdown
-    const trigger = canvas.getByRole("button", { name: "Open Menu" });
-    await userEvent.click(trigger);
-
-    // Wait for menu to be visible
-    const menu = await screen.findByRole("menu");
-    await expect(menu).toBeInTheDocument();
-
-    // Verify menu items are present
-    await expect(within(menu).getByRole("menuitem", { name: "Profile" })).toBeInTheDocument();
-    await expect(within(menu).getByRole("menuitem", { name: "Settings" })).toBeInTheDocument();
-
-    // Close with Escape key
-    await userEvent.keyboard("{Escape}");
-
-    // Verify menu is closed
-    await expect(screen.queryByRole("menu")).not.toBeInTheDocument();
-  },
-};
-
-export const ItemSelectionTest: Story = {
-  render: () => (
-    <DropdownMenu>
-      <DropdownMenu.Trigger asChild>
-        <Button>Open Menu</Button>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content>
-        <DropdownMenu.Item>Profile</DropdownMenu.Item>
-        <DropdownMenu.Item>Settings</DropdownMenu.Item>
-        <DropdownMenu.Item>Log out</DropdownMenu.Item>
-      </DropdownMenu.Content>
-    </DropdownMenu>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Open dropdown
-    const trigger = canvas.getByRole("button", { name: "Open Menu" });
-    await userEvent.click(trigger);
-
-    // Wait for menu to be visible
-    const menu = await screen.findByRole("menu");
-    await expect(menu).toBeInTheDocument();
-
-    // Click on an item
-    const profileItem = within(menu).getByRole("menuitem", { name: "Profile" });
-    await userEvent.click(profileItem);
-
-    // Menu should close after selection
-    await expect(screen.queryByRole("menu")).not.toBeInTheDocument();
-  },
-};
-
-export const KeyboardNavigationTest: Story = {
-  render: () => (
-    <DropdownMenu>
-      <DropdownMenu.Trigger asChild>
-        <Button>Open Menu</Button>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content>
-        <DropdownMenu.Item>First</DropdownMenu.Item>
-        <DropdownMenu.Item>Second</DropdownMenu.Item>
-        <DropdownMenu.Item>Third</DropdownMenu.Item>
-      </DropdownMenu.Content>
-    </DropdownMenu>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Focus trigger and open with Enter
-    const trigger = canvas.getByRole("button", { name: "Open Menu" });
-    trigger.focus();
-    await userEvent.keyboard("{Enter}");
-
-    // Wait for menu to be visible
-    const menu = await screen.findByRole("menu");
-    await expect(menu).toBeInTheDocument();
-
-    // Navigate with arrow keys
-    await userEvent.keyboard("{ArrowDown}");
-    await userEvent.keyboard("{ArrowDown}");
-
-    // Close with Escape
-    await userEvent.keyboard("{Escape}");
-
-    // Verify menu is closed
-    await expect(screen.queryByRole("menu")).not.toBeInTheDocument();
-  },
-};
-
-export const DisabledItemTest: Story = {
-  render: () => (
-    <DropdownMenu>
-      <DropdownMenu.Trigger asChild>
-        <Button>Open Menu</Button>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content>
-        <DropdownMenu.Item>Enabled</DropdownMenu.Item>
-        <DropdownMenu.Item disabled>Disabled</DropdownMenu.Item>
-      </DropdownMenu.Content>
-    </DropdownMenu>
-  ),
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Open dropdown
-    const trigger = canvas.getByRole("button", { name: "Open Menu" });
-    await userEvent.click(trigger);
-
-    // Wait for menu to be visible
-    const menu = await screen.findByRole("menu");
-    await expect(menu).toBeInTheDocument();
-
-    // Verify disabled item has correct attribute
-    const disabledItem = within(menu).getByRole("menuitem", { name: "Disabled" });
-    await expect(disabledItem).toHaveAttribute("data-disabled");
-  },
-};
-
-function CheckboxTestExample() {
+// One consolidated test folding the six former per-behavior tests: keyboard
+// open, item render, disabled marking, plain-item selection closes, arrow-key
+// highlight, Escape closes, and checkbox/radio state persisting across reopen.
+function InteractionExample() {
   const [checked, setChecked] = useState(false);
+  const [position, setPosition] = useState("one");
 
   return (
     <DropdownMenu>
@@ -503,52 +346,14 @@ function CheckboxTestExample() {
         <Button>Open Menu</Button>
       </DropdownMenu.Trigger>
       <DropdownMenu.Content>
+        <DropdownMenu.Item>Profile</DropdownMenu.Item>
+        <DropdownMenu.Item disabled>Disabled</DropdownMenu.Item>
+        <DropdownMenu.Separator />
         <DropdownMenu.CheckboxItem checked={checked} onCheckedChange={setChecked}>
           Toggle Option
         </DropdownMenu.CheckboxItem>
-      </DropdownMenu.Content>
-    </DropdownMenu>
-  );
-}
-
-export const CheckboxItemTest: Story = {
-  render: () => <CheckboxTestExample />,
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Open dropdown
-    const trigger = canvas.getByRole("button", { name: "Open Menu" });
-    await userEvent.click(trigger);
-
-    // Wait for menu to be visible
-    const menu = await screen.findByRole("menu");
-    await expect(menu).toBeInTheDocument();
-
-    // Find and click checkbox item
-    const checkboxItem = within(menu).getByRole("menuitemcheckbox", { name: "Toggle Option" });
-    await expect(checkboxItem).toHaveAttribute("aria-checked", "false");
-    await userEvent.click(checkboxItem);
-
-    // Re-open menu to verify state
-    await userEvent.click(trigger);
-    const menuAfter = await screen.findByRole("menu");
-    const checkboxItemAfter = within(menuAfter).getByRole("menuitemcheckbox", {
-      name: "Toggle Option",
-    });
-    await expect(checkboxItemAfter).toHaveAttribute("aria-checked", "true");
-  },
-};
-
-function RadioTestExample() {
-  const [value, setValue] = useState("one");
-
-  return (
-    <DropdownMenu>
-      <DropdownMenu.Trigger asChild>
-        <Button>Open Menu</Button>
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Content>
-        <DropdownMenu.RadioGroup value={value} onValueChange={setValue}>
+        <DropdownMenu.Separator />
+        <DropdownMenu.RadioGroup value={position} onValueChange={setPosition}>
           <DropdownMenu.RadioItem value="one">Option One</DropdownMenu.RadioItem>
           <DropdownMenu.RadioItem value="two">Option Two</DropdownMenu.RadioItem>
         </DropdownMenu.RadioGroup>
@@ -557,34 +362,68 @@ function RadioTestExample() {
   );
 }
 
-export const RadioItemTest: Story = {
-  render: () => <RadioTestExample />,
+export const InteractionTest: Story = {
+  tags: ["!autodocs"],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  render: () => <InteractionExample />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-
-    // Open dropdown
     const trigger = canvas.getByRole("button", { name: "Open Menu" });
+
+    // Opens on Enter; the first item takes the highlight and the disabled item is marked
+    trigger.focus();
+    await userEvent.keyboard("{Enter}");
+    let menu = await screen.findByRole("menu");
+    await waitFor(() =>
+      expect(within(menu).getByRole("menuitem", { name: "Profile" })).toHaveAttribute(
+        "data-highlighted",
+      ),
+    );
+    await expect(within(menu).getByRole("menuitem", { name: "Disabled" })).toHaveAttribute(
+      "data-disabled",
+    );
+
+    // Arrow keys move the highlight through the menu
+    await userEvent.keyboard("{ArrowDown}");
+
+    // Escape closes
+    await userEvent.keyboard("{Escape}");
+    await expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+
+    // Selecting a plain item closes the menu
     await userEvent.click(trigger);
+    menu = await screen.findByRole("menu");
+    await userEvent.click(within(menu).getByRole("menuitem", { name: "Profile" }));
+    await expect(screen.queryByRole("menu")).not.toBeInTheDocument();
 
-    // Wait for menu to be visible
-    const menu = await screen.findByRole("menu");
-    await expect(menu).toBeInTheDocument();
+    // Checkbox item toggles and persists across a reopen
+    await userEvent.click(trigger);
+    menu = await screen.findByRole("menu");
+    const checkbox = within(menu).getByRole("menuitemcheckbox", { name: "Toggle Option" });
+    await expect(checkbox).toHaveAttribute("aria-checked", "false");
+    await userEvent.click(checkbox);
+    await expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+    await userEvent.click(trigger);
+    menu = await screen.findByRole("menu");
+    await expect(
+      within(menu).getByRole("menuitemcheckbox", { name: "Toggle Option" }),
+    ).toHaveAttribute("aria-checked", "true");
 
-    // Verify initial selection
-    const optionOne = within(menu).getByRole("menuitemradio", { name: "Option One" });
+    // Radio item selects one of the group and persists across a reopen
     const optionTwo = within(menu).getByRole("menuitemradio", { name: "Option Two" });
-    await expect(optionOne).toHaveAttribute("aria-checked", "true");
     await expect(optionTwo).toHaveAttribute("aria-checked", "false");
-
-    // Select option two
     await userEvent.click(optionTwo);
-
-    // Re-open menu to verify state
     await userEvent.click(trigger);
-    const menuAfter = await screen.findByRole("menu");
-    const optionOneAfter = within(menuAfter).getByRole("menuitemradio", { name: "Option One" });
-    const optionTwoAfter = within(menuAfter).getByRole("menuitemradio", { name: "Option Two" });
-    await expect(optionOneAfter).toHaveAttribute("aria-checked", "false");
-    await expect(optionTwoAfter).toHaveAttribute("aria-checked", "true");
+    menu = await screen.findByRole("menu");
+    await expect(within(menu).getByRole("menuitemradio", { name: "Option One" })).toHaveAttribute(
+      "aria-checked",
+      "false",
+    );
+    await expect(within(menu).getByRole("menuitemradio", { name: "Option Two" })).toHaveAttribute(
+      "aria-checked",
+      "true",
+    );
   },
 };

--- a/src/components/sheet.stories.tsx
+++ b/src/components/sheet.stories.tsx
@@ -57,54 +57,6 @@ export const Default: Story = {
   },
 };
 
-export const LeftSide: Story = {
-  args: {
-    side: "left",
-    trigger: <Button>Open Left</Button>,
-    children: (
-      <>
-        <Sheet.Header>
-          <Sheet.Title>Left Sheet</Sheet.Title>
-          <Sheet.Description>This sheet slides in from the left.</Sheet.Description>
-        </Sheet.Header>
-        <div className="py-4">
-          <p className="text-fg-muted text-sm">Navigation menu or sidebar content.</p>
-        </div>
-      </>
-    ),
-  },
-};
-
-export const TopSide: Story = {
-  args: {
-    side: "top",
-    trigger: <Button>Open Top</Button>,
-    children: (
-      <>
-        <Sheet.Header>
-          <Sheet.Title>Top Sheet</Sheet.Title>
-          <Sheet.Description>This sheet slides in from the top.</Sheet.Description>
-        </Sheet.Header>
-      </>
-    ),
-  },
-};
-
-export const BottomSide: Story = {
-  args: {
-    side: "bottom",
-    trigger: <Button>Open Bottom</Button>,
-    children: (
-      <>
-        <Sheet.Header>
-          <Sheet.Title>Bottom Sheet</Sheet.Title>
-          <Sheet.Description>This sheet slides in from the bottom.</Sheet.Description>
-        </Sheet.Header>
-      </>
-    ),
-  },
-};
-
 export const PreventClose: Story = {
   args: {
     preventClose: true,
@@ -268,112 +220,60 @@ export const AllStates = () => (
   </div>
 );
 
-export const OpenCloseTest: Story = {
-  args: {
-    trigger: <Button>Open Sheet</Button>,
-    children: (
-      <>
+// One consolidated test folding the three former per-behavior tests across two
+// instances: the default sheet (closes via the X button and via an action
+// button) and preventClose (Escape is a no-op, the action button still closes).
+export const InteractionTest: Story = {
+  tags: ["!autodocs"],
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+  render: () => (
+    <div className="flex gap-2">
+      <Sheet trigger={<Button>Open default</Button>}>
         <Sheet.Header>
-          <Sheet.Title>Test Sheet</Sheet.Title>
+          <Sheet.Title>Default</Sheet.Title>
         </Sheet.Header>
         <Sheet.Footer>
           <Sheet.Close>
             <Button variant="outline">Close</Button>
           </Sheet.Close>
         </Sheet.Footer>
-      </>
-    ),
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
+      </Sheet>
 
-    // Open sheet
-    const trigger = canvas.getByRole("button", { name: "Open Sheet" });
-    await userEvent.click(trigger);
-
-    // Wait for sheet to be visible
-    const sheetElement = await screen.findByRole("dialog");
-    await expect(sheetElement).toBeInTheDocument();
-
-    // Close sheet via close button
-    const closeButton = within(sheetElement).getByRole("button", { name: "Close" });
-    await userEvent.click(closeButton);
-
-    // Verify sheet is closed
-    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-  },
-};
-
-export const CloseViaXButtonTest: Story = {
-  args: {
-    trigger: <Button>Open Sheet</Button>,
-    children: (
-      <>
+      <Sheet preventClose trigger={<Button>Open prevent-close</Button>}>
         <Sheet.Header>
-          <Sheet.Title>Test Sheet</Sheet.Title>
-        </Sheet.Header>
-      </>
-    ),
-  },
-  play: async ({ canvasElement }) => {
-    const canvas = within(canvasElement);
-
-    // Open sheet
-    const trigger = canvas.getByRole("button", { name: "Open Sheet" });
-    await userEvent.click(trigger);
-
-    // Wait for sheet to be visible
-    const sheetElement = await screen.findByRole("dialog");
-    await expect(sheetElement).toBeInTheDocument();
-
-    // Close via X button
-    const xButton = within(sheetElement).getByRole("button", { name: "Close sheet" });
-    await userEvent.click(xButton);
-
-    // Verify sheet is closed
-    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
-  },
-};
-
-export const PreventCloseTest: Story = {
-  args: {
-    preventClose: true,
-    trigger: <Button>Open Sheet</Button>,
-    children: (
-      <>
-        <Sheet.Header>
-          <Sheet.Title>Cannot dismiss by escape</Sheet.Title>
+          <Sheet.Title>Prevent close</Sheet.Title>
         </Sheet.Header>
         <Sheet.Footer>
           <Sheet.Close>
             <Button>Close via button</Button>
           </Sheet.Close>
         </Sheet.Footer>
-      </>
-    ),
-  },
+      </Sheet>
+    </div>
+  ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // Open sheet
-    const trigger = canvas.getByRole("button", { name: "Open Sheet" });
-    await userEvent.click(trigger);
+    // Default sheet: opens on trigger, closes via its X button
+    await userEvent.click(canvas.getByRole("button", { name: "Open default" }));
+    let sheet = await screen.findByRole("dialog");
+    await userEvent.click(within(sheet).getByRole("button", { name: "Close sheet" }));
+    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
-    // Wait for sheet to be visible
-    const sheetElement = await screen.findByRole("dialog");
-    await expect(sheetElement).toBeInTheDocument();
+    // ...and via an action button
+    await userEvent.click(canvas.getByRole("button", { name: "Open default" }));
+    sheet = await screen.findByRole("dialog");
+    await userEvent.click(within(sheet).getByRole("button", { name: "Close" }));
+    await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
 
-    // Try to close with Escape - should not close due to preventClose
+    // preventClose: Escape is a no-op; the action button still closes
+    await userEvent.click(canvas.getByRole("button", { name: "Open prevent-close" }));
+    sheet = await screen.findByRole("dialog");
     await userEvent.keyboard("{Escape}");
-
-    // Sheet should still be visible
-    await expect(screen.queryByRole("dialog")).toBeInTheDocument();
-
-    // Close via button - should work
-    const closeButton = within(sheetElement).getByRole("button", { name: "Close via button" });
-    await userEvent.click(closeButton);
-
-    // Verify sheet is closed
+    await expect(screen.getByRole("dialog")).toBeInTheDocument();
+    await userEvent.click(within(sheet).getByRole("button", { name: "Close via button" }));
     await expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   },
 };


### PR DESCRIPTION
Batch 2 of the stories-concise sweep — the **feature-heavy** components. Same discipline as #652: fold pure prop-permutations into the `All*` compositions + Controls, and collapse each file's several per-behavior `*Test` stories into one consolidated `InteractionTest`. Genuinely-distinct feature/behavior compositions are kept.

| component | exports | notes |
|---|---|---|
| dropdown-menu | **15 → 8** | keep submenu/checkbox/radio/inset + `TriggerOpenState` held-open demo · fold `DestructiveItem`/`WithDisabledItems` · 6 tests → 1 |
| data-table | **15 → 10** | keep search/pagination/selection/compact/empty/wide-content · fold `WithRowClick` · 5 tests → 1 · **keep both** `FullFeatured`+`AllFeatures` |
| dialog | **11 → 7** | keep PreventClose/HideCloseButton/WithForm/Controlled · fold `Destructive` · 4 tests → 1 |
| sheet | **11 → 6** | keep PreventClose/Controlled/FullScreen · fold `LeftSide`/`TopSide`/`BottomSide` · 3 tests → 1 |

**52 → 31 exports, −631/+200 lines.**

### Two judgment forks (asked before starting, set the batch precedent)
1. **Fold policy = prop-permutations too** (Button-concise), not test-consolidation only — so the prop-only variant stories that `All*` already covers were folded.
2. **data-table `FullFeatured` + `AllFeatures` both kept** — they map to two distinct registry surfaces (the span-3 showcase *preview card* vs the docs-body *breakdown*), so neither is redundant.

`sheet` `FullScreen` was kept (the goal scoped sheet's fold to the *side* variants only; `fullScreen` is a capability/use-case like dialog's `WithForm`). Every fold is itemized under Kept/Folded in the changeset for a one-comment veto.

### Verification
- Full Storybook vitest suite **151/151**
- `tsc --noEmit` clean · prettier clean
- Registry cross-check: `Default` / `AllStates` / `FullFeatured` / `AllFeatures` all survive
- Grep over `docs/` · `.storybook/` · `.mdx` · `.astro` — **no dangling reference** to any removed story name
- Consolidated tests preserve intent (dropdown keeps both click-open and keyboard-open; data-table even upgrades sorting to `aria-sort` assertions)

Empty (no-bump) changeset — stories ship in no tarball, no `.tsx` touched — matching #642 / #652.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M8TJKZycXhCNFNFY2QsxY