### PR TITLE
fix(switch): render an invalid state

### DIFF
--- a/.changeset/switch-invalid-state.md
+++ b/.changeset/switch-invalid-state.md
@@ -1,0 +1,7 @@
+---
+"@beaket/ui": patch
+---
+
+Switch now renders an invalid state.
+
+Switch was the only form control with no `aria-invalid` styling — a required switch marked invalid (e.g. an unaccepted terms toggle) showed no visual change, while its instrument siblings Checkbox and Radio both recolor. It now follows the same instrument grammar: `aria-invalid` recolors the border and focus ring to danger while the accent edge stays (role-agnostic, exactly as on Checkbox/Radio and the Select trigger).

--- a/src/components/switch.stories.tsx
+++ b/src/components/switch.stories.tsx
@@ -68,6 +68,10 @@ export const AllStates: Story = {
         <Switch disabled defaultChecked={true} aria-label="Disabled checked switch" />
         <span className="text-sm">Disabled (checked)</span>
       </div>
+      <div className="flex items-center gap-3">
+        <Switch aria-invalid aria-label="Invalid switch" />
+        <span className="text-sm">Invalid</span>
+      </div>
     </div>
   ),
 };

--- a/src/components/switch.tsx
+++ b/src/components/switch.tsx
@@ -8,8 +8,10 @@ const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 // Instrument grammar: the track floats on a static accent edge; pressing
 // travels the thumb (the key) 1px instead of dropping the chassis. Checked
 // fills with ink — state is carried by thumb position + ink, not a signal role.
+// Invalid recolors border + focus ring to danger while the accent edge stays
+// (role-agnostic, exactly as on checkbox/radio).
 const switchVariants = cva(
-  "group peer inline-flex shrink-0 cursor-pointer items-center p-0.5 transition-colors duration-100 outline-none shadow-offset-action data-[state=checked]:bg-bg-emphasis enabled:data-[state=checked]:hover:bg-bg-emphasis-hover data-[state=unchecked]:bg-border-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-border-focus disabled:shadow-none disabled:cursor-not-allowed disabled:border-dashed disabled:border-border-muted disabled:bg-bg-disabled disabled:text-fg-disabled disabled:data-[state=checked]:bg-bg-disabled border border-border-strong relative before:absolute before:inset-[-14px] before:content-['']",
+  "group peer inline-flex shrink-0 cursor-pointer items-center p-0.5 transition-colors duration-100 outline-none shadow-offset-action data-[state=checked]:bg-bg-emphasis enabled:data-[state=checked]:hover:bg-bg-emphasis-hover data-[state=unchecked]:bg-border-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-border-focus disabled:shadow-none disabled:cursor-not-allowed disabled:border-dashed disabled:border-border-muted disabled:bg-bg-disabled disabled:text-fg-disabled disabled:data-[state=checked]:bg-bg-disabled aria-[invalid=true]:border-danger-solid aria-[invalid=true]:focus-visible:outline-danger-solid border border-border-strong relative before:absolute before:inset-[-14px] before:content-['']",
   {
     variants: {
       size: {


### PR DESCRIPTION
## What

Switch was the **only form control with no `aria-invalid` styling**. A required switch marked invalid (e.g. an unaccepted terms toggle) showed no visual change, while its instrument siblings **Checkbox** and **Radio** both recolor.

It now follows the same instrument grammar as its siblings:

- `aria-invalid` recolors the **border** and **focus ring** to danger
- the **accent edge stays** (role-agnostic — exactly as on Checkbox/Radio and the Select trigger)

This closes the sharpest gap from a form-family expression audit: `select · checkbox · radio · input · textarea · switch` now all respond to `aria-invalid`.

## Changes

| File | Change |
|---|---|
| `src/components/switch.tsx` | append `aria-[invalid=true]:border-danger-solid` + `aria-[invalid=true]:focus-visible:outline-danger-solid` to `switchVariants` |
| `src/components/switch.stories.tsx` | add an `Invalid` row to `AllStates` (mirrors the Checkbox convention) |
| `.changeset/switch-invalid-state.md` | `patch` |

## Verification

- prettier clean · `tsc --noEmit` no switch errors · vitest **6/6** pass
- Browser-confirmed in Storybook: invalid switch shows the **danger border** with the **accent offset edge retained**, distinct from the accent-bordered unchecked state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M8TJKZycXhCNFNFY2QsxY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Switches marked as invalid now display the danger-colored border and focus ring, matching other form controls.
* **Documentation**
  * Added an invalid-state example to the Switch component showcase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->