### PR TITLE
fix(switch): give the off state a hover tint

### DIFF
--- a/.changeset/switch-off-hover.md
+++ b/.changeset/switch-off-hover.md
@@ -1,0 +1,7 @@
+---
+"@beaket/ui": patch
+---
+
+Switch off-state now responds to hover.
+
+The switch was the one instrument with no hover feedback when off — its checked track warms on hover and its siblings Checkbox and Radio tint their surface, but the off-channel sat inert. It now darkens one token step on hover (`border-muted` → `border`), completing the instrument grammar: hover tints the surface, press travels the key (the switch already travels its thumb, so no active tint is added).

--- a/src/components/switch.tsx
+++ b/src/components/switch.tsx
@@ -8,10 +8,12 @@ const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 // Instrument grammar: the track floats on a static accent edge; pressing
 // travels the thumb (the key) 1px instead of dropping the chassis. Checked
 // fills with ink — state is carried by thumb position + ink, not a signal role.
+// Hover tints the surface, like checkbox/radio: the on-track warms
+// (emphasis-hover), the off-channel darkens one step (border-muted → border).
 // Invalid recolors border + focus ring to danger while the accent edge stays
 // (role-agnostic, exactly as on checkbox/radio).
 const switchVariants = cva(
-  "group peer inline-flex shrink-0 cursor-pointer items-center p-0.5 transition-colors duration-100 outline-none shadow-offset-action data-[state=checked]:bg-bg-emphasis enabled:data-[state=checked]:hover:bg-bg-emphasis-hover data-[state=unchecked]:bg-border-muted focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-border-focus disabled:shadow-none disabled:cursor-not-allowed disabled:border-dashed disabled:border-border-muted disabled:bg-bg-disabled disabled:text-fg-disabled disabled:data-[state=checked]:bg-bg-disabled aria-[invalid=true]:border-danger-solid aria-[invalid=true]:focus-visible:outline-danger-solid border border-border-strong relative before:absolute before:inset-[-14px] before:content-['']",
+  "group peer inline-flex shrink-0 cursor-pointer items-center p-0.5 transition-colors duration-100 outline-none shadow-offset-action data-[state=checked]:bg-bg-emphasis enabled:data-[state=checked]:hover:bg-bg-emphasis-hover data-[state=unchecked]:bg-border-muted enabled:data-[state=unchecked]:hover:bg-border focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-border-focus disabled:shadow-none disabled:cursor-not-allowed disabled:border-dashed disabled:border-border-muted disabled:bg-bg-disabled disabled:text-fg-disabled disabled:data-[state=checked]:bg-bg-disabled aria-[invalid=true]:border-danger-solid aria-[invalid=true]:focus-visible:outline-danger-solid border border-border-strong relative before:absolute before:inset-[-14px] before:content-['']",
   {
     variants: {
       size: {


### PR DESCRIPTION
## What

The switch was the **one instrument with no hover feedback when off** (finding **#4**). Its checked track warms on hover, and its instrument siblings **Checkbox** and **Radio** tint their surface on hover — but the off-channel sat inert.

It now **darkens one token step on hover** (`border-muted` → `border`, i.e. tone-3 → tone-4), completing the instrument grammar:

- **hover tints the surface** — now true for the off state too
- **press travels the key** — the switch already travels its thumb, so no active surface tint is added (unlike Checkbox, which has no visible key when unchecked)

Tokens only — no `color-mix`. The magnitude (a full ramp step, firmer than the siblings' near-white tint) was chosen deliberately: the off-channel is a mid-light grey, so it can't move by the same near-invisible delta a white box does, and holding the token line is worth a hover that's a touch firmer.

## Verification

- Browser (Storybook): off-track darkens tone-3 → tone-4 on hover; checked/disabled/invalid unchanged.
- vitest switch **6/6** · `tsc` clean · prettier clean.
- **Chromatic**: no snapshot change at rest (hover isn't captured); this is a `:hover`-only addition.

Closes the last item of the form-family expression audit (#1 switch invalid, #2 invalid-edge rule, #3 select belonging, #4 switch off-hover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M8TJKZycXhCNFNFY2QsxY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hover feedback for Switch controls in the off state.
  * The off-state track now darkens slightly when hovered, providing consistent interaction feedback.

* **Documentation**
  * Added release documentation for the Switch hover-state improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->