### PR TITLE
feat(card): a surface, not a template

### DIFF
--- a/.changeset/card-surface-redesign.md
+++ b/.changeset/card-surface-redesign.md
@@ -1,0 +1,14 @@
+---
+"@beaket/ui": minor
+---
+
+Card is a surface, not a template.
+
+Reframed the Card around its material rather than an imposed structure. Its identity is now the drawn surface — square corners, a single-ink border, and the grey offset shade that marks a raised thing — and it imposes no header/body/footer: the root carries sensible padding and a column gap so you can pour any content straight in and it sits right. This is what pulls it away from reading like a Dialog, whose Cancel/confirm footer was the tell.
+
+- **`elevation` prop** (`flat` \| `shade` \| `overlay`, default `shade`) replaces the old `shadow?: boolean`. `shade` is the quiet grey offset that says "raised surface"; `overlay` lifts it onto `bg-bg-overlay` with the heavier offset; `flat` sits flush.
+- **`interactive` prop** — when the whole card is a link it earns the accent edge in place of the grey shade: thin at rest, grown on hover, dropped onto the edge when pressed. Pair with `asChild` to render a real `<a>` (the one place a surface carries the vivid voice).
+- **`Card.Section`** — an edge-to-edge helper that cancels the root padding so media and full-width rules reach the card's edges.
+- `Header` / `Title` / `Description` / `Action` / `Content` / `Footer` remain as optional, padding-free layout helpers — never the required anatomy.
+
+Migration: replace `<Card shadow>` with `<Card elevation="shade">` (now the default, so plain `<Card>` also lifts); a card with no shade is `<Card elevation="flat">`.

--- a/registry/registry.json
+++ b/registry/registry.json
@@ -213,14 +213,19 @@
     },
     {
       "name": "card",
-      "description": "Container component for grouping related content and actions",
-      "dependencies": ["clsx", "tailwind-merge"],
+      "description": "A quiet, content-free surface — identity in the material, flexibility in the children",
+      "dependencies": [
+        "@radix-ui/react-slot",
+        "class-variance-authority",
+        "clsx",
+        "tailwind-merge"
+      ],
       "registryDependencies": [],
       "files": ["components/card.tsx"],
       "docs": {
         "title": "Card",
-        "tagline": "A versatile container for grouping related content and actions.",
-        "sections": ["AllStates"],
+        "tagline": "A surface, not a template — pour any content into a quiet, drawn frame.",
+        "sections": ["Elevation", "Interactive", "AnyContent"],
         "previewStory": "Default"
       }
     },

--- a/src/components/card.stories.tsx
+++ b/src/components/card.stories.tsx
@@ -1,17 +1,20 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, within } from "storybook/test";
-import { Button } from "./button";
 import { Card } from "./card";
 
 const meta: Meta<typeof Card> = {
   title: "UI/Card",
   component: Card,
   tags: ["autodocs"],
+  argTypes: {
+    elevation: { control: "select", options: ["flat", "shade", "overlay"] },
+    interactive: { control: "boolean" },
+  },
   parameters: {
     docs: {
       description: {
         component:
-          "A versatile container component for grouping related content and actions. Uses a compound component pattern with Header, Title, Description, Action, Content, and Footer sub-components.",
+          "A surface, not a template. The Card's identity is its material — square corners, a single-ink border, and the drawn grey offset shade that marks a raised surface — and it imposes no structure: pour any content in. `elevation` sets how it lifts (flat / shade / overlay); `interactive` turns the whole card into a pressable link that carries the accent edge. Header / Title / Description / Action / Content / Footer and Section are optional layout helpers, never required anatomy.",
       },
     },
   },
@@ -21,139 +24,155 @@ export default meta;
 type Story = StoryObj<typeof Card>;
 
 export const Default: Story = {
-  render: () => (
-    <Card className="max-w-sm">
+  args: { elevation: "shade", interactive: false },
+  render: (args) => (
+    <Card {...args} className="max-w-sm">
       <Card.Header>
-        <Card.Title>Card Title</Card.Title>
-        <Card.Description>Card description text goes here.</Card.Description>
+        <Card.Title>acme-web</Card.Title>
+        <Card.Description>Marketing site and docs, deployed on the edge.</Card.Description>
       </Card.Header>
       <Card.Content>
         <p className="text-fg-muted text-sm">
-          This is the card content. You can put any content here.
-        </p>
-      </Card.Content>
-      <Card.Footer>
-        <Button>Action</Button>
-      </Card.Footer>
-    </Card>
-  ),
-};
-
-export const WithAction: Story = {
-  render: () => (
-    <Card className="max-w-sm">
-      <Card.Header>
-        <Card.Title>Project Settings</Card.Title>
-        <Card.Description>Manage your project configuration.</Card.Description>
-        <Card.Action>
-          <Button variant="outline" size="sm">
-            Edit
-          </Button>
-        </Card.Action>
-      </Card.Header>
-      <Card.Content>
-        <p className="text-fg-muted text-sm">
-          Configure project name, description, and visibility settings.
+          Deploys run on every push to <code>main</code>. Nothing else to configure.
         </p>
       </Card.Content>
     </Card>
   ),
 };
 
-export const Simple: Story = {
-  render: () => (
-    <Card className="max-w-sm">
-      <Card.Content>
-        <p className="text-sm">A simple card with only content, no header or footer.</p>
-      </Card.Content>
-    </Card>
-  ),
-};
+export const Elevation = () => (
+  <div className="flex flex-wrap items-start gap-6">
+    {(["flat", "shade", "overlay"] as const).map((e) => (
+      <Card key={e} elevation={e} className="w-52">
+        <Card.Header>
+          <Card.Title>acme-web</Card.Title>
+          <Card.Description>{e}</Card.Description>
+        </Card.Header>
+      </Card>
+    ))}
+  </div>
+);
 
-export const AllStates = () => (
-  <div className="grid max-w-2xl gap-6">
-    <Card>
-      <Card.Header>
-        <Card.Title>Basic Card</Card.Title>
-        <Card.Description>A simple card with header and content.</Card.Description>
-      </Card.Header>
-      <Card.Content>
-        <p className="text-fg-muted text-sm">Card content goes here.</p>
-      </Card.Content>
+export const Interactive = () => (
+  <div className="flex max-w-sm flex-col gap-3">
+    <Card asChild interactive>
+      <a href="#acme-web">
+        <Card.Header>
+          <Card.Title>acme-web</Card.Title>
+          <Card.Description>Open the project — the whole card is the link.</Card.Description>
+        </Card.Header>
+      </a>
     </Card>
+    <p className="text-fg-muted text-sm">
+      Hover to grow the accent edge; press to drop the card onto it.
+    </p>
+  </div>
+);
 
+// The same frame every time — only the children change. That is the flexibility:
+// identity in the material, content free.
+export const AnyContent = () => (
+  <div className="grid max-w-3xl grid-cols-[repeat(auto-fill,minmax(200px,1fr))] gap-4">
     <Card>
-      <Card.Header>
-        <Card.Title>With Footer</Card.Title>
-        <Card.Description>Card with action buttons in footer.</Card.Description>
-      </Card.Header>
-      <Card.Content>
-        <p className="text-fg-muted text-sm">Some content here.</p>
-      </Card.Content>
-      <Card.Footer>
-        <Button variant="outline">Cancel</Button>
-        <Button>Save</Button>
-      </Card.Footer>
-    </Card>
-
-    <Card>
-      <Card.Header>
-        <Card.Title>With Action Button</Card.Title>
-        <Card.Description>Header contains an action button.</Card.Description>
-        <Card.Action>
-          <Button variant="outline" size="sm">
-            Settings
-          </Button>
-        </Card.Action>
-      </Card.Header>
-      <Card.Content>
-        <p className="text-fg-muted text-sm">Content with header action.</p>
-      </Card.Content>
+      <div>
+        <div className="text-3xl font-semibold tracking-tight tabular-nums">1.28M</div>
+        <div className="text-fg-subtle mt-1 text-xs tracking-wide uppercase">
+          requests · this month
+        </div>
+      </div>
     </Card>
 
     <Card>
-      <Card.Header className="border-border border-b">
-        <Card.Title>With Bordered Header</Card.Title>
-        <Card.Description>The header has a bottom border.</Card.Description>
-      </Card.Header>
-      <Card.Content>
-        <p className="text-fg-muted text-sm">Content below bordered header.</p>
-      </Card.Content>
+      <dl className="grid gap-2 text-sm">
+        <div className="flex justify-between">
+          <dt className="text-fg-muted">Plan</dt>
+          <dd>Team</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-fg-muted">Seats</dt>
+          <dd className="tabular-nums">12</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt className="text-fg-muted">Region</dt>
+          <dd>iad1</dd>
+        </div>
+      </dl>
+    </Card>
+
+    <Card>
+      <div className="flex items-center gap-3">
+        <div className="bg-bg-emphasis text-fg-on-emphasis grid size-11 place-items-center font-semibold">
+          J
+        </div>
+        <div>
+          <div className="font-semibold">Jin Ma</div>
+          <div className="text-fg-muted text-sm">Maintainer</div>
+        </div>
+      </div>
+    </Card>
+
+    <Card>
+      <Card.Section>
+        <div className="bg-bg-hover text-fg-subtle flex h-24 items-center justify-center text-xs tracking-wide uppercase">
+          figure
+        </div>
+      </Card.Section>
+      <div>
+        <div className="font-semibold">Elevation, drawn</div>
+        <div className="text-fg-muted text-sm">Depth without light.</div>
+      </div>
+    </Card>
+
+    <Card>
+      <blockquote className="text-sm">
+        <p>&ldquo;Ink is never diluted, only rationed.&rdquo;</p>
+        <footer className="text-fg-subtle mt-2 text-xs tracking-wide uppercase">
+          Ink &amp; Instrument
+        </footer>
+      </blockquote>
+    </Card>
+
+    <Card>
+      <div className="text-fg-subtle text-center">
+        <div className="text-border font-mono text-2xl">&empty;</div>
+        <div className="mt-1 text-sm">No projects yet</div>
+      </div>
     </Card>
   </div>
 );
 
 export const InteractionTest: Story = {
   render: () => (
-    <Card className="max-w-sm" data-testid="test-card">
-      <Card.Header>
-        <Card.Title data-testid="card-title">Test Title</Card.Title>
-        <Card.Description data-testid="card-description">Test description</Card.Description>
-      </Card.Header>
-      <Card.Content data-testid="card-content">
-        <p>Test content</p>
-      </Card.Content>
-      <Card.Footer data-testid="card-footer">
-        <Button>Test Action</Button>
-      </Card.Footer>
-    </Card>
+    <div className="flex flex-col gap-4">
+      <Card data-testid="surface" className="max-w-sm">
+        <Card.Header>
+          <Card.Title data-testid="title">acme-web</Card.Title>
+          <Card.Description data-testid="desc">Edge-deployed.</Card.Description>
+        </Card.Header>
+        <Card.Content data-testid="content">Ready on main.</Card.Content>
+      </Card>
+      <Card asChild interactive>
+        <a href="#open" data-testid="link">
+          <Card.Title>Open acme-web</Card.Title>
+        </a>
+      </Card>
+    </div>
   ),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    const card = canvas.getByTestId("test-card");
-    await expect(card).toBeInTheDocument();
+    const surface = canvas.getByTestId("surface");
+    await expect(surface).toBeInTheDocument();
+    await expect(surface).toHaveAttribute("data-slot", "card");
 
-    const title = canvas.getByTestId("card-title");
-    await expect(title).toHaveTextContent("Test Title");
+    await expect(canvas.getByTestId("title")).toHaveTextContent("acme-web");
+    await expect(canvas.getByTestId("desc")).toHaveTextContent("Edge-deployed.");
+    await expect(canvas.getByTestId("content")).toHaveTextContent("Ready on main.");
 
-    const description = canvas.getByTestId("card-description");
-    await expect(description).toHaveTextContent("Test description");
-
-    const content = canvas.getByTestId("card-content");
-    await expect(content).toHaveTextContent("Test content");
-
-    const footer = canvas.getByTestId("card-footer");
-    await expect(footer).toBeInTheDocument();
+    // An interactive card renders as a real, focusable link (asChild).
+    const link = canvas.getByTestId("link");
+    await expect(link.tagName).toBe("A");
+    link.focus();
+    await expect(link).toHaveFocus();
   },
 };

--- a/src/components/card.tsx
+++ b/src/components/card.tsx
@@ -1,33 +1,91 @@
+import { Slot } from "@radix-ui/react-slot";
+import { cva } from "class-variance-authority";
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));
 
-interface CardRootProps extends React.ComponentProps<"div"> {
-  /** Add offset shadow to the card */
-  shadow?: boolean;
+// A card is a surface, not a template. Its identity is the material — square
+// corners, a single-ink border, and the drawn grey offset shade that marks a
+// raised surface — never an imposed header/body/footer. Content is whatever you
+// pour in; the padding + column gap make raw children sit right with no ceremony.
+//
+// Exactly one shadow utility may ever land in the class list: twMerge can't
+// dedupe custom shadow utilities against one another, so the grey shade (per
+// elevation) and the pressable accent edge are assigned through mutually
+// exclusive compound variants rather than layered and overridden.
+const cardVariants = cva(
+  "border border-border-muted bg-bg-raised text-fg flex flex-col gap-4 p-5",
+  {
+    variants: {
+      elevation: {
+        flat: "",
+        shade: "",
+        overlay: "bg-bg-overlay",
+      },
+      interactive: {
+        true: "cursor-pointer transition-[box-shadow,translate] duration-100 active:translate-x-px active:translate-y-px focus-visible:outline-2 focus-visible:outline-border-focus focus-visible:outline-offset-2",
+        false: "",
+      },
+    },
+    compoundVariants: [
+      // Passive surface — the quiet grey shade, one drawn level per elevation.
+      { interactive: false, elevation: "shade", class: "shadow-offset" },
+      { interactive: false, elevation: "overlay", class: "shadow-offset-overlay" },
+      // Pressable — when the whole card is a link it earns the accent edge in place
+      // of the grey shade: thin at rest, grown on hover, dropped onto the edge when
+      // pressed. The one place a surface carries the vivid voice.
+      {
+        interactive: true,
+        class: "shadow-offset-action hover:shadow-offset-action-hover active:shadow-none",
+      },
+    ],
+    defaultVariants: { elevation: "shade", interactive: false },
+  },
+);
+
+export interface CardRootProps extends React.ComponentProps<"div"> {
+  /** flat | shade | overlay. How the surface lifts off the page — the drawn grey offset shade by default */
+  elevation?: "flat" | "shade" | "overlay";
+  /** Turn the whole card into a pressable link: the accent edge replaces the grey shade, grows on hover, and drops when pressed */
+  interactive?: boolean;
+  /** Merge props onto the immediate child (e.g. an `<a>`) instead of rendering a div — for a card that is itself a link */
+  asChild?: boolean;
 }
 
-function CardRoot({ className, shadow, ...props }: CardRootProps) {
+function CardRoot({ className, elevation, interactive, asChild = false, ...props }: CardRootProps) {
+  const Comp = asChild ? Slot : "div";
   return (
-    <div
+    <Comp
       data-slot="card"
-      className={cn(
-        "border-border bg-bg-raised text-fg flex flex-col gap-0 border",
-        shadow && "shadow-offset",
-        className,
-      )}
+      className={cn(cardVariants({ elevation, interactive }), className)}
       {...props}
     />
   );
 }
 
+// Edge-to-edge — cancels the root's padding so media and full-width rules reach
+// the card's edges. As the first/last child it also clears the top/bottom
+// padding (couples to the root's `p-5`; override alongside it if you change it).
+function CardSection({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-section"
+      className={cn("-mx-5 first:-mt-5 last:-mb-5", className)}
+      {...props}
+    />
+  );
+}
+
+// The parts below are optional layout helpers, never the required anatomy. They
+// carry no padding of their own — the root already pads and gaps them — so
+// reach for them only when you want the ruled-header/footer reading.
 function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card-header"
       className={cn(
-        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 pt-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 has-data-[slot=card-action]:grid-cols-[1fr_auto]",
         className,
       )}
       {...props}
@@ -42,7 +100,9 @@ function CardTitle({ className, ...props }: React.ComponentProps<"h4">) {
 }
 
 function CardDescription({ className, ...props }: React.ComponentProps<"p">) {
-  return <p data-slot="card-description" className={cn("text-fg-muted", className)} {...props} />;
+  return (
+    <p data-slot="card-description" className={cn("text-fg-muted text-sm", className)} {...props} />
+  );
 }
 
 function CardAction({ className, ...props }: React.ComponentProps<"div">) {
@@ -56,20 +116,17 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
 }
 
 function CardContent({ className, ...props }: React.ComponentProps<"div">) {
-  return <div data-slot="card-content" className={cn("px-6 pt-4 pb-6", className)} {...props} />;
+  return <div data-slot="card-content" className={cn(className)} {...props} />;
 }
 
 function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
   return (
-    <div
-      data-slot="card-footer"
-      className={cn("flex items-center gap-2 px-6 pb-6 [.border-t]:pt-6", className)}
-      {...props}
-    />
+    <div data-slot="card-footer" className={cn("flex items-center gap-2", className)} {...props} />
   );
 }
 
 export const Card = Object.assign(CardRoot, {
+  Section: CardSection,
   Header: CardHeader,
   Title: CardTitle,
   Description: CardDescription,


### PR DESCRIPTION
## A card is a surface, not a template

Redesigns the Card around its **material** instead of an imposed structure. The old Card shipped shadcn's mandatory `Header / Title / Description / Content / Footer` anatomy — and once you put a `Cancel / Save` footer on it, it read like a Dialog. The identity here is the drawn surface: **square corners, a single-ink hairline, and the grey offset shade** that marks a raised thing. Content is whatever you pour in.

This landed via an artifact-first dogfood loop (three rendered look-and-feel passes), and the direction was confirmed by research across ~11 libraries: beaket's `shadow-offset` (thin, no blur) sits closest to the neo-brutalist / offset family, not Material's blur ladder — a differentiator worth leaning into.

### What changed
- **`elevation`** (`flat` | `shade` | `overlay`, default `shade`) replaces `shadow?: boolean`. One drawn level per elevation, assigned through mutually exclusive `cva` compound variants so exactly one custom shadow utility ever lands (twMerge can't dedupe them against each other).
- **`interactive`** — when the whole card is a link it earns the accent edge in place of the grey shade (thin at rest → grown on hover → dropped when pressed). Pair with **`asChild`** to render a real `<a>`.
- **`Card.Section`** — an edge-to-edge helper that cancels the root padding so media and full-width rules reach the card's edges.
- The root now carries `p-5 gap-4`, so `<Card>anything</Card>` sits right with no ceremony.
- `Header / Title / Description / Action / Content / Footer` remain as **optional, padding-free** layout helpers — never required anatomy.
- Border is the tone-3 hairline (`border-border-muted`), keeping the surface quiet and honouring the one-pen "no middle grey" rule.

### Migration
`<Card shadow>` → `<Card elevation="shade">` (now the default, so plain `<Card>` also lifts). A card with no shade is `<Card elevation="flat">`.

### Verification
- 5 story tests pass (`Default`, `Elevation`, `Interactive`, `AnyContent`, `InteractionTest`); `tsc` + prettier clean.
- Rendered and eyeballed in Storybook: the elevation ladder, the `interactive` hover-grow / press-drop, and the `Card.Section` media bleed. `AnyContent` shows one identical frame holding a stat, a key/value list, a person, a media block, a quote, and an empty state — the "surface, not template" thesis in one screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned cards as flexible surfaces with flat, shaded, and overlay elevation options.
  * Added interactive card styling for link-like cards, including hover, press, and focus states.
  * Added `Card.Section` for full-width media and edge-to-edge content.
  * Cards now support arbitrary content and can render as external elements.

* **Documentation**
  * Added migration guidance for replacing the former shadow option with elevation settings.
  * Expanded examples covering elevation, interactive cards, and varied content layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->