### PR TITLE
feat(cli): warn and guide users when component styles are updated

### DIFF
--- a/.changeset/beaket-ui-diff-command.md
+++ b/.changeset/beaket-ui-diff-command.md
@@ -1,0 +1,10 @@
+---
+"@beaket/ui": minor
+---
+
+feat(cli): tell existing users when a component's style has moved
+
+Copied components don't auto-update, so a consumer on an older style had no way to know a component had been restyled upstream — `add` only knew "a file is here" and asked to overwrite, learning nothing about whether their copy was actually behind.
+
+- **`diff` command** — `npx @beaket/ui diff` lists every installed component as up to date or having upstream changes; `npx @beaket/ui diff <component>` prints the line-by-line diff between your copy and the registry, then points you at `add <component> --overwrite` (or hand-merging if you've customized it). It never writes — you own the code.
+- **Smarter `add`** — an existing file is compared against upstream: files already matching are left untouched (no prompt), and only a genuine upstream change prompts to overwrite, with wording that says your copy may be an older style rather than just that a file exists. Skipped files point at `diff` to see what changed.

--- a/.changeset/beaket-ui-diff-command.md
+++ b/.changeset/beaket-ui-diff-command.md
@@ -4,7 +4,7 @@
 
 feat(cli): tell existing users when a component's style has moved
 
-Copied components don't auto-update, so a consumer on an older style had no way to know a component had been restyled upstream — `add` only knew "a file is here" and asked to overwrite, learning nothing about whether their copy was actually behind.
+Copied components don't auto-update, so a consumer on an older style had no way to know a component now differs from the registry — `add` only knew "a file is here" and asked to overwrite, learning nothing about whether their copy was actually out of sync.
 
-- **`diff` command** — `npx @beaket/ui diff` lists every installed component as up to date or having upstream changes; `npx @beaket/ui diff <component>` prints the line-by-line diff between your copy and the registry, then points you at `add <component> --overwrite` (or hand-merging if you've customized it). It never writes — you own the code.
-- **Smarter `add`** — an existing file is compared against upstream: files already matching are left untouched (no prompt), and only a genuine upstream change prompts to overwrite, with wording that says your copy may be an older style rather than just that a file exists. Skipped files point at `diff` to see what changed.
+- **`diff` command** — `npx @beaket/ui diff` lists every installed component as matching the registry or differing from it; `npx @beaket/ui diff <component>` prints the line-by-line diff between your copy and the registry, then points you at `add <component> --overwrite` (or hand-merging if you've customized it). It never writes — you own the code. A difference may be an upstream restyle or your own edits; without installed-version tracking the CLI can't tell them apart, so it frames it as a difference and leaves the choice to you.
+- **Smarter `add`** — an existing file is compared against the registry: files already matching are left untouched (no prompt), and only files that differ prompt to overwrite, with wording that says your copy is out of sync rather than just that a file exists. Skipped files point at `diff` to see what changed.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -54,17 +54,17 @@ npx @beaket/ui add <components...> [options]
 | ----------------- | ------------------------ |
 | `-o, --overwrite` | Overwrite existing files |
 
-When a component already exists, `add` compares your copy against the latest registry version: files that already match are left untouched, and only genuine upstream changes prompt to overwrite — so you know your copy is behind an updated style, not just that a file is present.
+When a component already exists, `add` compares your copy against the latest registry version: files that already match are left untouched, and only files that differ prompt to overwrite — so you know your copy is out of sync, not just that a file is present.
 
 ### `diff`
 
-Check installed components for upstream style updates. Because you own the copied code, `diff` never changes anything — it just shows what moved and how to update.
+Check installed components against the registry. Because you own the copied code, `diff` never changes anything — it just shows what differs and how to update. A difference may be an upstream restyle or your own edits; the CLI can't tell them apart, so review before taking the latest.
 
 ```bash
 npx @beaket/ui diff [component]
 ```
 
-- Without an argument, lists every installed component as up to date or having upstream changes.
+- Without an argument, lists every installed component as matching the registry or differing from it.
 - With a component name, prints the line-by-line diff between your copy and the latest registry version, then points you at `add <component> --overwrite` to take the update (or hand-merge if you've customized it).
 
 ## License

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -54,6 +54,19 @@ npx @beaket/ui add <components...> [options]
 | ----------------- | ------------------------ |
 | `-o, --overwrite` | Overwrite existing files |
 
+When a component already exists, `add` compares your copy against the latest registry version: files that already match are left untouched, and only genuine upstream changes prompt to overwrite — so you know your copy is behind an updated style, not just that a file is present.
+
+### `diff`
+
+Check installed components for upstream style updates. Because you own the copied code, `diff` never changes anything — it just shows what moved and how to update.
+
+```bash
+npx @beaket/ui diff [component]
+```
+
+- Without an argument, lists every installed component as up to date or having upstream changes.
+- With a component name, prints the line-by-line diff between your copy and the latest registry version, then points you at `add <component> --overwrite` to take the update (or hand-merge if you've customized it).
+
 ## License
 
 MIT

--- a/packages/cli/src/commands/add.ts
+++ b/packages/cli/src/commands/add.ts
@@ -63,22 +63,34 @@ export async function add(componentNames: string[], options: AddOptions) {
   const componentsDir = path.join(process.cwd(), config.components);
   const allWritten: string[] = [];
   const allSkipped: string[] = [];
+  const allUnchanged: string[] = [];
 
   for (const def of componentDefs) {
     if (!def) continue;
     const files = await fetchComponent(def);
-    const { written, skipped } = await writeComponentFiles(componentsDir, files, options.overwrite);
+    const { written, skipped, unchanged } = await writeComponentFiles(
+      componentsDir,
+      files,
+      options.overwrite,
+    );
     allWritten.push(...written);
     allSkipped.push(...skipped);
+    allUnchanged.push(...unchanged);
+  }
+
+  // Files already matching upstream — reassure rather than warn.
+  if (allUnchanged.length > 0) {
+    console.log(pc.green("✔"), `${allUnchanged.length} file(s) already up to date.`);
   }
 
   // Show skipped files
   if (allSkipped.length > 0) {
     console.log(
       pc.yellow("ℹ"),
-      `Skipped ${allSkipped.length} file(s): (use --overwrite to overwrite)`,
+      `Skipped ${allSkipped.length} file(s): (use --overwrite to take the latest)`,
     );
     allSkipped.forEach((f) => console.log(`  - ${f}`));
+    console.log(pc.dim("  See what changed with"), pc.cyan("npx @beaket/ui diff <component>"));
   }
 
   if (allWritten.length === 0) {

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -1,0 +1,138 @@
+import path from "path";
+import pc from "picocolors";
+import { getConfig } from "../utils/config.ts";
+import {
+  collapseContext,
+  compareComponent,
+  diffLines,
+  isComponentInstalled,
+  type ComponentComparison,
+  type DiffLine,
+} from "../utils/diff.ts";
+import { fetchRegistry } from "../utils/registry.ts";
+
+function printDiffLine(line: DiffLine): void {
+  if (line.type === "add") console.log(pc.green(`+ ${line.text}`));
+  else if (line.type === "remove") console.log(pc.red(`- ${line.text}`));
+  else console.log(pc.dim(`  ${line.text}`));
+}
+
+function printFileDiff(cmp: ComponentComparison): void {
+  for (const file of cmp.files) {
+    if (file.status === "same") continue;
+
+    console.log();
+    if (file.status === "missing") {
+      console.log(pc.yellow(`  ${file.path}`), pc.dim("(new file — not in your project)"));
+      continue;
+    }
+
+    console.log(pc.bold(`  ${file.path}`));
+    const lines = collapseContext(diffLines(file.local ?? "", file.upstream));
+    lines.forEach(printDiffLine);
+  }
+}
+
+/** How many files in a comparison actually changed (differ or are new). */
+function changedCount(cmp: ComponentComparison): number {
+  return cmp.files.filter((f) => f.status !== "same").length;
+}
+
+export async function diff(componentName: string | undefined) {
+  console.log();
+
+  const config = await getConfig();
+  if (!config) {
+    console.log(pc.red("Error:"), "beaket.ui.json not found.");
+    console.log("Run", pc.cyan("npx @beaket/ui init"), "first.");
+    process.exit(1);
+  }
+
+  const registry = await fetchRegistry();
+  const componentsDir = path.join(process.cwd(), config.components);
+
+  // Single component: show the actual diff and how to update.
+  if (componentName) {
+    const def = registry.components.find((c) => c.name === componentName);
+    if (!def) {
+      console.log(pc.red("Error:"), `Component not found: ${componentName}`);
+      console.log();
+      console.log("Available components:");
+      registry.components.forEach((c) => console.log(`  - ${c.name}`));
+      process.exit(1);
+    }
+
+    const cmp = await compareComponent(def, componentsDir);
+
+    if (cmp.status === "not-installed") {
+      console.log(pc.yellow("ℹ"), `${componentName} is not installed.`);
+      console.log("  Add it with", pc.cyan(`npx @beaket/ui add ${componentName}`));
+      console.log();
+      return;
+    }
+
+    if (cmp.status === "up-to-date") {
+      console.log(pc.green("✔"), `${componentName} is up to date with the registry.`);
+      console.log();
+      return;
+    }
+
+    console.log(pc.yellow("⚠"), `${componentName} differs from the latest registry version.`);
+    printFileDiff(cmp);
+    console.log();
+    console.log(pc.dim("You own this code — review the changes above, then either:"));
+    console.log("  •", "hand-merge what you want to keep, or");
+    console.log(
+      "  •",
+      "take the latest with",
+      pc.cyan(`npx @beaket/ui add ${componentName} --overwrite`),
+    );
+    console.log();
+    return;
+  }
+
+  // Overview: check every installed component against upstream.
+  const installed: typeof registry.components = [];
+  for (const def of registry.components) {
+    if (await isComponentInstalled(def, componentsDir)) installed.push(def);
+  }
+
+  if (installed.length === 0) {
+    console.log(pc.yellow("ℹ"), `No Beaket UI components found in ${config.components}.`);
+    console.log("  Add one with", pc.cyan("npx @beaket/ui add button"));
+    console.log();
+    return;
+  }
+
+  console.log(pc.dim(`Checking ${installed.length} installed component(s) against the registry…`));
+
+  const results: ComponentComparison[] = [];
+  for (const def of installed) results.push(await compareComponent(def, componentsDir));
+
+  const outdated = results.filter((r) => r.status === "outdated");
+  const upToDate = results.filter((r) => r.status === "up-to-date");
+
+  console.log();
+  if (upToDate.length > 0) {
+    upToDate.forEach((r) => console.log(pc.green("✔"), r.name, pc.dim("up to date")));
+  }
+  outdated.forEach((r) => {
+    const files = changedCount(r);
+    console.log(pc.yellow("⚠"), r.name, pc.dim(`${files} file(s) changed upstream`));
+  });
+
+  console.log();
+  if (outdated.length === 0) {
+    console.log(pc.green("All components are up to date."));
+    console.log();
+    return;
+  }
+
+  console.log(pc.yellow(`${outdated.length} component(s) have upstream style updates.`));
+  console.log("  Review one with", pc.cyan("npx @beaket/ui diff <component>"));
+  console.log(
+    "  Update with     ",
+    pc.cyan(`npx @beaket/ui add ${outdated.map((r) => r.name).join(" ")} --overwrite`),
+  );
+  console.log();
+}

--- a/packages/cli/src/commands/diff.ts
+++ b/packages/cli/src/commands/diff.ts
@@ -91,7 +91,7 @@ export async function diff(componentName: string | undefined) {
     return;
   }
 
-  // Overview: check every installed component against upstream.
+  // Overview: check every installed component against the registry.
   const installed: typeof registry.components = [];
   for (const def of registry.components) {
     if (await isComponentInstalled(def, componentsDir)) installed.push(def);
@@ -118,17 +118,22 @@ export async function diff(componentName: string | undefined) {
   }
   outdated.forEach((r) => {
     const files = changedCount(r);
-    console.log(pc.yellow("⚠"), r.name, pc.dim(`${files} file(s) changed upstream`));
+    console.log(pc.yellow("⚠"), r.name, pc.dim(`${files} file(s) differ from the registry`));
   });
 
   console.log();
   if (outdated.length === 0) {
-    console.log(pc.green("All components are up to date."));
+    console.log(pc.green("All components match the registry."));
     console.log();
     return;
   }
 
-  console.log(pc.yellow(`${outdated.length} component(s) have upstream style updates.`));
+  console.log(pc.yellow(`${outdated.length} component(s) differ from the registry.`));
+  console.log(
+    pc.dim(
+      "  (a difference may be an upstream restyle or your own edits — review before updating)",
+    ),
+  );
   console.log("  Review one with", pc.cyan("npx @beaket/ui diff <component>"));
   console.log(
     "  Update with     ",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { add } from "./commands/add.ts";
+import { diff } from "./commands/diff.ts";
 import { init } from "./commands/init.ts";
 import { theme } from "./commands/theme.ts";
 
@@ -26,6 +27,12 @@ program
   .argument("<components...>", "Component names to add")
   .option("-o, --overwrite", "Overwrite existing files")
   .action(add);
+
+program
+  .command("diff")
+  .description("Check installed components for upstream style updates")
+  .argument("[component]", "Component to diff against the registry (omit to check all)")
+  .action((component?: string) => diff(component));
 
 program
   .command("theme")

--- a/packages/cli/src/utils/diff.test.ts
+++ b/packages/cli/src/utils/diff.test.ts
@@ -1,0 +1,181 @@
+import fs from "fs-extra";
+import os from "os";
+import path from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  collapseContext,
+  compareComponent,
+  deriveComponentStatus,
+  diffLines,
+  isComponentInstalled,
+  normalize,
+  toLocalRelativePath,
+  type FileComparison,
+} from "./diff.ts";
+import type { ComponentDefinition } from "./registry.ts";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("toLocalRelativePath", () => {
+  it("strips the registry components/ prefix", () => {
+    expect(toLocalRelativePath("components/button.tsx")).toBe("button.tsx");
+  });
+
+  it("leaves an already-flat path alone", () => {
+    expect(toLocalRelativePath("button.tsx")).toBe("button.tsx");
+  });
+});
+
+describe("normalize", () => {
+  it("treats CRLF and LF as equal", () => {
+    expect(normalize("a\r\nb")).toBe(normalize("a\nb"));
+  });
+
+  it("ignores trailing whitespace and a final newline", () => {
+    expect(normalize("a  \nb\n")).toBe(normalize("a\nb"));
+  });
+
+  it("keeps a real content difference", () => {
+    expect(normalize("a\nb")).not.toBe(normalize("a\nc"));
+  });
+});
+
+describe("deriveComponentStatus", () => {
+  const file = (status: FileComparison["status"]): FileComparison => ({
+    path: "x.tsx",
+    status,
+    local: "",
+    upstream: "",
+  });
+
+  it("is not-installed when every file is missing", () => {
+    expect(deriveComponentStatus([file("missing"), file("missing")])).toBe("not-installed");
+  });
+
+  it("is not-installed for an empty file list", () => {
+    expect(deriveComponentStatus([])).toBe("not-installed");
+  });
+
+  it("is up-to-date when all present files match", () => {
+    expect(deriveComponentStatus([file("same"), file("same")])).toBe("up-to-date");
+  });
+
+  it("is outdated when a present file differs", () => {
+    expect(deriveComponentStatus([file("same"), file("different")])).toBe("outdated");
+  });
+
+  it("is outdated when one file of a multi-file component is new", () => {
+    expect(deriveComponentStatus([file("same"), file("missing")])).toBe("outdated");
+  });
+});
+
+describe("diffLines", () => {
+  it("marks a changed line as remove + add and keeps context", () => {
+    const result = diffLines("a\nb\nc", "a\nB\nc");
+    expect(result).toEqual([
+      { type: "context", text: "a" },
+      { type: "remove", text: "b" },
+      { type: "add", text: "B" },
+      { type: "context", text: "c" },
+    ]);
+  });
+
+  it("reports all-context for identical input", () => {
+    expect(diffLines("a\nb", "a\nb").every((l) => l.type === "context")).toBe(true);
+  });
+
+  it("handles pure additions", () => {
+    const result = diffLines("a", "a\nb");
+    expect(result).toEqual([
+      { type: "context", text: "a" },
+      { type: "add", text: "b" },
+    ]);
+  });
+});
+
+describe("collapseContext", () => {
+  it("replaces a long unchanged run with a single marker", () => {
+    const lines = [
+      ...Array.from({ length: 10 }, (_, i) => ({ type: "context" as const, text: `c${i}` })),
+      { type: "add" as const, text: "new" },
+    ];
+    const collapsed = collapseContext(lines, 2);
+    // The far-away context lines collapse to one "…" marker; the 2 nearest remain.
+    expect(collapsed.filter((l) => l.text === "…")).toHaveLength(1);
+    expect(collapsed.some((l) => l.type === "add" && l.text === "new")).toBe(true);
+    expect(collapsed).toContainEqual({ type: "context", text: "c9" });
+    expect(collapsed).not.toContainEqual({ type: "context", text: "c0" });
+  });
+
+  it("leaves short diffs untouched", () => {
+    const lines = [
+      { type: "context" as const, text: "a" },
+      { type: "remove" as const, text: "b" },
+      { type: "add" as const, text: "B" },
+    ];
+    expect(collapseContext(lines)).toEqual(lines);
+  });
+});
+
+const buttonDef: ComponentDefinition = {
+  name: "button",
+  dependencies: [],
+  registryDependencies: [],
+  files: ["components/button.tsx"],
+};
+
+async function tempDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "beaket-diff-"));
+}
+
+describe("isComponentInstalled", () => {
+  it("is false when no file exists", async () => {
+    const dir = await tempDir();
+    expect(await isComponentInstalled(buttonDef, dir)).toBe(false);
+  });
+
+  it("is true when the component file exists", async () => {
+    const dir = await tempDir();
+    await fs.writeFile(path.join(dir, "button.tsx"), "x");
+    expect(await isComponentInstalled(buttonDef, dir)).toBe(true);
+  });
+});
+
+describe("compareComponent", () => {
+  function stubFetchContent(content: string) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(new Response(content, { status: 200 }))),
+    );
+  }
+
+  it("reports not-installed when the file is absent locally", async () => {
+    const dir = await tempDir();
+    stubFetchContent("export const Button = 1;");
+    const cmp = await compareComponent(buttonDef, dir);
+    expect(cmp.status).toBe("not-installed");
+    expect(cmp.files[0].status).toBe("missing");
+  });
+
+  it("reports up-to-date when local matches upstream (ignoring line endings)", async () => {
+    const dir = await tempDir();
+    await fs.writeFile(path.join(dir, "button.tsx"), "line1\r\nline2\n");
+    stubFetchContent("line1\nline2");
+    const cmp = await compareComponent(buttonDef, dir);
+    expect(cmp.status).toBe("up-to-date");
+    expect(cmp.files[0].status).toBe("same");
+  });
+
+  it("reports outdated when the local copy differs", async () => {
+    const dir = await tempDir();
+    await fs.writeFile(path.join(dir, "button.tsx"), "old style");
+    stubFetchContent("new style");
+    const cmp = await compareComponent(buttonDef, dir);
+    expect(cmp.status).toBe("outdated");
+    expect(cmp.files[0].status).toBe("different");
+    expect(cmp.files[0].local).toBe("old style");
+    expect(cmp.files[0].upstream).toBe("new style");
+  });
+});

--- a/packages/cli/src/utils/diff.test.ts
+++ b/packages/cli/src/utils/diff.test.ts
@@ -16,6 +16,9 @@ import type { ComponentDefinition } from "./registry.ts";
 
 afterEach(() => {
   vi.restoreAllMocks();
+  // restoreAllMocks doesn't undo vi.stubGlobal — unstub so the fetch stub from
+  // the compareComponent tests doesn't leak into other tests.
+  vi.unstubAllGlobals();
 });
 
 describe("toLocalRelativePath", () => {
@@ -33,8 +36,12 @@ describe("normalize", () => {
     expect(normalize("a\r\nb")).toBe(normalize("a\nb"));
   });
 
-  it("ignores trailing whitespace and a final newline", () => {
-    expect(normalize("a  \nb\n")).toBe(normalize("a\nb"));
+  it("ignores a trailing final newline", () => {
+    expect(normalize("a\nb\n")).toBe(normalize("a\nb"));
+  });
+
+  it("preserves per-line trailing whitespace (can be significant in a template literal)", () => {
+    expect(normalize("a  \nb")).not.toBe(normalize("a\nb"));
   });
 
   it("keeps a real content difference", () => {

--- a/packages/cli/src/utils/diff.ts
+++ b/packages/cli/src/utils/diff.ts
@@ -1,0 +1,175 @@
+import fs from "fs-extra";
+import path from "path";
+import { fetchComponent, type ComponentDefinition } from "./registry.ts";
+
+/**
+ * A registry file path is repo-relative (`components/button.tsx`); the copy in a
+ * consumer's project lives flat under their components dir (`button.tsx`).
+ */
+export function toLocalRelativePath(registryFilePath: string): string {
+  return registryFilePath.replace(/^components\//, "");
+}
+
+/**
+ * Compare content by meaning, not bytes: a CRLF checkout, trailing whitespace,
+ * or a final-newline difference is not a style change and shouldn't read as one.
+ */
+export function normalize(content: string): string {
+  return content
+    .replace(/\r\n/g, "\n")
+    .replace(/[ \t]+$/gm, "")
+    .trimEnd();
+}
+
+export type FileStatus = "same" | "different" | "missing";
+export type ComponentStatus = "up-to-date" | "outdated" | "not-installed";
+
+export interface FileComparison {
+  /** Local relative path, e.g. `button.tsx`. */
+  path: string;
+  status: FileStatus;
+  local: string | null;
+  upstream: string;
+}
+
+export interface ComponentComparison {
+  name: string;
+  status: ComponentStatus;
+  files: FileComparison[];
+}
+
+/**
+ * Overall status from the per-file results. A component whose files are all
+ * absent isn't installed; any local file differing from (or missing against) an
+ * installed component means the copy is behind upstream.
+ */
+export function deriveComponentStatus(files: FileComparison[]): ComponentStatus {
+  if (files.length === 0 || files.every((f) => f.status === "missing")) {
+    return "not-installed";
+  }
+  if (files.some((f) => f.status === "different" || f.status === "missing")) {
+    return "outdated";
+  }
+  return "up-to-date";
+}
+
+/**
+ * Cheap presence check (no network): a component counts as installed when at
+ * least one of its files exists locally. Used to scope the `diff` overview to
+ * what the consumer actually has.
+ */
+export async function isComponentInstalled(
+  def: ComponentDefinition,
+  componentsDir: string,
+): Promise<boolean> {
+  for (const filePath of def.files) {
+    const localPath = path.join(componentsDir, toLocalRelativePath(filePath));
+    if (await fs.pathExists(localPath)) return true;
+  }
+  return false;
+}
+
+/** Fetch the upstream files for a component and compare them against the local copy. */
+export async function compareComponent(
+  def: ComponentDefinition,
+  componentsDir: string,
+): Promise<ComponentComparison> {
+  const upstreamFiles = await fetchComponent(def);
+  const files: FileComparison[] = [];
+
+  for (const upstream of upstreamFiles) {
+    const rel = toLocalRelativePath(upstream.path);
+    const localPath = path.join(componentsDir, rel);
+
+    if (!(await fs.pathExists(localPath))) {
+      files.push({ path: rel, status: "missing", local: null, upstream: upstream.content });
+      continue;
+    }
+
+    const local = await fs.readFile(localPath, "utf-8");
+    const status: FileStatus =
+      normalize(local) === normalize(upstream.content) ? "same" : "different";
+    files.push({ path: rel, status, local, upstream: upstream.content });
+  }
+
+  return { name: def.name, status: deriveComponentStatus(files), files };
+}
+
+export type DiffLineType = "add" | "remove" | "context";
+
+export interface DiffLine {
+  type: DiffLineType;
+  text: string;
+}
+
+/**
+ * Line-level diff via longest-common-subsequence. Component files are small
+ * (a few hundred lines), so the O(n·m) table is cheap and keeps the CLI free of
+ * a diff dependency.
+ */
+export function diffLines(before: string, after: string): DiffLine[] {
+  const a = before.split("\n");
+  const b = after.split("\n");
+  const n = a.length;
+  const m = b.length;
+
+  const lcs: number[][] = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i][j] = a[i] === b[j] ? lcs[i + 1][j + 1] + 1 : Math.max(lcs[i + 1][j], lcs[i][j + 1]);
+    }
+  }
+
+  const out: DiffLine[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      out.push({ type: "context", text: a[i] });
+      i++;
+      j++;
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      out.push({ type: "remove", text: a[i] });
+      i++;
+    } else {
+      out.push({ type: "add", text: b[j] });
+      j++;
+    }
+  }
+  while (i < n) out.push({ type: "remove", text: a[i++] });
+  while (j < m) out.push({ type: "add", text: b[j++] });
+  return out;
+}
+
+/**
+ * Collapse long runs of unchanged lines to `context` around each change, so a
+ * one-line edit doesn't print the whole file. Runs longer than `2·context + 1`
+ * become a `…` marker.
+ */
+export function collapseContext(lines: DiffLine[], context = 3): DiffLine[] {
+  const keep = new Array<boolean>(lines.length).fill(false);
+  lines.forEach((line, idx) => {
+    if (line.type !== "context") {
+      for (
+        let k = Math.max(0, idx - context);
+        k <= Math.min(lines.length - 1, idx + context);
+        k++
+      ) {
+        keep[k] = true;
+      }
+    }
+  });
+
+  const out: DiffLine[] = [];
+  let gap = false;
+  lines.forEach((line, idx) => {
+    if (keep[idx]) {
+      out.push(line);
+      gap = false;
+    } else if (!gap) {
+      out.push({ type: "context", text: "…" });
+      gap = true;
+    }
+  });
+  return out;
+}

--- a/packages/cli/src/utils/diff.ts
+++ b/packages/cli/src/utils/diff.ts
@@ -11,14 +11,14 @@ export function toLocalRelativePath(registryFilePath: string): string {
 }
 
 /**
- * Compare content by meaning, not bytes: a CRLF checkout, trailing whitespace,
- * or a final-newline difference is not a style change and shouldn't read as one.
+ * Compare content by meaning, not bytes — but only for differences that are
+ * never real content: a CRLF checkout (git autocrlf) or a trailing final
+ * newline. Per-line trailing whitespace is left intact: it can be significant
+ * inside a template literal, and for an update tool a false "up to date" (a real
+ * change hidden) is worse than a false "differs".
  */
 export function normalize(content: string): string {
-  return content
-    .replace(/\r\n/g, "\n")
-    .replace(/[ \t]+$/gm, "")
-    .trimEnd();
+  return content.replace(/\r\n/g, "\n").replace(/\n+$/, "");
 }
 
 export type FileStatus = "same" | "different" | "missing";
@@ -41,7 +41,10 @@ export interface ComponentComparison {
 /**
  * Overall status from the per-file results. A component whose files are all
  * absent isn't installed; any local file differing from (or missing against) an
- * installed component means the copy is behind upstream.
+ * installed component means the copy differs from the current registry. Without
+ * installed-version tracking we can't tell an upstream restyle apart from a
+ * local customization — both surface as "outdated", so callers must frame it as
+ * a difference, not a proven update, and never overwrite blindly.
  */
 export function deriveComponentStatus(files: FileComparison[]): ComponentStatus {
   if (files.length === 0 || files.every((f) => f.status === "missing")) {

--- a/packages/cli/src/utils/files.ts
+++ b/packages/cli/src/utils/files.ts
@@ -38,12 +38,12 @@ export async function writeComponentFiles(
       }
 
       if (!overwrite) {
-        // Distinguish a genuine upstream style update from a bare name clash, so
-        // the user knows their copy is behind — not just that a file is there.
+        // Distinguish a real content difference from a bare name clash, so the
+        // user knows their copy is out of sync — not just that a file is there.
         const { confirm } = await prompts({
           type: "confirm",
           name: "confirm",
-          message: `${path.basename(targetPath)} differs from the latest registry version — your copy may be an older style. Overwrite?`,
+          message: `${path.basename(targetPath)} differs from the registry version. Overwrite?`,
           initial: false,
         });
         if (!confirm) {

--- a/packages/cli/src/utils/files.ts
+++ b/packages/cli/src/utils/files.ts
@@ -2,11 +2,14 @@ import { spawn } from "child_process";
 import fs from "fs-extra";
 import path from "path";
 import prompts from "prompts";
+import { normalize } from "./diff.ts";
 import type { ComponentFile } from "./registry.ts";
 
 export interface WriteResult {
   written: string[];
   skipped: string[];
+  /** Files already identical to upstream — left untouched, no prompt. */
+  unchanged: string[];
 }
 
 export async function writeComponentFiles(
@@ -16,6 +19,7 @@ export async function writeComponentFiles(
 ): Promise<WriteResult> {
   const written: string[] = [];
   const skipped: string[] = [];
+  const unchanged: string[] = [];
 
   for (const file of files) {
     // Transform file path: components/button.tsx -> button.tsx
@@ -24,11 +28,22 @@ export async function writeComponentFiles(
 
     // Check if file exists
     if (await fs.pathExists(targetPath)) {
+      const local = await fs.readFile(targetPath, "utf-8");
+      const differs = normalize(local) !== normalize(file.content);
+
+      // Already the latest — nothing to do, and no reason to nag the user.
+      if (!differs) {
+        unchanged.push(targetPath);
+        continue;
+      }
+
       if (!overwrite) {
+        // Distinguish a genuine upstream style update from a bare name clash, so
+        // the user knows their copy is behind — not just that a file is there.
         const { confirm } = await prompts({
           type: "confirm",
           name: "confirm",
-          message: `${path.basename(targetPath)} already exists. Overwrite?`,
+          message: `${path.basename(targetPath)} differs from the latest registry version — your copy may be an older style. Overwrite?`,
           initial: false,
         });
         if (!confirm) {
@@ -43,7 +58,7 @@ export async function writeComponentFiles(
     written.push(targetPath);
   }
 
-  return { written, skipped };
+  return { written, skipped, unchanged };
 }
 
 export async function installDependencies(deps: string[]): Promise<void> {


### PR DESCRIPTION
## Why

Beaket UI is copy-paste — components are copied into a consumer's project, so they **never auto-update**. When a component's style moves upstream (and the CHANGELOG shows this is where most of the churn is — Card reframed, Button's accent edge, Breadcrumb's ink), an existing user had no way to find out.

Today the only "your copy is behind" signal is for **theme tokens** (`syncTheme` compares the injected block and offers to update). For **component `.tsx` files** there was nothing:

- `add` only checked *"does a file exist?"* and asked `already exists. Overwrite?` — learning nothing about whether the local copy was actually stale or identical.
- There was no way to discover which installed components had upstream changes.

So an existing user on an older style got no warning and no guidance on what to do.

## What

Two changes, both driven off one shared comparison util:

### `diff` command
```bash
npx @beaket/ui diff            # overview: which installed components are up to date vs. outdated
npx @beaket/ui diff button     # line-by-line diff of your copy vs. the registry + how to update
```
It's **read-only** — you own the copied code, so `diff` never writes. When a component is behind, it points you at `add <component> --overwrite` (or hand-merging if you've customized it).

### Smarter `add`
An existing file is now compared against upstream before prompting:
- Files that **already match** are left untouched with no prompt (was: always prompted to overwrite).
- Only a **genuine upstream change** prompts — worded as _"differs from the latest registry version — your copy may be an older style"_ instead of a bare name clash — and skipped files point at `diff` to see what changed.

### Implementation
- New `utils/diff.ts`: `normalize` (compare by meaning, ignoring CRLF/trailing whitespace), an LCS `diffLines` + `collapseContext` (no new dependency), `compareComponent`, and pure `deriveComponentStatus` / `isComponentInstalled` helpers.
- `writeComponentFiles` returns a new `unchanged` bucket; `add` reports it.

## Testing
- 20 new unit tests in `utils/diff.test.ts` (normalize, LCS diff, context collapsing, status derivation, and `compareComponent` against a stubbed fetch + temp files). Full CLI suite: **42 passing**.
- Typecheck, `tsup` build, and Prettier all clean.
- Smoke-tested the built CLI against the live registry: outdated overview, single-component diff, and the up-to-date path all render correctly.

## Out of scope
Per the requested scope, this does **not** add version tracking in `beaket.ui.json` or CHANGELOG/migration-note surfacing — those remain natural follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CgUhyozXd3wTP9y9dzCDag

---
_Generated by [Claude Code](https://claude.ai/code/session_01CgUhyozXd3wTP9y9dzCDag)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `diff` command to compare installed components with the latest versions.
  * View detailed file and line-level changes, or check all installed components at once.
  * Added guidance for reviewing changes or applying updates with `add --overwrite`.

* **Improvements**
  * `add` now identifies components that are already up to date.
  * Existing components prompt for overwrite only when upstream changes are detected.
  * Updated CLI documentation with the new behavior and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->